### PR TITLE
Added prompt template intstructions

### DIFF
--- a/api-server/README.md
+++ b/api-server/README.md
@@ -101,7 +101,7 @@ The command above starts the API server on the default socket address. Besides, 
 - The `--dir .:.` option specifies the current directory as the root directory of the WASI file system.
 
 - The `--nn-preload default:GGML:AUTO:llama-2-7b-chat.Q5_K_M.gguf` option specifies the Llama model to be used by the API server. The pattern of the argument is `<name>:<encoding>:<target>:<model path>`. Here, the model used is `llama-2-7b-chat.Q5_K_M.gguf`; and we give it an alias `default` as its name in the runtime environment. You can change the model name here if you're not using llama2-7b-chat
-- The `--prompt-template llama-2-chat` is the prompt template for the model.
+- The `--prompt-template llama-2-chat` is the prompt template for the model.Here we are using llama-2 Chat template if you want to use any other model please select prompt template accordingly, See the [CLI options for the API server](#cli-options) under "-p" for currently supported prompt templates
 - The `--model-name llama-2-7b-chat` specifies the model name. It is used in the chat request.
 
 ## Endpoints
@@ -404,6 +404,8 @@ wasmedge --dir .:. --nn-preload default:GGML:AUTO:llama-2-7b-chat.Q5_K_M.gguf ll
 ```
 
 Then, you will be asked to open `http://127.0.0.1:8080` from your browser.
+
+<a id="cli-options"></a>
 
 ## CLI options for the API server
 


### PR DESCRIPTION
## Issue
Currently I was working on llama-3 based model and had to run it using llamaedge api server but current instructions are entirely based on llama-2 and I got really confused about prompt template and thought that i will have to write the template myself and add it to source code, on exploring I found out that llama edge already supports llama-3 prompt template (along with other models) while going through "[run-llm.sh](https://github.com/LlamaEdge/LlamaEdge/blob/main/run-llm.sh)" file, its just not depicted properly in [llamaedge api server readme](https://github.com/LlamaEdge/LlamaEdge/tree/main/api-server).

## Changes I made
I have added reference to [CLI options](https://github.com/LlamaEdge/LlamaEdge/tree/main/api-server#cli-options-for-the-api-server) in the [Running llamaedge api server](https://github.com/LlamaEdge/LlamaEdge/tree/main/api-server#run-llamaedge-api-server) instructions where various prompt template and other helpful functions are also defined