### PR TITLE
Release 0.9.0

### DIFF
--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }
 endpoints = { path = "endpoints", version = "^0.7" }
-chat-prompts = { path = "chat-prompts", version = "^0.6" }
+chat-prompts = { path = "chat-prompts", version = "^0.7" }
 thiserror = "1"
 uuid = { version = "1.4", features = ["v4", "fast-rng", "macro-diagnostics"] }
 clap = { version = "4.4.6", features = ["cargo", "derive"] }

--- a/api-server/chat-prompts/Cargo.toml
+++ b/api-server/chat-prompts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chat-prompts"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/api-server/endpoints/Cargo.toml
+++ b/api-server/endpoints/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endpoints"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/api-server/endpoints/src/rag.rs
+++ b/api-server/endpoints/src/rag.rs
@@ -344,3 +344,78 @@ pub struct ChunksResponse {
     pub filename: String,
     pub chunks: Vec<String>,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetrieveObject {
+    /// The retrieved sources.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub points: Option<Vec<RagScoredPoint>>,
+
+    /// The number of similar points to retrieve
+    pub limit: usize,
+
+    /// The score threshold
+    pub score_threshold: f32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RagScoredPoint {
+    /// Source of the context
+    pub source: String,
+
+    /// Points vector distance to the query vector
+    pub score: f32,
+}
+
+#[test]
+fn test_rag_serialize_retrieve_object() {
+    {
+        let ro = RetrieveObject {
+            points: Some(vec![RagScoredPoint {
+                source: "source".to_string(),
+                score: 0.5,
+            }]),
+            limit: 1,
+            score_threshold: 0.5,
+        };
+        let json = serde_json::to_string(&ro).unwrap();
+        assert_eq!(
+            json,
+            r#"{"points":[{"source":"source","score":0.5}],"limit":1,"score_threshold":0.5}"#
+        );
+    }
+
+    {
+        let ro = RetrieveObject {
+            points: None,
+            limit: 1,
+            score_threshold: 0.5,
+        };
+        let json = serde_json::to_string(&ro).unwrap();
+        assert_eq!(json, r#"{"limit":1,"score_threshold":0.5}"#);
+    }
+}
+
+#[test]
+fn test_rag_deserialize_retrieve_object() {
+    {
+        let json =
+            r#"{"points":[{"source":"source","score":0.5}],"limit":1,"score_threshold":0.5}"#;
+        let ro: RetrieveObject = serde_json::from_str(json).unwrap();
+        assert_eq!(ro.limit, 1);
+        assert_eq!(ro.score_threshold, 0.5);
+        assert!(ro.points.is_some());
+        let points = ro.points.unwrap();
+        assert_eq!(points.len(), 1);
+        assert_eq!(points[0].source, "source");
+        assert_eq!(points[0].score, 0.5);
+    }
+
+    {
+        let json = r#"{"limit":1,"score_threshold":0.5}"#;
+        let ro: RetrieveObject = serde_json::from_str(json).unwrap();
+        assert_eq!(ro.limit, 1);
+        assert_eq!(ro.score_threshold, 0.5);
+        assert!(ro.points.is_none());
+    }
+}

--- a/api-server/llama-api-server/Cargo.toml
+++ b/api-server/llama-api-server/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.8.6"
 edition = "2021"
 
 [dependencies]
-llama-core = { path = "../llama-core", version = "^0.7" }
+llama-core = { path = "../llama-core", version = "^0.8" }
 futures = { version = "0.3.6", default-features = false, features = ["async-await", "std"] }
 serde.workspace = true
 serde_json = "1.0"

--- a/api-server/llama-api-server/Cargo.toml
+++ b/api-server/llama-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-api-server"
-version = "0.8.6"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/api-server/llama-core/Cargo.toml
+++ b/api-server/llama-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-core"
-version = "0.7.4"
+version = "0.8.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/chat/Cargo.toml
+++ b/chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-chat"
-version = "0.8.6"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/chat/Cargo.toml
+++ b/chat/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.8.6"
 edition = "2021"
 
 [dependencies]
-chat-prompts = { path = "../api-server/chat-prompts", version = "^0.6" }
+chat-prompts = { path = "../api-server/chat-prompts", version = "^0.7" }
 endpoints = { path = "../api-server/endpoints", version = "^0.7" }
 wasmedge-wasi-nn = "0.7.0"
 clap = { version = "4.4.6", features = ["cargo"] }

--- a/run-llm.sh
+++ b/run-llm.sh
@@ -262,7 +262,7 @@ if [ -n "$model" ]; then
     printf "[+] Install WasmEdge with wasi-nn_ggml plugin ...\n\n"
 
     if [ "$ggml_version" = "latest" ]; then
-        if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -v 0.13.5 --plugins wasi_nn-ggml wasmedge_rustls; then
+        if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v 0.13.5 --rustls; then
             source $HOME/.wasmedge/env
             wasmedge_path=$(which wasmedge)
             printf "\n    The WasmEdge Runtime is installed in %s.\n\n" "$wasmedge_path"
@@ -325,7 +325,7 @@ elif [ "$interactive" -eq 0 ]; then
     printf "[+] Installing WasmEdge with wasi-nn_ggml plugin ...\n\n"
 
     if [ "$ggml_version" = "latest" ]; then
-        if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -v 0.13.5 --plugins wasi_nn-ggml wasmedge_rustls; then
+        if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v 0.13.5 --rustls; then
             source $HOME/.wasmedge/env
             wasmedge_path=$(which wasmedge)
             printf "\n    The WasmEdge Runtime is installed in %s.\n\n" "$wasmedge_path"
@@ -432,7 +432,7 @@ elif [ "$interactive" -eq 1 ]; then
     if [[ "$reinstall_wasmedge" == "1" ]]; then
         # install WasmEdge + wasi-nn_ggml plugin
         if [ "$ggml_version" = "latest" ]; then
-            if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -v 0.13.5 --plugins wasi_nn-ggml wasmedge_rustls; then
+            if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v 0.13.5 --rustls; then
                 source $HOME/.wasmedge/env
                 wasmedge_path=$(which wasmedge)
                 printf "\n    The WasmEdge Runtime is installed in %s.\n\n" "$wasmedge_path"

--- a/simple/Cargo.toml
+++ b/simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-simple"
-version = "0.8.6"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Major changes:

- `llama-core` crate
  - (BREAKING) Update the `rag_retrieve_context` API
  - (BREAKING) Remove `ScoredPoint` type alias
- `chat-prompts` crate
  - (BREAKING) Update the `MergeRagContext` trait
- `endpoints` crate
  - Define `RetrieveObject` and `RagScoredPoint` structs
- `run-llm.sh`
  - Use `WasmEdge Installer v2` to install the latest version of WasmEdge