### PR TITLE
Release 0.10.0

### DIFF
--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }
-endpoints = { path = "endpoints", version = "^0.7" }
+endpoints = { path = "endpoints", version = "^0.8" }
 chat-prompts = { path = "chat-prompts", version = "^0.7" }
 thiserror = "1"
 uuid = { version = "1.4", features = ["v4", "fast-rng", "macro-diagnostics"] }

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -422,7 +422,7 @@ Options:
   -c, --ctx-size <CTX_SIZE>
           Context size [default: 512]
   -p, --prompt-template <PROMPT_TEMPLATE>
-          Sets the prompt template [possible values: llama-2-chat, mistral-instruct, mistrallite, openchat, codellama-instruct, codellama-super-instruct, human-assistant, vicuna-1.0-chat, vicuna-1.1-chat, vicuna-llava, chatml, baichuan-2, wizard-coder, zephyr, stablelm-zephyr, intel-neural, deepseek-chat, deepseek-coder, solar-instruct, phi-2-chat, phi-2-instruct, phi-3-chat, phi-3-instruct, gemma-instruct]
+          Sets the prompt template [possible values: llama-2-chat, llama-3-chat, mistral-instruct, mistrallite, openchat, codellama-instruct, codellama-super-instruct, human-assistant, vicuna-1.0-chat, vicuna-1.1-chat, vicuna-llava, chatml, baichuan-2, wizard-coder, zephyr, stablelm-zephyr, intel-neural, deepseek-chat, deepseek-coder, solar-instruct, phi-2-chat, phi-2-instruct, phi-3-chat, phi-3-instruct, gemma-instruct, octopus]
   -r, --reverse-prompt <REVERSE_PROMPT>
           Halt generation at PROMPT, return control
   -n, --n-predict <N_PREDICT>

--- a/api-server/chat-prompts/Cargo.toml
+++ b/api-server/chat-prompts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chat-prompts"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/api-server/chat-prompts/src/chat/baichuan.rs
+++ b/api-server/chat-prompts/src/chat/baichuan.rs
@@ -100,7 +100,7 @@ impl BuildChatPrompt for Baichuan2ChatPrompt {
                 ChatCompletionRequestMessage::Assistant(message) => {
                     prompt = self.append_assistant_message(&prompt, message)?;
                 }
-                ChatCompletionRequestMessage::System(_) => continue,
+                _ => continue,
             }
         }
 

--- a/api-server/chat-prompts/src/chat/belle.rs
+++ b/api-server/chat-prompts/src/chat/belle.rs
@@ -77,7 +77,7 @@ impl BuildChatPrompt for HumanAssistantChatPrompt {
                 ChatCompletionRequestMessage::Assistant(message) => {
                     prompt = self.append_assistant_message(&prompt, message)?;
                 }
-                ChatCompletionRequestMessage::System(_) => continue,
+                _ => continue,
             }
         }
 

--- a/api-server/chat-prompts/src/chat/chatml.rs
+++ b/api-server/chat-prompts/src/chat/chatml.rs
@@ -110,7 +110,7 @@ impl BuildChatPrompt for ChatMLPrompt {
                 ChatCompletionRequestMessage::Assistant(message) => {
                     prompt = self.append_assistant_message(&prompt, message)?;
                 }
-                ChatCompletionRequestMessage::System(_) => continue,
+                _ => continue,
             }
         }
 

--- a/api-server/chat-prompts/src/chat/deepseek.rs
+++ b/api-server/chat-prompts/src/chat/deepseek.rs
@@ -77,7 +77,7 @@ impl BuildChatPrompt for DeepseekChatPrompt {
                 ChatCompletionRequestMessage::Assistant(message) => {
                     prompt = self.append_assistant_message(&prompt, message)?;
                 }
-                ChatCompletionRequestMessage::System(_) => continue,
+                _ => continue,
             }
         }
 
@@ -186,7 +186,7 @@ impl BuildChatPrompt for DeepseekCoderPrompt {
                 ChatCompletionRequestMessage::Assistant(message) => {
                     prompt = self.append_assistant_message(&prompt, message)?;
                 }
-                ChatCompletionRequestMessage::System(_) => continue,
+                _ => continue,
             }
         }
 

--- a/api-server/chat-prompts/src/chat/gemma.rs
+++ b/api-server/chat-prompts/src/chat/gemma.rs
@@ -80,7 +80,7 @@ impl BuildChatPrompt for GemmaInstructPrompt {
                 ChatCompletionRequestMessage::Assistant(message) => {
                     prompt = self.append_assistant_message(&prompt, message)?;
                 }
-                ChatCompletionRequestMessage::System(_) => continue,
+                _ => continue,
             }
         }
 

--- a/api-server/chat-prompts/src/chat/intel.rs
+++ b/api-server/chat-prompts/src/chat/intel.rs
@@ -99,7 +99,7 @@ impl BuildChatPrompt for NeuralChatPrompt {
                 ChatCompletionRequestMessage::Assistant(message) => {
                     prompt = self.append_assistant_message(&prompt, message)?;
                 }
-                ChatCompletionRequestMessage::System(_) => continue,
+                _ => continue,
             }
         }
 

--- a/api-server/chat-prompts/src/chat/llama.rs
+++ b/api-server/chat-prompts/src/chat/llama.rs
@@ -111,7 +111,7 @@ impl BuildChatPrompt for Llama2ChatPrompt {
                 ChatCompletionRequestMessage::Assistant(message) => {
                     prompt = self.append_assistant_message(&prompt, message)?;
                 }
-                ChatCompletionRequestMessage::System(_) => continue,
+                _ => continue,
             }
         }
 
@@ -215,7 +215,7 @@ impl BuildChatPrompt for CodeLlamaInstructPrompt {
                 ChatCompletionRequestMessage::Assistant(message) => {
                     prompt = self.append_assistant_message(&prompt, message)?;
                 }
-                ChatCompletionRequestMessage::System(_) => continue,
+                _ => continue,
             }
         }
 
@@ -319,7 +319,7 @@ impl BuildChatPrompt for CodeLlamaSuperInstructPrompt {
                 ChatCompletionRequestMessage::Assistant(message) => {
                     prompt = self.append_assistant_message(&prompt, message)?;
                 }
-                ChatCompletionRequestMessage::System(_) => continue,
+                _ => continue,
             }
         }
 
@@ -427,7 +427,7 @@ impl BuildChatPrompt for Llama3ChatPrompt {
                 ChatCompletionRequestMessage::Assistant(message) => {
                     prompt = self.append_assistant_message(&prompt, message)?;
                 }
-                ChatCompletionRequestMessage::System(_) => continue,
+                _ => continue,
             }
         }
 

--- a/api-server/chat-prompts/src/chat/mistral.rs
+++ b/api-server/chat-prompts/src/chat/mistral.rs
@@ -80,7 +80,7 @@ impl BuildChatPrompt for MistralInstructPrompt {
                 ChatCompletionRequestMessage::Assistant(message) => {
                     prompt = self.append_assistant_message(&prompt, message)?;
                 }
-                ChatCompletionRequestMessage::System(_) => continue,
+                _ => continue,
             }
         }
 
@@ -164,7 +164,7 @@ impl BuildChatPrompt for MistralLitePrompt {
                 ChatCompletionRequestMessage::Assistant(message) => {
                     prompt = self.append_assistant_message(&prompt, message)?;
                 }
-                ChatCompletionRequestMessage::System(_) => continue,
+                _ => continue,
             }
         }
 

--- a/api-server/chat-prompts/src/chat/octopus.rs
+++ b/api-server/chat-prompts/src/chat/octopus.rs
@@ -99,7 +99,7 @@ impl BuildChatPrompt for OctopusPrompt {
                 ChatCompletionRequestMessage::Assistant(message) => {
                     prompt = self.append_assistant_message(&prompt, message)?;
                 }
-                ChatCompletionRequestMessage::System(_) => continue,
+                _ => continue,
             }
         }
 

--- a/api-server/chat-prompts/src/chat/openchat.rs
+++ b/api-server/chat-prompts/src/chat/openchat.rs
@@ -81,7 +81,7 @@ impl BuildChatPrompt for OpenChatPrompt {
                 ChatCompletionRequestMessage::Assistant(message) => {
                     prompt = self.append_assistant_message(&prompt, message)?;
                 }
-                ChatCompletionRequestMessage::System(_) => continue,
+                _ => continue,
             }
         }
 

--- a/api-server/chat-prompts/src/chat/phi.rs
+++ b/api-server/chat-prompts/src/chat/phi.rs
@@ -119,7 +119,7 @@ impl BuildChatPrompt for Phi2ChatPrompt {
                 ChatCompletionRequestMessage::Assistant(message) => {
                     prompt = self.append_assistant_message(&prompt, message)?;
                 }
-                ChatCompletionRequestMessage::System(_) => continue,
+                _ => continue,
             }
         }
 
@@ -266,7 +266,7 @@ impl BuildChatPrompt for Phi3ChatPrompt {
                 ChatCompletionRequestMessage::Assistant(message) => {
                     prompt = self.append_assistant_message(&prompt, message)?;
                 }
-                ChatCompletionRequestMessage::System(_) => continue,
+                _ => continue,
             }
         }
 

--- a/api-server/chat-prompts/src/chat/solar.rs
+++ b/api-server/chat-prompts/src/chat/solar.rs
@@ -80,7 +80,7 @@ impl BuildChatPrompt for SolarInstructPrompt {
                 ChatCompletionRequestMessage::Assistant(message) => {
                     prompt = self.append_assistant_message(&prompt, message)?;
                 }
-                ChatCompletionRequestMessage::System(_) => continue,
+                _ => continue,
             }
         }
 

--- a/api-server/chat-prompts/src/chat/vicuna.rs
+++ b/api-server/chat-prompts/src/chat/vicuna.rs
@@ -102,7 +102,7 @@ impl BuildChatPrompt for VicunaChatPrompt {
                 ChatCompletionRequestMessage::Assistant(message) => {
                     prompt = self.append_assistant_message(&prompt, message)?;
                 }
-                ChatCompletionRequestMessage::System(_) => continue,
+                _ => continue,
             }
         }
 
@@ -184,7 +184,7 @@ impl BuildChatPrompt for Vicuna11ChatPrompt {
                 ChatCompletionRequestMessage::Assistant(message) => {
                     prompt = self.append_assistant_message(&prompt, message)?;
                 }
-                ChatCompletionRequestMessage::System(_) => continue,
+                _ => continue,
             }
         }
         prompt.push_str(" ASSISTANT:");
@@ -319,7 +319,7 @@ impl BuildChatPrompt for VicunaLlavaPrompt {
                 ChatCompletionRequestMessage::Assistant(message) => {
                     prompt = self.append_assistant_message(&prompt, message)?;
                 }
-                ChatCompletionRequestMessage::System(_) => continue,
+                _ => continue,
             }
         }
 

--- a/api-server/chat-prompts/src/chat/zephyr.rs
+++ b/api-server/chat-prompts/src/chat/zephyr.rs
@@ -96,7 +96,7 @@ impl BuildChatPrompt for ZephyrChatPrompt {
                 ChatCompletionRequestMessage::Assistant(message) => {
                     prompt = self.append_assistant_message(&prompt, message)?;
                 }
-                ChatCompletionRequestMessage::System(_) => continue,
+                _ => continue,
             }
         }
 
@@ -180,7 +180,7 @@ impl BuildChatPrompt for StableLMZephyrChatPrompt {
                 ChatCompletionRequestMessage::Assistant(message) => {
                     prompt = self.append_assistant_message(&prompt, message)?;
                 }
-                ChatCompletionRequestMessage::System(_) => continue,
+                _ => continue,
             }
         }
 

--- a/api-server/endpoints/Cargo.toml
+++ b/api-server/endpoints/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endpoints"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/api-server/endpoints/src/embeddings.rs
+++ b/api-server/endpoints/src/embeddings.rs
@@ -6,8 +6,10 @@ use serde::{Deserialize, Serialize};
 pub struct EmbeddingRequest {
     /// ID of the model to use.
     pub model: String,
-    /// Input text to embed. Each input must not exceed the max input tokens for the model (8191 tokens for text-embedding-ada-002) and cannot be an empty string.
-    pub input: Vec<String>,
+    /// Input text to embed,encoded as a string or array of tokens.
+    ///
+    /// To embed multiple inputs in a single request, pass an array of strings or array of token arrays. The input must not exceed the max input tokens for the model (8192 tokens for text-embedding-ada-002), cannot be an empty string, and any array must be 2048 dimensions or less.
+    pub input: InputText,
     /// The format to return the embeddings in. Can be either float or base64.
     /// Defaults to float.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -15,6 +17,87 @@ pub struct EmbeddingRequest {
     /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<String>,
+}
+
+#[test]
+fn test_embedding_serialize_embedding_request() {
+    let embedding_request = EmbeddingRequest {
+        model: "text-embedding-ada-002".to_string(),
+        input: "Hello, world!".into(),
+        encoding_format: None,
+        user: None,
+    };
+    let serialized = serde_json::to_string(&embedding_request).unwrap();
+    assert_eq!(
+        serialized,
+        r#"{"model":"text-embedding-ada-002","input":"Hello, world!"}"#
+    );
+
+    let embedding_request = EmbeddingRequest {
+        model: "text-embedding-ada-002".to_string(),
+        input: vec!["Hello, world!", "This is a test string"].into(),
+        encoding_format: None,
+        user: None,
+    };
+    let serialized = serde_json::to_string(&embedding_request).unwrap();
+    assert_eq!(
+        serialized,
+        r#"{"model":"text-embedding-ada-002","input":["Hello, world!","This is a test string"]}"#
+    );
+}
+
+#[test]
+fn test_embedding_deserialize_embedding_request() {
+    let serialized = r#"{"model":"text-embedding-ada-002","input":"Hello, world!"}"#;
+    let embedding_request: EmbeddingRequest = serde_json::from_str(serialized).unwrap();
+    assert_eq!(embedding_request.model, "text-embedding-ada-002");
+    assert_eq!(embedding_request.input, InputText::from("Hello, world!"));
+    assert_eq!(embedding_request.encoding_format, None);
+    assert_eq!(embedding_request.user, None);
+
+    let serialized =
+        r#"{"model":"text-embedding-ada-002","input":["Hello, world!","This is a test string"]}"#;
+    let embedding_request: EmbeddingRequest = serde_json::from_str(serialized).unwrap();
+    assert_eq!(embedding_request.model, "text-embedding-ada-002");
+    assert_eq!(
+        embedding_request.input,
+        InputText::from(vec!["Hello, world!", "This is a test string"])
+    );
+    assert_eq!(embedding_request.encoding_format, None);
+    assert_eq!(embedding_request.user, None);
+}
+
+/// Defines the input text for the embedding request.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum InputText {
+    String(String),
+    Array(Vec<String>),
+}
+impl From<&str> for InputText {
+    fn from(s: &str) -> Self {
+        InputText::String(s.to_string())
+    }
+}
+impl From<&String> for InputText {
+    fn from(s: &String) -> Self {
+        InputText::String(s.to_string())
+    }
+}
+impl From<&[String]> for InputText {
+    fn from(s: &[String]) -> Self {
+        InputText::Array(s.to_vec())
+    }
+}
+impl From<Vec<&str>> for InputText {
+    fn from(s: Vec<&str>) -> Self {
+        InputText::Array(s.iter().map(|s| s.to_string()).collect())
+    }
+}
+impl From<Vec<String>> for InputText {
+    fn from(s: Vec<String>) -> Self {
+        InputText::Array(s)
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/api-server/endpoints/src/rag.rs
+++ b/api-server/endpoints/src/rag.rs
@@ -1,7 +1,7 @@
 use crate::{
     chat::{
         ChatCompletionRequest, ChatCompletionRequestMessage, ChatCompletionRequestSampling,
-        ChatResponseFormat, Tool, ToolChoice,
+        ChatResponseFormat, StreamOptions, Tool, ToolChoice,
     },
     embeddings::EmbeddingRequest,
 };
@@ -127,6 +127,9 @@ pub struct RagChatCompletionsRequest {
     /// Defaults to false.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stream: Option<bool>,
+    /// Options for streaming response. Only set this when you set `stream: true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream_options: Option<StreamOptions>,
     /// A list of tokens at which to stop generation. If None, no stop tokens are used. Up to 4 sequences where the API will stop generating further tokens.
     /// Defaults to None
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -171,6 +174,7 @@ impl RagChatCompletionsRequest {
             top_p: self.top_p,
             n_choice: self.n_choice,
             stream: self.stream,
+            stream_options: self.stream_options.clone(),
             stop: self.stop.clone(),
             max_tokens: self.max_tokens,
             presence_penalty: self.presence_penalty,
@@ -203,6 +207,7 @@ impl RagChatCompletionsRequest {
             top_p: chat_completions_request.top_p,
             n_choice: chat_completions_request.n_choice,
             stream: chat_completions_request.stream,
+            stream_options: chat_completions_request.stream_options,
             stop: chat_completions_request.stop,
             max_tokens: chat_completions_request.max_tokens,
             presence_penalty: chat_completions_request.presence_penalty,
@@ -249,6 +254,7 @@ impl RagChatCompletionRequestBuilder {
                 top_p: None,
                 n_choice: None,
                 stream: None,
+                stream_options: None,
                 stop: None,
                 max_tokens: None,
                 presence_penalty: None,

--- a/api-server/endpoints/src/rag.rs
+++ b/api-server/endpoints/src/rag.rs
@@ -26,7 +26,7 @@ impl RagEmbeddingRequest {
         RagEmbeddingRequest {
             embedding_request: EmbeddingRequest {
                 model: "dummy-embedding-model".to_string(),
-                input: input.to_vec(),
+                input: input.into(),
                 encoding_format: None,
                 user: None,
             },
@@ -52,7 +52,7 @@ impl RagEmbeddingRequest {
 fn test_rag_serialize_embedding_request() {
     let embedding_request = EmbeddingRequest {
         model: "model".to_string(),
-        input: vec!["input".to_string()],
+        input: "Hello, world!".into(),
         encoding_format: None,
         user: None,
     };
@@ -66,13 +66,13 @@ fn test_rag_serialize_embedding_request() {
     let json = serde_json::to_string(&rag_embedding_request).unwrap();
     assert_eq!(
         json,
-        r#"{"embeddings":{"model":"model","input":["input"]},"url":"http://localhost:6333","collection_name":"qdrant_collection_name"}"#
+        r#"{"embeddings":{"model":"model","input":"Hello, world!"},"url":"http://localhost:6333","collection_name":"qdrant_collection_name"}"#
     );
 }
 
 #[test]
 fn test_rag_deserialize_embedding_request() {
-    let json = r#"{"embeddings":{"model":"model","input":["input"]},"url":"http://localhost:6333","collection_name":"qdrant_collection_name"}"#;
+    let json = r#"{"embeddings":{"model":"model","input":["Hello, world!"]},"url":"http://localhost:6333","collection_name":"qdrant_collection_name"}"#;
     let rag_embedding_request: RagEmbeddingRequest = serde_json::from_str(json).unwrap();
     assert_eq!(rag_embedding_request.qdrant_url, "http://localhost:6333");
     assert_eq!(
@@ -82,7 +82,7 @@ fn test_rag_deserialize_embedding_request() {
     assert_eq!(rag_embedding_request.embedding_request.model, "model");
     assert_eq!(
         rag_embedding_request.embedding_request.input,
-        vec!["input".to_string()]
+        vec!["Hello, world!"].into()
     );
 }
 

--- a/api-server/llama-api-server/Cargo.toml
+++ b/api-server/llama-api-server/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "llama-api-server"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 
 [dependencies]
-llama-core = { path = "../llama-core", version = "^0.8" }
+llama-core = { path = "../llama-core", version = "^0.9" }
 futures = { version = "0.3.6", default-features = false, features = ["async-await", "std"] }
 serde.workspace = true
 serde_json = "1.0"

--- a/api-server/llama-core/Cargo.toml
+++ b/api-server/llama-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-core"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/api-server/llama-core/src/chat.rs
+++ b/api-server/llama-core/src/chat.rs
@@ -38,6 +38,12 @@ pub async fn chat_completions_stream(
 ) -> Result<impl futures::TryStream<Ok = String, Error = LlamaCoreError>, LlamaCoreError> {
     let model_name = chat_request.model.clone();
 
+    // parse the `include_usage` option
+    let include_usage = match chat_request.stream_options {
+        Some(ref stream_options) => stream_options.include_usage.unwrap_or_default(),
+        None => false,
+    };
+
     // update metadata
     let mut metadata = update_metadata(chat_request).await?;
 
@@ -58,6 +64,13 @@ pub async fn chat_completions_stream(
     set_prompt(chat_request.model.as_ref(), &prompt)?;
 
     let mut one_more_run_then_stop = true;
+    let mut stream_state = match include_usage {
+        true => StreamState::Usage,
+        false => StreamState::Done,
+    };
+    let mut context_full_state = ContextFullState::Message;
+    let mut prompt_too_long_state = PromptTooLongState::Message;
+
     let stream = stream::repeat_with(move || {
         // get graph
         match &model_name {
@@ -145,6 +158,7 @@ pub async fn chat_completions_stream(
                                         logprobs: None,
                                         finish_reason: None,
                                     }],
+                                    usage: None,
                                 };
 
                                 // serialize chat completion chunk
@@ -161,13 +175,55 @@ pub async fn chat_completions_stream(
                             Err(wasmedge_wasi_nn::Error::BackendError(
                                 wasmedge_wasi_nn::BackendError::EndOfSequence,
                             )) => {
-                                match one_more_run_then_stop {
-                                    true => {
-                                        one_more_run_then_stop = false;
+                                match stream_state {
+                                    StreamState::Usage => {
+                                        stream_state = StreamState::Done;
+
+                                        // retrieve the number of prompt and completion tokens
+                                        let token_info = get_token_info_by_graph(graph)?;
+
+                                        let usage = Some(Usage {
+                                            prompt_tokens: token_info.prompt_tokens,
+                                            completion_tokens: token_info.completion_tokens,
+                                            total_tokens: token_info.prompt_tokens + token_info.completion_tokens,
+                                        });
+
+                                        let created = SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .map_err(|e| {
+                                            LlamaCoreError::Operation(format!(
+                                                "Failed to get the current time. {}",
+                                                e
+                                            ))
+                                        })?;
+
+                                        let chat_completion_chunk = ChatCompletionChunk {
+                                            id: gen_chat_id(),
+                                            object: "chat.completion.chunk".to_string(),
+                                            created: created.as_secs(),
+                                            model: graph.name().to_owned(),
+                                            system_fingerprint: "fp_44709d6fcb".to_string(),
+                                            choices: vec![],
+                                            usage,
+                                        };
+
+                                        // serialize chat completion chunk
+                                        let chunk_str =
+                                        serde_json::to_string(&chat_completion_chunk).map_err(|e| {
+                                            LlamaCoreError::Operation(format!(
+                                                "Failed to serialize chat completion chunk. {}",
+                                                e
+                                            ))
+                                        })?;
+
+                                        Ok(format!("data: {}\n\n", chunk_str))
+                                    }
+                                    StreamState::Done => {
+                                        stream_state = StreamState::EndOfSequence;
 
                                         Ok("data: [DONE]\n\n".to_string())
                                     }
-                                    false => {
+                                    StreamState::EndOfSequence => {
                                         // clear context
                                         if let Err(e) = graph.finish_single() {
                                             return Err(LlamaCoreError::Backend(BackendError::FinishSingle(
@@ -182,8 +238,13 @@ pub async fn chat_completions_stream(
                             Err(wasmedge_wasi_nn::Error::BackendError(
                                 wasmedge_wasi_nn::BackendError::ContextFull,
                             )) => {
-                                match one_more_run_then_stop {
-                                    true => {
+                                match context_full_state {
+                                    ContextFullState::Message => {
+                                        match include_usage {
+                                            true => context_full_state = ContextFullState::Usage,
+                                            false => context_full_state = ContextFullState::Done,
+                                        }
+
                                         let created = SystemTime::now()
                                             .duration_since(std::time::UNIX_EPOCH)
                                             .map_err(|e| {
@@ -210,9 +271,8 @@ pub async fn chat_completions_stream(
                                                 logprobs: None,
                                                 finish_reason: Some(FinishReason::length),
                                             }],
+                                            usage: None,
                                         };
-
-                                        one_more_run_then_stop = false;
 
                                         // serialize chat completion chunk
                                         let chunk_str =
@@ -225,7 +285,55 @@ pub async fn chat_completions_stream(
 
                                         Ok(format!("data: {}\n\n", chunk_str))
                                     }
-                                    false => {
+                                    ContextFullState::Usage => {
+                                        context_full_state = ContextFullState::Done;
+
+                                        // retrieve the number of prompt and completion tokens
+                                        let token_info = get_token_info_by_graph(graph)?;
+
+                                        let usage = Some(Usage {
+                                            prompt_tokens: token_info.prompt_tokens,
+                                            completion_tokens: token_info.completion_tokens,
+                                            total_tokens: token_info.prompt_tokens + token_info.completion_tokens,
+                                        });
+
+                                        let created = SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .map_err(|e| {
+                                            LlamaCoreError::Operation(format!(
+                                                "Failed to get the current time. {}",
+                                                e
+                                            ))
+                                        })?;
+
+                                        let chat_completion_chunk = ChatCompletionChunk {
+                                            id: gen_chat_id(),
+                                            object: "chat.completion.chunk".to_string(),
+                                            created: created.as_secs(),
+                                            model: graph.name().to_owned(),
+                                            system_fingerprint: "fp_44709d6fcb".to_string(),
+                                            choices: vec![],
+                                            usage,
+                                        };
+
+                                        // serialize chat completion chunk
+                                        let chunk_str =
+                                        serde_json::to_string(&chat_completion_chunk).map_err(|e| {
+                                            LlamaCoreError::Operation(format!(
+                                                "Failed to serialize chat completion chunk. {}",
+                                                e
+                                            ))
+                                        })?;
+
+                                        Ok(format!("data: {}\n\n", chunk_str))
+
+                                    }
+                                    ContextFullState::Done => {
+                                        context_full_state = ContextFullState::EndOfSequence;
+
+                                        Ok("data: [DONE]\n\n".to_string())
+                                    }
+                                    ContextFullState::EndOfSequence => {
                                         // clear context
                                         if let Err(e) = graph.finish_single() {
                                             return Err(LlamaCoreError::Backend(BackendError::FinishSingle(
@@ -240,8 +348,13 @@ pub async fn chat_completions_stream(
                             Err(wasmedge_wasi_nn::Error::BackendError(
                                 wasmedge_wasi_nn::BackendError::PromptTooLong,
                             )) => {
-                                match one_more_run_then_stop {
-                                    true => {
+                                match prompt_too_long_state {
+                                    PromptTooLongState::Message => {
+                                        match include_usage {
+                                            true => prompt_too_long_state = PromptTooLongState::Usage,
+                                            false => prompt_too_long_state = PromptTooLongState::Done,
+                                        }
+
                                         let created = SystemTime::now()
                                             .duration_since(std::time::UNIX_EPOCH)
                                             .map_err(|e| {
@@ -268,9 +381,8 @@ pub async fn chat_completions_stream(
                                                 logprobs: None,
                                                 finish_reason: Some(FinishReason::length),
                                             }],
+                                            usage: None,
                                         };
-
-                                        one_more_run_then_stop = false;
 
                                         // serialize chat completion chunk
                                         let chunk_str =
@@ -283,7 +395,54 @@ pub async fn chat_completions_stream(
 
                                         Ok(format!("data: {}\n\n", chunk_str))
                                     }
-                                    false => {
+                                    PromptTooLongState::Usage => {
+                                        prompt_too_long_state = PromptTooLongState::Done;
+
+                                        // retrieve the number of prompt and completion tokens
+                                        let token_info = get_token_info_by_graph(graph)?;
+
+                                        let usage = Some(Usage {
+                                            prompt_tokens: token_info.prompt_tokens,
+                                            completion_tokens: token_info.completion_tokens,
+                                            total_tokens: token_info.prompt_tokens + token_info.completion_tokens,
+                                        });
+
+                                        let created = SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .map_err(|e| {
+                                            LlamaCoreError::Operation(format!(
+                                                "Failed to get the current time. {}",
+                                                e
+                                            ))
+                                        })?;
+
+                                        let chat_completion_chunk = ChatCompletionChunk {
+                                            id: gen_chat_id(),
+                                            object: "chat.completion.chunk".to_string(),
+                                            created: created.as_secs(),
+                                            model: graph.name().to_owned(),
+                                            system_fingerprint: "fp_44709d6fcb".to_string(),
+                                            choices: vec![],
+                                            usage,
+                                        };
+
+                                        // serialize chat completion chunk
+                                        let chunk_str =
+                                        serde_json::to_string(&chat_completion_chunk).map_err(|e| {
+                                            LlamaCoreError::Operation(format!(
+                                                "Failed to serialize chat completion chunk. {}",
+                                                e
+                                            ))
+                                        })?;
+
+                                        Ok(format!("data: {}\n\n", chunk_str))
+                                    }
+                                    PromptTooLongState::Done => {
+                                        prompt_too_long_state = PromptTooLongState::EndOfSequence;
+
+                                        Ok("data: [DONE]\n\n".to_string())
+                                    }
+                                    PromptTooLongState::EndOfSequence => {
                                         // clear context
                                         if let Err(e) = graph.finish_single() {
                                             return Err(LlamaCoreError::Backend(BackendError::FinishSingle(
@@ -376,6 +535,11 @@ pub async fn chat_completions_stream(
                                     }
                                 };
 
+                                // ! debug
+                                // retrieve the number of prompt and completion tokens
+                                let token_info = get_token_info_by_graph(graph)?;
+                                println!("[DEBUG] token_info: {:?}", token_info);
+
                                 let created = SystemTime::now()
                                     .duration_since(std::time::UNIX_EPOCH)
                                     .map_err(|e| {
@@ -402,6 +566,7 @@ pub async fn chat_completions_stream(
                                         logprobs: None,
                                         finish_reason: None,
                                     }],
+                                    usage: None,
                                 };
 
                                 // serialize chat completion chunk
@@ -467,6 +632,7 @@ pub async fn chat_completions_stream(
                                                 logprobs: None,
                                                 finish_reason: Some(FinishReason::length),
                                             }],
+                                            usage: None,
                                         };
 
                                         one_more_run_then_stop = false;
@@ -525,6 +691,7 @@ pub async fn chat_completions_stream(
                                                 logprobs: None,
                                                 finish_reason: Some(FinishReason::length),
                                             }],
+                                            usage: None,
                                         };
 
                                         one_more_run_then_stop = false;
@@ -1361,4 +1528,27 @@ fn set_metadata(model_name: Option<&String>, metadata: &Metadata) -> Result<(), 
             }
         }
     }
+}
+
+#[derive(Debug)]
+enum ContextFullState {
+    Message,
+    Usage,
+    Done,
+    EndOfSequence,
+}
+
+#[derive(Debug)]
+enum StreamState {
+    Usage,
+    Done,
+    EndOfSequence,
+}
+
+#[derive(Debug)]
+enum PromptTooLongState {
+    Message,
+    Usage,
+    Done,
+    EndOfSequence,
 }

--- a/api-server/llama-core/src/embeddings.rs
+++ b/api-server/llama-core/src/embeddings.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use endpoints::{
     common::Usage,
-    embeddings::{EmbeddingObject, EmbeddingRequest, EmbeddingsResponse},
+    embeddings::{EmbeddingObject, EmbeddingRequest, EmbeddingsResponse, InputText},
 };
 use serde::{Deserialize, Serialize};
 
@@ -63,7 +63,12 @@ pub async fn embeddings(
     }
 
     // compute embeddings
-    let (data, usage) = compute_embeddings(graph, &embedding_request.input)?;
+    let (data, usage) = match &embedding_request.input {
+        InputText::String(text) => compute_embeddings(graph, &[text.to_owned()])?,
+        InputText::Array(texts) => compute_embeddings(graph, texts.as_slice())?,
+    };
+
+    // let (data, usage) = compute_embeddings(graph, &embedding_request.input)?;
 
     if graph.metadata.log_prompts || graph.metadata.log_enable {
         println!("[+] Embeddings computed successfully.\n");

--- a/chat/Cargo.toml
+++ b/chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-chat"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 
 [dependencies]

--- a/chat/README.md
+++ b/chat/README.md
@@ -110,49 +110,51 @@ If you have 3 apples, each costing 5 dollars, the total cost of the apples is 15
 The options for `llama-chat` wasm app are:
 
 ```console
-~/workspace/llama-utils/chat$ wasmedge llama-chat.wasm -h
-Usage: llama-chat.wasm [OPTIONS]
+~/LlamaEdge/chat$ wasmedge llama-chat.wasm -h
+
+Usage: llama-chat.wasm [OPTIONS] --prompt-template <PROMPT_TEMPLATE>
 
 Options:
-  -a, --model-alias <ALIAS>
+  -m, --model-name <MODEL_NAME>
+          Model name [default: default]
+  -a, --model-alias <MODEL_ALIAS>
           Model alias [default: default]
   -c, --ctx-size <CTX_SIZE>
           Size of the prompt context [default: 512]
-  -n, --n-predict <N_PRDICT>
+  -n, --n-predict <N_PREDICT>
           Number of tokens to predict [default: 1024]
   -g, --n-gpu-layers <N_GPU_LAYERS>
           Number of layers to run on the GPU [default: 100]
   -b, --batch-size <BATCH_SIZE>
           Batch size for prompt processing [default: 512]
       --temp <TEMP>
-          Temperature for sampling [default: 0.8]
+          Temperature for sampling
       --top-p <TOP_P>
-          An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. 1.0 = disabled. [default: 0.9]
+          An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. 1.0 = disabled
       --repeat-penalty <REPEAT_PENALTY>
           Penalize repeat sequence of tokens [default: 1.1]
       --presence-penalty <PRESENCE_PENALTY>
-          Repeat alpha presence penalty. 0.0 = disabled. [default: 0.0]
-      -frequency-penalty <FREQUENCY_PENALTY>
+          Repeat alpha presence penalty. 0.0 = disabled [default: 0.0]
+      --frequency-penalty <FREQUENCY_PENALTY>
           Repeat alpha frequency penalty. 0.0 = disabled [default: 0.0]
+  -p, --prompt-template <PROMPT_TEMPLATE>
+          Sets the prompt template [possible values: llama-2-chat, llama-3-chat, mistral-instruct, mistrallite, openchat, codellama-instruct, codellama-super-instruct, human-assistant, vicuna-1.0-chat, vicuna-1.1-chat, vicuna-llava, chatml, baichuan-2, wizard-coder, zephyr, stablelm-zephyr, intel-neural, deepseek-chat, deepseek-coder, solar-instruct, phi-2-chat, phi-2-instruct, phi-3-chat, phi-3-instruct, gemma-instruct, octopus]
   -r, --reverse-prompt <REVERSE_PROMPT>
-          Halt generation at PROMPT, return control.
+          Halt generation at PROMPT, return control
   -s, --system-prompt <SYSTEM_PROMPT>
-          System prompt message string [default: "[Default system message for the prompt template]"]
-  -p, --prompt-template <TEMPLATE>
-          Prompt template. [default: llama-2-chat] [possible values: llama-2-chat, codellama-instruct, codellama-super-instruct, mistral-instruct, mistrallite, openchat, human-assistant, vicuna-1.0-chat, vicuna-1.1-chat, chatml, baichuan-2, wizard-coder, zephyr, stablelm-zephyr, intel-neural, deepseek-chat, deepseek-coder, solar-instruct, phi-2-instruct, phi-3-chat, phi-3-instruct, gemma-instruct]
+          System prompt message string
       --log-prompts
           Print prompt strings to stdout
       --log-stat
           Print statistics to stdout
       --log-all
           Print all log information to stdout
+      --disable-stream
+          enable streaming stdout
   -h, --help
           Print help
   -V, --version
           Print version
-
-Example: the command to run `llama-2-7B` model,
-  wasmedge --dir .:. --nn-preload default:GGML:AUTO:llama-2-7b-chat.Q5_K_M.gguf llama-chat.wasm -p llama-2-chat
 ```
 
 ## Optional: Build the `llama-chat` wasm app yourself

--- a/chat/src/main.rs
+++ b/chat/src/main.rs
@@ -53,7 +53,7 @@ struct Cli {
     #[arg(short, long)]
     reverse_prompt: Option<String>,
     /// System prompt message string.
-    #[arg(long)]
+    #[arg(short, long)]
     system_prompt: Option<String>,
     /// Print prompt strings to stdout
     #[arg(long)]

--- a/chat/src/main.rs
+++ b/chat/src/main.rs
@@ -197,7 +197,7 @@ async fn main() -> anyhow::Result<()> {
         .with_presence_penalty(cli.presence_penalty)
         .with_frequency_penalty(cli.frequency_penalty)
         .with_sampling(sampling)
-        .with_stream(!cli.disable_stream)
+        .enable_stream(!cli.disable_stream)
         .build();
 
     // add system message if provided

--- a/simple/Cargo.toml
+++ b/simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-simple"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Major changes:

- Endpoints
  - Add `ChatCompletionToolMessage`
  - Add `stream_options` field in `ChatCompletionRequest`
  - Improve `EmbeddingRequest::input` to accept values of `String` and `Vec<String>` types

- Chat-prompts
  - Support `tool message` in `ChatMLPrompt`

- Llama-core
  - Support `usage` in streaming response

- Llama-chat
  - Add `-s` for `--system-prompt` CLI option