### PR TITLE
Release 0.7.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,3 +73,11 @@ jobs:
           cargo +nightly fmt --all -- --check
           cargo +nightly clippy --target wasm32-wasi -- -D warnings
           cargo build --target wasm32-wasi --release
+
+      - name: Build api-server
+        id: build_api_server_w_https
+        run: |
+          cd api-server
+          cargo +nightly fmt --all -- --check
+          cargo +nightly clippy --target wasm32-wasi -- -D warnings
+          cargo build --target wasm32-wasi --release --features https

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,12 +40,19 @@ jobs:
           cargo build --target wasm32-wasi --release
           cp ./target/wasm32-wasi/release/llama-chat.wasm ../llama-chat.wasm
 
-      - name: Build api-server
+      - name: Build api-server without https feature
         id: build_api_server
         run: |
           cd api-server
           cargo build --target wasm32-wasi --release
           cp ./target/wasm32-wasi/release/llama-api-server.wasm ../llama-api-server.wasm
+
+      - name: Build api-server with https feature
+        id: build_api_server_w_https
+        run: |
+          cd api-server
+          cargo build --target wasm32-wasi --release --features https
+          cp ./target/wasm32-wasi/release/llama-api-server.wasm ../llama-api-server-full.wasm
 
       - name: Calculate checksum
         id: checksum
@@ -72,6 +79,7 @@ jobs:
           prerelease: true
           files: |
             llama-api-server.wasm
+            llama-api-server-full.wasm
             llama-chat.wasm
             llama-simple.wasm
             SHA256SUM

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -184,7 +184,7 @@ The command above starts the API server on the default socket address. Besides, 
     curl -X POST http://localhost:8080/v1/chunks \
         -H 'accept:application/json' \
         -H 'Content-Type: application/json' \
-        -d '{"file_id":"file_4bc24593-2a57-4646-af16-028855e7802e", "filename":"paris.txt"}'
+        -d '{"id":"file_4bc24593-2a57-4646-af16-028855e7802e", "filename":"paris.txt"}'
     ```
 
     The following is an example return with the generated chunks:

--- a/api-server/llama-api-server/Cargo.toml
+++ b/api-server/llama-api-server/Cargo.toml
@@ -18,7 +18,11 @@ clap = { version = "4.4.6", features = ["cargo"] }
 once_cell = "1.18"
 mime_guess = "2.0.4"
 futures-util = "0.3"
-llama-core = { path = "../llama-core", version = "^0.6" }
+llama-core = { path = "../llama-core", version = "^0.6", default-features = false }
 url = "^2.5"
 anyhow = "1.0.80"
 multipart-2021 = "0.19.0"
+
+[features]
+default = []
+https = ["llama-core/https"]

--- a/api-server/llama-api-server/Cargo.toml
+++ b/api-server/llama-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-api-server"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 
 [dependencies]

--- a/api-server/llama-api-server/src/backend/ggml.rs
+++ b/api-server/llama-api-server/src/backend/ggml.rs
@@ -415,12 +415,15 @@ pub(crate) async fn rag_query_handler(
                         println!("    * user query: {}\n", query_text);
                     }
 
+                    // get the available embedding models
+                    let embedding_model_names = match llama_core::utils::embedding_model_names() {
+                        Ok(model_names) => model_names,
+                        Err(e) => return error::internal_server_error(e.to_string()),
+                    };
+
                     // create a embedding request
                     let embedding_request = EmbeddingRequest {
-                        model: chat_request
-                            .model
-                            .clone()
-                            .unwrap_or("dummy-embedding-model".to_string()),
+                        model: embedding_model_names[0].clone(),
                         input: vec![query_text.clone()],
                         encoding_format: None,
                         user: chat_request.user.clone(),

--- a/api-server/llama-core/Cargo.toml
+++ b/api-server/llama-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-core"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/api-server/llama-core/Cargo.toml
+++ b/api-server/llama-core/Cargo.toml
@@ -20,10 +20,12 @@ uuid.workspace = true
 once_cell = "1.18"
 futures = { version = "0.3.6", default-features = false, features = ["async-await", "std"] }
 futures-util = "0.3"
-reqwest = { package = "reqwest_wasi", version = "0.11", features = ["json", "wasmedge-tls", "stream"] }
-# qdrant_rest_client = { version = "0.0.3", features = ["wasmedge-tls"] }
-qdrant_rest_client = { git = "https://github.com/second-state/qdrant-rest-client.git", branch = "debug-search-points", features = [
-    "wasmedge-tls",
-] }
+reqwest = { package = "reqwest_wasi", version = "0.11", features = ["json", "stream"] }
+# qdrant_rest_client = { version = "0.0.3", default-features = false}
+qdrant_rest_client = { version = "0.0.4", git = "https://github.com/second-state/qdrant-rest-client.git", branch = "main", default-features = false }
 text-splitter = { version = "^0.7", features = ["tiktoken-rs", "markdown"] }
 tiktoken-rs = "^0.5"
+
+[features]
+default = ["https"]
+https = ["reqwest/wasmedge-tls", "qdrant_rest_client/wasmedge-tls"]

--- a/api-server/llama-core/Cargo.toml
+++ b/api-server/llama-core/Cargo.toml
@@ -21,8 +21,7 @@ once_cell = "1.18"
 futures = { version = "0.3.6", default-features = false, features = ["async-await", "std"] }
 futures-util = "0.3"
 reqwest = { package = "reqwest_wasi", version = "0.11", features = ["json", "stream"] }
-# qdrant_rest_client = { version = "0.0.3", default-features = false}
-qdrant_rest_client = { version = "0.0.4", git = "https://github.com/second-state/qdrant-rest-client.git", branch = "main", default-features = false }
+qdrant_rest_client = { version = "0.0.4", default-features = false }
 text-splitter = { version = "^0.7", features = ["tiktoken-rs", "markdown"] }
 tiktoken-rs = "^0.5"
 

--- a/api-server/llama-core/src/lib.rs
+++ b/api-server/llama-core/src/lib.rs
@@ -4,7 +4,7 @@ pub mod embeddings;
 pub mod error;
 pub mod models;
 pub mod rag;
-pub(crate) mod utils;
+pub mod utils;
 
 pub use error::LlamaCoreError;
 

--- a/api-server/llama-core/src/utils.rs
+++ b/api-server/llama-core/src/utils.rs
@@ -1,3 +1,5 @@
+use crate::{error::LlamaCoreError, CHAT_GRAPHS, EMBEDDING_GRAPHS};
+
 pub(crate) fn print_log_begin_separator(
     title: impl AsRef<str>,
     ch: Option<&str>,
@@ -28,4 +30,48 @@ pub(crate) fn print_log_end_separator(ch: Option<&str>, len: Option<usize>) {
 
 pub(crate) fn gen_chat_id() -> String {
     format!("chatcmpl-{}", uuid::Uuid::new_v4())
+}
+
+/// Return the names of the chat models.
+pub fn chat_model_names() -> Result<Vec<String>, LlamaCoreError> {
+    let chat_graphs = CHAT_GRAPHS
+        .get()
+        .ok_or(LlamaCoreError::Operation(String::from(
+            "Fail to get the underlying value of `CHAT_GRAPHS`.",
+        )))?;
+
+    let chat_graphs = chat_graphs.lock().map_err(|e| {
+        LlamaCoreError::Operation(format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e))
+    })?;
+
+    let mut model_names = Vec::new();
+    for model_name in chat_graphs.keys() {
+        model_names.push(model_name.clone());
+    }
+
+    Ok(model_names)
+}
+
+/// Return the names of the embedding models.
+pub fn embedding_model_names() -> Result<Vec<String>, LlamaCoreError> {
+    let embedding_graphs =
+        EMBEDDING_GRAPHS
+            .get()
+            .ok_or(LlamaCoreError::Operation(String::from(
+                "Fail to get the underlying value of `EMBEDDING_GRAPHS`.",
+            )))?;
+
+    let embedding_graphs = embedding_graphs.lock().map_err(|e| {
+        LlamaCoreError::Operation(format!(
+            "Fail to acquire the lock of `EMBEDDING_GRAPHS`. {}",
+            e
+        ))
+    })?;
+
+    let mut model_names = Vec::new();
+    for model_name in embedding_graphs.keys() {
+        model_names.push(model_name.clone());
+    }
+
+    Ok(model_names)
 }

--- a/chat/Cargo.toml
+++ b/chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-chat"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 
 [dependencies]

--- a/simple/Cargo.toml
+++ b/simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-simple"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Major changes:

- Llama-api-server
  - Introduce `https` feature to enable `llama-core/https` dep.
  - Fix the incorrect model name while dealing with user RAG queries.

- Llama-core
  - New helper APIs `chat_model_names` and `embedding_model_names` for getting the names of chat and embedding models.
  - Introduce `https` feature for enabling `wasmedge-tls` features in `reqwest` and `qdrant_rest_client` deps, respectively.

- Misc.
  - Correct a type in `README` of api-server