### PR TITLE
Release 0.11.0

### DIFF
--- a/api-server/README.md
+++ b/api-server/README.md
@@ -138,7 +138,7 @@ If the command is successful, you should see the similar output as below in your
 
 ### `/v1/chat/completions` endpoint
 
-`/v1/chat/completions` endpoint is used for multi-turn conversations between human users and LLM models.
+`/v1/chat/completions` endpoint is used for multi-turn conversations between human users and LLM models. To use this endpoint, user `chat` or `max` subcommands to start the API server.
 
 <details> <summary> Example </summary>
 
@@ -181,7 +181,7 @@ Here is the response from LlamaEdge API server:
 
 ### `/v1/files` endpoint
 
-`/v1/files` endpoint is used for uploading text and markdown files to LlamaEdge API server.
+`/v1/files` endpoint is used for uploading text and markdown files to LlamaEdge API server.  To use this endpoint, user `embedding` or `max` subcommands to start the API server.
 
 <details> <summary> Example </summary>
 
@@ -212,7 +212,7 @@ If you'd like to build a RAG chatbot, it's strongly recommended to visit [LlamaE
 
 ### `/v1/chunks` endpoint
 
-To segment the uploaded file to chunks for computing embeddings, use the `/v1/chunks` API.
+To segment the uploaded file to chunks for computing embeddings, use the `/v1/chunks` API.  To use this endpoint, user `embedding` or `max` subcommands to start the API server.
 
 <details> <summary> Example </summary>
 
@@ -248,7 +248,7 @@ If you'd like to build a RAG chatbot, it's strongly recommended to visit [LlamaE
 
 ### `/v1/embeddings` endpoint
 
-To compute embeddings for user query or file chunks, use the `/v1/embeddings` API.
+To compute embeddings for user query or file chunks, use the `/v1/embeddings` API.  To use this endpoint, user `embedding` or `max` subcommands to start the API server.
 
 <details> <summary> Example </summary>
 
@@ -349,7 +349,7 @@ If you'd like to build a RAG chatbot, it's strongly recommended to visit [LlamaE
 
 ### `/v1/completions` endpoint
 
-To obtain the completion for a single prompt, use the `/v1/completions` API.
+To obtain the completion for a single prompt, use the `/v1/completions` API. To use this endpoint, user `chat` or `max` subcommands to start the API server.
 
 <details> <summary> Example </summary>
 
@@ -426,7 +426,7 @@ Options:
   -V, --version                    Print version
 ```
 
-<details> <summary> `chat` subcommand for chat completions only </summary>
+<details> <summary> *chat* subcommand for chat completions only </summary>
 
 ```console
 $ wasmedge llama-api-server.wasm help chat

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -410,21 +410,42 @@ Then, you will be asked to open `http://127.0.0.1:8080` from your browser.
 The `-h` or `--help` option can list the available options of the `llama-api-server` wasm app:
 
 ```console
-$ wasmedge llama-api-server.wasm -h
+$ wasmedge llama-api-server.wasm help
 
-Usage: llama-api-server.wasm [OPTIONS] --prompt-template <PROMPT_TEMPLATE>
+Usage: llama-api-server.wasm [OPTIONS] <COMMAND>
+
+Commands:
+  chat       Start server for chat completions
+  embedding  Start server for computing embeddings
+  max        Start server for both chat completions and computing embeddings
+  help       Print this message or the help of the given subcommand(s)
 
 Options:
-  -m, --model-name <MODEL_NAME>
-          Model name [default: default]
-  -a, --model-alias <MODEL_ALIAS>
-          Model alias [default: default]
+      --socket-addr <SOCKET_ADDR>  Socket address of LlamaEdge API Server instance [default: 0.0.0.0:8080]
+  -h, --help                       Print help
+  -V, --version                    Print version
+```
+
+<details> <summary> `chat` subcommand for chat completions only </summary>
+
+```console
+$ wasmedge llama-api-server.wasm help chat
+
+Start server for chat completions
+
+Usage: llama-api-server.wasm chat [OPTIONS] --model-name <MODEL_NAME> --prompt-template <PROMPT_TEMPLATE>
+
+Options:
+      --model-name <MODEL_NAME>
+          Name of chat model
+      --model-alias <MODEL_ALIAS>
+          Alias for chat model [default: default]
   -c, --ctx-size <CTX_SIZE>
-          Context size [default: 512]
+          Context size of chat model [default: 512]
   -p, --prompt-template <PROMPT_TEMPLATE>
-          Sets the prompt template [possible values: llama-2-chat, llama-3-chat, mistral-instruct, mistrallite, openchat, codellama-instruct, codellama-super-instruct, human-assistant, vicuna-1.0-chat, vicuna-1.1-chat, vicuna-llava, chatml, baichuan-2, wizard-coder, zephyr, stablelm-zephyr, intel-neural, deepseek-chat, deepseek-coder, solar-instruct, phi-2-chat, phi-2-instruct, phi-3-chat, phi-3-instruct, gemma-instruct, octopus]
+          Prompt template used for chat completions [possible values: llama-2-chat, llama-3-chat, mistral-instruct, mistrallite, openchat, codellama-instruct, codellama-super-instruct, human-assistant, vicuna-1.0-chat, vicuna-1.1-chat, vicuna-llava, chatml, baichuan-2, wizard-coder, zephyr, stablelm-zephyr, intel-neural, deepseek-chat, deepseek-coder, solar-instruct, phi-2-chat, phi-2-instruct, phi-3-chat, phi-3-instruct, gemma-instruct, octopus]
   -r, --reverse-prompt <REVERSE_PROMPT>
-          Halt generation at PROMPT, return control
+          Reverse prompt for stopping generation
   -n, --n-predict <N_PREDICT>
           Number of tokens to predict [default: 1024]
   -g, --n-gpu-layers <N_GPU_LAYERS>
@@ -449,15 +470,94 @@ Options:
           Print statistics to stdout
       --log-all
           Print all log information to stdout
-      --socket-addr <SOCKET_ADDR>
-          Socket address of LlamaEdge API Server instance [default: 0.0.0.0:8080]
       --web-ui <WEB_UI>
           Root path for the Web UI files [default: chatbot-ui]
   -h, --help
           Print help
-  -V, --version
-          Print version
 ```
+
+</details>
+
+<details> <summary> `embedding` subcommand for computing embeddings only </summary>
+
+```console
+$ wasmedge llama-api-server.wasm help embedding
+
+Start server for computing embeddings
+
+Usage: llama-api-server.wasm embedding [OPTIONS] --model-name <MODEL_NAME>
+
+Options:
+      --model-name <MODEL_NAME>    Name of embedding model
+      --model-alias <MODEL_ALIAS>  Alias for embedding model [default: default]
+  -c, --ctx-size <CTX_SIZE>        Context size of embedding model [default: 512]
+  -b, --batch-size <BATCH_SIZE>    Batch size for embedding model [default: 512]
+      --log-stat                   Print statistics to stdout
+      --log-all                    Print all log information to stdout
+  -h, --help                       Print help
+```
+
+</details>
+
+<details> <summary> `max` subcommand for both chat completions and computing embeddings</summary>
+
+```console
+$ wasmedge llama-api-server.wasm help max
+
+Start server for both chat completions and computing embeddings
+
+Usage: llama-api-server.wasm max [OPTIONS] --model-name <MODEL_NAME> --prompt-template <PROMPT_TEMPLATE> --embedding-model-name <EMBEDDING_MODEL_NAME>
+
+Options:
+      --model-name <MODEL_NAME>
+          Name of chat model
+      --model-alias <MODEL_ALIAS>
+          Alias for chat model [default: default]
+      --ctx-size <CTX_SIZE>
+          Context size of chat model [default: 512]
+      --prompt-template <PROMPT_TEMPLATE>
+          Prompt template used for chat completions [possible values: llama-2-chat, llama-3-chat, mistral-instruct, mistrallite, openchat, codellama-instruct, codellama-super-instruct, human-assistant, vicuna-1.0-chat, vicuna-1.1-chat, vicuna-llava, chatml, baichuan-2, wizard-coder, zephyr, stablelm-zephyr, intel-neural, deepseek-chat, deepseek-coder, solar-instruct, phi-2-chat, phi-2-instruct, phi-3-chat, phi-3-instruct, gemma-instruct, octopus]
+      --reverse-prompt <REVERSE_PROMPT>
+          Reverse prompt for stopping generation
+      --n-predict <N_PREDICT>
+          Number of tokens to predict [default: 1024]
+      --n-gpu-layers <N_GPU_LAYERS>
+          Number of layers to run on the GPU [default: 100]
+      --batch-size <BATCH_SIZE>
+          Batch size for prompt processing [default: 512]
+      --temp <TEMP>
+          Temperature for sampling [default: 1.0]
+      --top-p <TOP_P>
+          An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. 1.0 = disabled [default: 1.0]
+      --repeat-penalty <REPEAT_PENALTY>
+          Penalize repeat sequence of tokens [default: 1.1]
+      --presence-penalty <PRESENCE_PENALTY>
+          Repeat alpha presence penalty. 0.0 = disabled [default: 0.0]
+      --frequency-penalty <FREQUENCY_PENALTY>
+          Repeat alpha frequency penalty. 0.0 = disabled [default: 0.0]
+      --llava-mmproj <LLAVA_MMPROJ>
+          Path to the multimodal projector file
+      --embedding-model-name <EMBEDDING_MODEL_NAME>
+          Name of embedding model
+      --embedding-model-alias <EMBEDDING_MODEL_ALIAS>
+          Alias for embedding model [default: embedding]
+      --embedding-ctx-size <EMBEDDING_CTX_SIZE>
+          Context size of embedding model [default: 512]
+      --embedding-batch-size <EMBEDDING_BATCH_SIZE>
+          Batch size for embedding model [default: 512]
+      --log-prompts
+          Print prompt strings to stdout
+      --log-stat
+          Print statistics to stdout
+      --log-all
+          Print all log information to stdout
+      --web-ui <WEB_UI>
+          Root path for the Web UI files [default: chatbot-ui]
+  -h, --help
+          Print help
+```
+
+</details>
 
 Please guarantee that the port is not occupied by other processes. If the port specified is available on your machine and the command is successful, you should see the following output in the terminal:
 

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -92,14 +92,14 @@ Run the API server with the following command:
 wasmedge --dir .:. \
     --nn-preload default:GGML:AUTO:llama-2-7b-chat.Q5_K_M.gguf \
     llama-api-server.wasm \
+    chat \
     --prompt-template llama-2-chat \
     --model-name llama-2-7b-chat
 ```
 
-The command above starts the API server on the default socket address. Besides, there are also some other options specified in the command:
+The command above use `chat` subcommand to start an API server on the default socket address. Besides, there are also some other options specified in the command:
 
 - The `--dir .:.` option specifies the current directory as the root directory of the WASI file system.
-
 - The `--nn-preload default:GGML:AUTO:llama-2-7b-chat.Q5_K_M.gguf` option specifies the Llama model to be used by the API server. The pattern of the argument is `<name>:<encoding>:<target>:<model path>`. Here, the model used is `llama-2-7b-chat.Q5_K_M.gguf`; and we give it an alias `default` as its name in the runtime environment. You can change the model name here if you're not using llama2-7b-chat
 - The `--prompt-template llama-2-chat` is the prompt template for the model.
 - The `--model-name llama-2-7b-chat` specifies the model name. It is used in the chat request.

--- a/api-server/llama-api-server/Cargo.toml
+++ b/api-server/llama-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-api-server"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
 
 [dependencies]

--- a/api-server/llama-api-server/src/backend/mod.rs
+++ b/api-server/llama-api-server/src/backend/mod.rs
@@ -25,6 +25,7 @@ async fn handle_chat_request(req: Request<Body>) -> Result<Response<Body>, hyper
         "/v1/models" => ggml::models_handler().await,
         "/v1/chat/completions" => ggml::chat_completions_handler(req).await,
         "/v1/completions" => ggml::completions_handler(req).await,
+        "/v1/info" => ggml::server_info().await,
         _ => error::invalid_endpoint(req.uri().path()),
     }
 }
@@ -35,6 +36,7 @@ async fn handle_embedding_request(req: Request<Body>) -> Result<Response<Body>, 
         "/v1/embeddings" => ggml::embeddings_handler(req).await,
         "/v1/files" => ggml::files_handler(req).await,
         "/v1/chunks" => ggml::chunks_handler(req).await,
+        "/v1/info" => ggml::server_info().await,
         _ => error::invalid_endpoint(req.uri().path()),
     }
 }
@@ -47,6 +49,7 @@ async fn handle_chat_embedding_request(req: Request<Body>) -> Result<Response<Bo
         "/v1/embeddings" => ggml::embeddings_handler(req).await,
         "/v1/files" => ggml::files_handler(req).await,
         "/v1/chunks" => ggml::chunks_handler(req).await,
+        "/v1/info" => ggml::server_info().await,
         _ => error::invalid_endpoint(req.uri().path()),
     }
 }

--- a/api-server/llama-api-server/src/backend/mod.rs
+++ b/api-server/llama-api-server/src/backend/mod.rs
@@ -2,14 +2,48 @@ pub(crate) mod ggml;
 
 use crate::error;
 use hyper::{Body, Request, Response};
+use llama_core::RunningMode;
 
 pub(crate) async fn handle_llama_request(
     req: Request<Body>,
 ) -> Result<Response<Body>, hyper::Error> {
+    let running_mode = match llama_core::running_mode() {
+        Ok(mode) => mode,
+        Err(e) => return error::internal_server_error(e.to_string()),
+    };
+
+    match running_mode {
+        RunningMode::Chat => handle_chat_request(req).await,
+        RunningMode::Embeddings => handle_embedding_request(req).await,
+        RunningMode::ChatEmbedding => handle_chat_embedding_request(req).await,
+        _ => error::not_implemented(),
+    }
+}
+
+async fn handle_chat_request(req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
     match req.uri().path() {
+        "/v1/models" => ggml::models_handler().await,
         "/v1/chat/completions" => ggml::chat_completions_handler(req).await,
         "/v1/completions" => ggml::completions_handler(req).await,
+        _ => error::invalid_endpoint(req.uri().path()),
+    }
+}
+
+async fn handle_embedding_request(req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
+    match req.uri().path() {
         "/v1/models" => ggml::models_handler().await,
+        "/v1/embeddings" => ggml::embeddings_handler(req).await,
+        "/v1/files" => ggml::files_handler(req).await,
+        "/v1/chunks" => ggml::chunks_handler(req).await,
+        _ => error::invalid_endpoint(req.uri().path()),
+    }
+}
+
+async fn handle_chat_embedding_request(req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
+    match req.uri().path() {
+        "/v1/models" => ggml::models_handler().await,
+        "/v1/chat/completions" => ggml::chat_completions_handler(req).await,
+        "/v1/completions" => ggml::completions_handler(req).await,
         "/v1/embeddings" => ggml::embeddings_handler(req).await,
         "/v1/files" => ggml::files_handler(req).await,
         "/v1/chunks" => ggml::chunks_handler(req).await,

--- a/api-server/llama-api-server/src/main.rs
+++ b/api-server/llama-api-server/src/main.rs
@@ -4,7 +4,7 @@ mod utils;
 
 use anyhow::Result;
 use chat_prompts::PromptTemplateType;
-use clap::Parser;
+use clap::{Args, Parser, Subcommand};
 use error::ServerError;
 use hyper::{
     header,
@@ -12,7 +12,7 @@ use hyper::{
     Body, Request, Response, Server, StatusCode,
 };
 use llama_core::MetadataBuilder;
-use std::{net::SocketAddr, path::PathBuf};
+use std::{net::SocketAddr, path::PathBuf, sync::Arc};
 use utils::log;
 
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -23,19 +23,39 @@ const DEFAULT_SOCKET_ADDRESS: &str = "0.0.0.0:8080";
 #[derive(Debug, Parser)]
 #[command(author, about, version, long_about=None)]
 struct Cli {
-    /// Model name
-    #[arg(short, long, default_value = "default")]
+    #[clap(subcommand)]
+    command: Commands,
+
+    /// Socket address of LlamaEdge API Server instance
+    #[arg(long, default_value = DEFAULT_SOCKET_ADDRESS)]
+    socket_addr: String,
+}
+
+#[derive(Debug, Subcommand)]
+enum Commands {
+    /// Start server for chat completions
+    Chat(ChatArgs),
+    /// Start server for computing embeddings
+    Embedding(EmbeddingArgs),
+    /// Start server for both chat completions and computing embeddings
+    Max(FullArgs),
+}
+
+#[derive(Debug, Args)]
+struct ChatArgs {
+    /// Name of chat model
+    #[arg(long, required = true)]
     model_name: String,
-    /// Model alias
-    #[arg(short = 'a', long, default_value = "default")]
+    /// Alias for chat model
+    #[arg(long, default_value = "default")]
     model_alias: String,
-    /// Context size
+    /// Context size of chat model
     #[arg(short, long, default_value = "512")]
     ctx_size: u64,
-    /// Sets the prompt template.
+    /// Prompt template used for chat completions
     #[arg(short, long, value_parser = clap::value_parser!(PromptTemplateType), required = true)]
     prompt_template: PromptTemplateType,
-    /// Halt generation at PROMPT, return control.
+    /// Reverse prompt for stopping generation.
     #[arg(short, long)]
     reverse_prompt: Option<String>,
     /// Number of tokens to predict
@@ -74,9 +94,102 @@ struct Cli {
     /// Print all log information to stdout
     #[arg(long)]
     log_all: bool,
-    /// Socket address of LlamaEdge API Server instance
-    #[arg(long, default_value = DEFAULT_SOCKET_ADDRESS)]
-    socket_addr: String,
+    /// Root path for the Web UI files
+    #[arg(long, default_value = "chatbot-ui")]
+    web_ui: PathBuf,
+}
+
+#[derive(Debug, Args)]
+struct EmbeddingArgs {
+    /// Name of embedding model
+    #[arg(long, required = true)]
+    model_name: String,
+    /// Alias for embedding model
+    #[arg(long, default_value = "default")]
+    model_alias: String,
+    /// Context size of embedding model
+    #[arg(short, long, default_value = "512")]
+    ctx_size: u64,
+    /// Batch size for embedding model
+    #[arg(short, long, default_value = "512")]
+    batch_size: u64,
+    /// Print statistics to stdout
+    #[arg(long)]
+    log_stat: bool,
+    /// Print all log information to stdout
+    #[arg(long)]
+    log_all: bool,
+}
+
+#[derive(Debug, Args)]
+struct FullArgs {
+    // * Chat model arguments
+    /// Name of chat model
+    #[arg(long, required = true)]
+    model_name: String,
+    /// Alias for chat model
+    #[arg(long, default_value = "default")]
+    model_alias: String,
+    /// Context size of chat model
+    #[arg(long, default_value = "512")]
+    ctx_size: u64,
+    /// Prompt template used for chat completions
+    #[arg(long, value_parser = clap::value_parser!(PromptTemplateType), required = true)]
+    prompt_template: PromptTemplateType,
+    /// Reverse prompt for stopping generation.
+    #[arg(long)]
+    reverse_prompt: Option<String>,
+    /// Number of tokens to predict
+    #[arg(long, default_value = "1024")]
+    n_predict: u64,
+    /// Number of layers to run on the GPU
+    #[arg(long, default_value = "100")]
+    n_gpu_layers: u64,
+    /// Batch size for prompt processing
+    #[arg(long, default_value = "512")]
+    batch_size: u64,
+    /// Temperature for sampling
+    #[arg(long, default_value = "1.0")]
+    temp: f64,
+    /// An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. 1.0 = disabled
+    #[arg(long, default_value = "1.0")]
+    top_p: f64,
+    /// Penalize repeat sequence of tokens
+    #[arg(long, default_value = "1.1")]
+    repeat_penalty: f64,
+    /// Repeat alpha presence penalty. 0.0 = disabled
+    #[arg(long, default_value = "0.0")]
+    presence_penalty: f64,
+    /// Repeat alpha frequency penalty. 0.0 = disabled
+    #[arg(long, default_value = "0.0")]
+    frequency_penalty: f64,
+    /// Path to the multimodal projector file
+    #[arg(long)]
+    llava_mmproj: Option<String>,
+
+    // * Embedding model arguments
+    /// Name of embedding model
+    #[arg(long, required = true)]
+    embedding_model_name: String,
+    /// Alias for embedding model
+    #[arg(long, default_value = "embedding")]
+    embedding_model_alias: String,
+    /// Context size of embedding model
+    #[arg(long, default_value = "512")]
+    embedding_ctx_size: u64,
+    /// Batch size for embedding model
+    #[arg(long, default_value = "512")]
+    embedding_batch_size: u64,
+
+    /// Print prompt strings to stdout
+    #[arg(long)]
+    log_prompts: bool,
+    /// Print statistics to stdout
+    #[arg(long)]
+    log_stat: bool,
+    /// Print all log information to stdout
+    #[arg(long)]
+    log_all: bool,
     /// Root path for the Web UI files
     #[arg(long, default_value = "chatbot-ui")]
     web_ui: PathBuf,
@@ -95,76 +208,249 @@ async fn main() -> Result<(), ServerError> {
     let cli = Cli::parse();
 
     // log the version of the server
-    log(format!(
-        "\n[INFO] LlamaEdge version: {}",
-        env!("CARGO_PKG_VERSION")
-    ));
+    let server_version = env!("CARGO_PKG_VERSION").to_string();
+    log(format!("[INFO] LlamaEdge-RAG version: {}", &server_version));
 
-    // log the cli options
-    log(format!("[INFO] Model name: {}", &cli.model_name));
-    log(format!("[INFO] Model alias: {}", &cli.model_alias));
-    log(format!("[INFO] Context size: {}", &cli.ctx_size));
-    log(format!("[INFO] Prompt template: {}", &cli.prompt_template));
-    if let Some(reverse_prompt) = &cli.reverse_prompt {
-        log(format!("[INFO] reverse prompt: {}", reverse_prompt));
-    }
-    log(format!(
-        "[INFO] Number of tokens to predict: {}",
-        &cli.n_predict
-    ));
-    log(format!(
-        "[INFO] Number of layers to run on the GPU: {}",
-        &cli.n_gpu_layers
-    ));
-    log(format!(
-        "[INFO] Batch size for prompt processing: {}",
-        &cli.batch_size
-    ));
-    log(format!("[INFO] Temperature for sampling: {}", &cli.temp));
-    log(format!(
-        "[INFO] Top-p sampling (1.0 = disabled): {}",
-        &cli.top_p
-    ));
-    log(format!(
-        "[INFO] Penalize repeat sequence of tokens: {}",
-        &cli.repeat_penalty
-    ));
-    log(format!(
-        "[INFO] Presence penalty (0.0 = disabled): {}",
-        &cli.presence_penalty
-    ));
-    log(format!(
-        "[INFO] Frequency penalty (0.0 = disabled): {}",
-        &cli.frequency_penalty
-    ));
-    if let Some(llava_mmproj) = &cli.llava_mmproj {
-        log(format!("[INFO] Multimodal projector: {}", llava_mmproj));
-    }
-    log(format!("[INFO] Enable prompt log: {}", &cli.log_prompts));
-    log(format!("[INFO] Enable plugin log: {}", &cli.log_stat));
-    log(format!("[INFO] Socket address: {}", &cli.socket_addr));
+    let web_ui = match cli.command {
+        Commands::Chat(chat_args) => {
+            // log
+            {
+                // log the cli options
+                log(format!("[INFO] Model name: {}", &chat_args.model_name));
+                log(format!("[INFO] Model alias: {}", &chat_args.model_alias));
+                log(format!("[INFO] Context size: {}", &chat_args.ctx_size));
+                log(format!("[INFO] Batch size: {}", &chat_args.batch_size));
+                log(format!(
+                    "[INFO] Prompt template: {}",
+                    &chat_args.prompt_template
+                ));
+                if let Some(reverse_prompt) = &chat_args.reverse_prompt {
+                    log(format!("[INFO] reverse prompt: {}", reverse_prompt));
+                }
+                log(format!(
+                    "[INFO] Number of tokens to predict: {}",
+                    &chat_args.n_predict
+                ));
+                log(format!(
+                    "[INFO] Number of layers to run on the GPU: {}",
+                    &chat_args.n_gpu_layers
+                ));
+                log(format!(
+                    "[INFO] Temperature for sampling: {}",
+                    &chat_args.temp
+                ));
+                log(format!(
+                    "[INFO] Top-p sampling (1.0 = disabled): {}",
+                    &chat_args.top_p
+                ));
+                log(format!(
+                    "[INFO] Penalize repeat sequence of tokens: {}",
+                    &chat_args.repeat_penalty
+                ));
+                log(format!(
+                    "[INFO] Presence penalty (0.0 = disabled): {}",
+                    &chat_args.presence_penalty
+                ));
+                log(format!(
+                    "[INFO] Frequency penalty (0.0 = disabled): {}",
+                    &chat_args.frequency_penalty
+                ));
+                if let Some(llava_mmproj) = &chat_args.llava_mmproj {
+                    log(format!("[INFO] Multimodal projector: {}", llava_mmproj));
+                }
+                log(format!(
+                    "[INFO] Enable prompt log: {}",
+                    &chat_args.log_prompts
+                ));
+                log(format!("[INFO] Enable plugin log: {}", &chat_args.log_stat));
+            }
 
-    // create a Metadata instance
-    let metadata = MetadataBuilder::new(cli.model_name, cli.model_alias, cli.prompt_template)
-        .with_ctx_size(cli.ctx_size)
-        .with_n_predict(cli.n_predict)
-        .with_n_gpu_layers(cli.n_gpu_layers)
-        .with_batch_size(cli.batch_size)
-        .with_temperature(cli.temp)
-        .with_top_p(cli.top_p)
-        .with_repeat_penalty(cli.repeat_penalty)
-        .with_presence_penalty(cli.presence_penalty)
-        .with_frequency_penalty(cli.frequency_penalty)
-        .with_reverse_prompt(cli.reverse_prompt)
-        .with_mmproj(cli.llava_mmproj.clone())
-        .enable_prompts_log(cli.log_prompts || cli.log_all)
-        .enable_plugin_log(cli.log_stat || cli.log_all)
-        .enable_debug_log(plugin_debug)
-        .build();
+            // create a Metadata instance
+            let metadata = MetadataBuilder::new(
+                chat_args.model_name,
+                chat_args.model_alias,
+                chat_args.prompt_template,
+            )
+            .with_ctx_size(chat_args.ctx_size)
+            .with_batch_size(chat_args.batch_size)
+            .with_n_predict(chat_args.n_predict)
+            .with_n_gpu_layers(chat_args.n_gpu_layers)
+            .with_temperature(chat_args.temp)
+            .with_top_p(chat_args.top_p)
+            .with_repeat_penalty(chat_args.repeat_penalty)
+            .with_presence_penalty(chat_args.presence_penalty)
+            .with_frequency_penalty(chat_args.frequency_penalty)
+            .with_reverse_prompt(chat_args.reverse_prompt)
+            .with_mmproj(chat_args.llava_mmproj.clone())
+            .enable_prompts_log(chat_args.log_prompts || chat_args.log_all)
+            .enable_plugin_log(chat_args.log_stat || chat_args.log_all || plugin_debug)
+            .enable_debug_log(plugin_debug)
+            .build();
 
-    // initialize the core context
-    llama_core::init_core_context(&[metadata])
-        .map_err(|e| ServerError::Operation(format!("{}", e)))?;
+            // initialize the core context
+            llama_core::init_core_context(Some(&[metadata]), None)
+                .map_err(|e| ServerError::Operation(format!("{}", e)))?;
+
+            chat_args.web_ui.to_string_lossy().to_string()
+        }
+        Commands::Embedding(embedding_args) => {
+            // log
+            {
+                // log the cli options
+                log(format!("[INFO] Model name: {}", &embedding_args.model_name));
+                log(format!(
+                    "[INFO] Model alias: {}",
+                    &embedding_args.model_alias
+                ));
+                log(format!("[INFO] Context size: {}", &embedding_args.ctx_size));
+                log(format!("[INFO] Batch size: {}", &embedding_args.batch_size));
+            }
+
+            // create metadata for embedding model
+            let metadata = MetadataBuilder::new(
+                embedding_args.model_name,
+                embedding_args.model_alias,
+                PromptTemplateType::Llama2Chat, // TODO: dummy value. Embedding model does not use prompt template
+            )
+            .with_ctx_size(embedding_args.ctx_size)
+            .with_batch_size(embedding_args.batch_size)
+            .enable_plugin_log(embedding_args.log_stat || embedding_args.log_all || plugin_debug)
+            .enable_debug_log(plugin_debug)
+            .build();
+
+            // initialize the core context
+            llama_core::init_core_context(None, Some(&[metadata]))
+                .map_err(|e| ServerError::Operation(format!("{}", e)))?;
+
+            String::new()
+        }
+        Commands::Max(full_args) => {
+            // log
+            {
+                // log the cli options
+                log(format!(
+                    "[INFO] Name of chat model: {}",
+                    &full_args.model_name
+                ));
+                log(format!(
+                    "[INFO] Name of embedding model: {}",
+                    &full_args.embedding_model_name
+                ));
+                log(format!(
+                    "[INFO] Alias for chat model: {}",
+                    &full_args.model_alias
+                ));
+                log(format!(
+                    "[INFO] Alias for embedding model: {}",
+                    &full_args.embedding_model_alias
+                ));
+                log(format!(
+                    "[INFO] Context size of chat model: {}",
+                    &full_args.ctx_size
+                ));
+                log(format!(
+                    "[INFO] Context size of embedding model: {}",
+                    &full_args.embedding_ctx_size
+                ));
+                log(format!(
+                    "[INFO] Batch size for chat model: {}",
+                    &full_args.batch_size
+                ));
+                log(format!(
+                    "[INFO] Batch size for embedding model: {}",
+                    &full_args.embedding_batch_size
+                ));
+                log(format!(
+                    "[INFO] Prompt template: {}",
+                    &full_args.prompt_template
+                ));
+                if let Some(reverse_prompt) = &full_args.reverse_prompt {
+                    log(format!("[INFO] reverse prompt: {}", reverse_prompt));
+                }
+                log(format!(
+                    "[INFO] Number of tokens to predict: {}",
+                    &full_args.n_predict
+                ));
+                log(format!(
+                    "[INFO] Number of layers to run on the GPU: {}",
+                    &full_args.n_gpu_layers
+                ));
+                log(format!(
+                    "[INFO] Temperature for sampling: {}",
+                    &full_args.temp
+                ));
+                log(format!(
+                    "[INFO] Top-p sampling (1.0 = disabled): {}",
+                    &full_args.top_p
+                ));
+                log(format!(
+                    "[INFO] Penalize repeat sequence of tokens: {}",
+                    &full_args.repeat_penalty
+                ));
+                log(format!(
+                    "[INFO] Presence penalty (0.0 = disabled): {}",
+                    &full_args.presence_penalty
+                ));
+                log(format!(
+                    "[INFO] Frequency penalty (0.0 = disabled): {}",
+                    &full_args.frequency_penalty
+                ));
+                if let Some(llava_mmproj) = &full_args.llava_mmproj {
+                    log(format!("[INFO] Multimodal projector: {}", llava_mmproj));
+                }
+                log(format!(
+                    "[INFO] Enable prompt log: {}",
+                    &full_args.log_prompts
+                ));
+                log(format!("[INFO] Enable plugin log: {}", &full_args.log_stat));
+            }
+
+            // create metadata for chat model
+            let metadata_chat = {
+                MetadataBuilder::new(
+                    full_args.model_name,
+                    full_args.model_alias,
+                    full_args.prompt_template,
+                )
+                .with_ctx_size(full_args.ctx_size)
+                .with_batch_size(full_args.batch_size)
+                .with_n_predict(full_args.n_predict)
+                .with_n_gpu_layers(full_args.n_gpu_layers)
+                .with_temperature(full_args.temp)
+                .with_top_p(full_args.top_p)
+                .with_repeat_penalty(full_args.repeat_penalty)
+                .with_presence_penalty(full_args.presence_penalty)
+                .with_frequency_penalty(full_args.frequency_penalty)
+                .with_reverse_prompt(full_args.reverse_prompt)
+                .with_mmproj(full_args.llava_mmproj.clone())
+                .enable_prompts_log(full_args.log_prompts || full_args.log_all)
+                .enable_plugin_log(full_args.log_stat || full_args.log_all || plugin_debug)
+                .enable_debug_log(plugin_debug)
+                .build()
+            };
+
+            // create metadata for embedding model
+            let metadata_embedding = {
+                MetadataBuilder::new(
+                    full_args.embedding_model_name,
+                    full_args.embedding_model_alias,
+                    PromptTemplateType::Llama2Chat, // TODO: dummy value. Embedding model does not use prompt template
+                )
+                .with_ctx_size(full_args.embedding_ctx_size)
+                .with_batch_size(full_args.embedding_batch_size)
+                .enable_plugin_log(full_args.log_stat || full_args.log_all || plugin_debug)
+                .enable_debug_log(plugin_debug)
+                .build()
+            };
+
+            // initialize the core context
+            llama_core::init_core_context(Some(&[metadata_chat]), Some(&[metadata_embedding]))
+                .map_err(|e| ServerError::Operation(format!("{}", e)))?;
+
+            full_args.web_ui.to_string_lossy().to_string()
+        }
+    };
+    let ref_web_ui = Arc::new(web_ui);
 
     // get the plugin version info
     let plugin_info =
@@ -176,9 +462,14 @@ async fn main() -> Result<(), ServerError> {
     ));
 
     let new_service = make_service_fn(move |_| {
-        let web_ui = cli.web_ui.to_string_lossy().to_string();
+        // let web_ui = cli.web_ui.to_string_lossy().to_string();
+        let web_ui = ref_web_ui.clone();
 
-        async move { Ok::<_, Error>(service_fn(move |req| handle_request(req, web_ui.clone()))) }
+        async move {
+            Ok::<_, Error>(service_fn(move |req| {
+                handle_request(req, (*web_ui).clone())
+            }))
+        }
     });
 
     // socket address

--- a/api-server/llama-core/Cargo.toml
+++ b/api-server/llama-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-core"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/chat/Cargo.toml
+++ b/chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-chat"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
 
 [dependencies]

--- a/chat/src/main.rs
+++ b/chat/src/main.rs
@@ -179,7 +179,7 @@ async fn main() -> anyhow::Result<()> {
     let metadata = builder.build();
 
     // initialize the core context
-    init_core_context(&[metadata])?;
+    init_core_context(Some(&[metadata]), None)?;
 
     // get the plugin version info
     let plugin_info = llama_core::get_plugin_info()?;

--- a/run-llm.sh
+++ b/run-llm.sh
@@ -306,7 +306,7 @@ if [ -n "$model" ]; then
 
     model_name=${wfile%-Q*}
 
-    cmd="wasmedge --dir .:. --nn-preload default:GGML:AUTO:$wfile llama-api-server.wasm --prompt-template ${prompt_type} --model-name ${model_name} --socket-addr 0.0.0.0:${port} --log-prompts --log-stat"
+    cmd="wasmedge --dir .:. --nn-preload default:GGML:AUTO:$wfile llama-api-server.wasm --socket-addr 0.0.0.0:${port} chat --prompt-template ${prompt_type} --model-name ${model_name} --log-prompts --log-stat"
 
     # Add reverse prompt if it exists
     if [ -n "$reverse_prompt" ]; then
@@ -380,7 +380,7 @@ elif [ "$interactive" -eq 0 ]; then
     printf "\n"
 
     # * start llama-api-server
-    cmd="wasmedge --dir .:. --nn-preload default:GGML:AUTO:gemma-2b-it-Q5_K_M.gguf llama-api-server.wasm -p gemma-instruct -c 4096 --model-name gemma-2b-it --socket-addr 0.0.0.0:${port} --log-prompts --log-stat"
+    cmd="wasmedge --dir .:. --nn-preload default:GGML:AUTO:gemma-2b-it-Q5_K_M.gguf llama-api-server.wasm --socket-addr 0.0.0.0:${port} chat --prompt-template gemma-instruct --ctx-size 4096 --model-name gemma-2b-it --log-prompts --log-stat"
 
     printf "[+] Will run the following command to start the server:\n\n"
     printf "    %s\n\n" "$cmd"
@@ -733,7 +733,7 @@ elif [ "$interactive" -eq 1 ]; then
 
         model_name=${wfile%-Q*}
 
-        cmd="wasmedge --dir .:. --nn-preload default:GGML:AUTO:$wfile llama-api-server.wasm --prompt-template ${prompt_type} --model-name ${model_name} --socket-addr 0.0.0.0:${port} --log-prompts --log-stat"
+        cmd="wasmedge --dir .:. --nn-preload default:GGML:AUTO:$wfile llama-api-server.wasm --socket-addr 0.0.0.0:${port} chat --prompt-template ${prompt_type} --model-name ${model_name} --log-prompts --log-stat"
 
         # Add reverse prompt if it exists
         if [ -n "$reverse_prompt" ]; then

--- a/simple/Cargo.toml
+++ b/simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-simple"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Major changes

- llama-api-server
  - Introduce `chat`, `embedding`, and `max` subcommands in CLI
    - The following endpoints are available with `chat` subcommand starting server
      - `/v1/models`
      - `/v1/chat/completions`
      - `/v1/completions`
    - The following endpoints are available with `embedding` subcommand starting server
      - `/v1/models`
      - `/v1/embeddings`
      - `/v1/files`
      - `/v1/chunks`
    - All endpoints mentioned above are available with `max` subcommand starting server
  - Add `/v1/info` endpoint

- llama-core
  - (BREAKING) Improve `init_core_context` API