### PR TITLE
added ggml parameter `--no-mmap`

### DIFF
--- a/api-server/README.md
+++ b/api-server/README.md
@@ -433,6 +433,8 @@ Options:
           Number of tokens to predict [default: 1024]
   -g, --n-gpu-layers <N_GPU_LAYERS>
           Number of layers to run on the GPU [default: 100]
+      --no-mmap
+          Disable memory mapping for file access
       --temp <TEMP>
           Temperature for sampling [default: 1.0]
       --top-p <TOP_P>

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -440,7 +440,7 @@ Options:
   -g, --n-gpu-layers <N_GPU_LAYERS>
           Number of layers to run on the GPU [default: 100]
       --no-mmap
-          Disable memory mapping for file access
+          Disable memory mapping for file access of chat models
       --temp <TEMP>
           Temperature for sampling [default: 1.0]
       --top-p <TOP_P>

--- a/api-server/llama-api-server/src/main.rs
+++ b/api-server/llama-api-server/src/main.rs
@@ -68,7 +68,7 @@ struct Cli {
     /// Number of layers to run on the GPU
     #[arg(short = 'g', long, default_value = "100")]
     n_gpu_layers: u64,
-    /// Disable memory mapping for file access
+    /// Disable memory mapping for file access of chat models
     #[arg(long)]
     no_mmap: Option<bool>,
     /// Temperature for sampling
@@ -218,7 +218,7 @@ async fn main() -> Result<(), ServerError> {
     // log no_mmap
     if let Some(no_mmap) = &cli.no_mmap {
         info!(
-            "[INFO] Disable memory mapping for file access : {}",
+            "[INFO] Disable memory mapping for file access of chat models : {}",
             no_mmap.clone()
         );
     }

--- a/api-server/llama-api-server/src/main.rs
+++ b/api-server/llama-api-server/src/main.rs
@@ -70,7 +70,7 @@ struct Cli {
     n_gpu_layers: u64,
     /// Disable memory mapping for file access
     #[arg(long)]
-    no_mmap: bool,
+    no_mmap: Option<bool>,
     /// Temperature for sampling
     #[arg(long, default_value = "1.0")]
     temp: f64,
@@ -214,9 +214,14 @@ async fn main() -> Result<(), ServerError> {
 
     // log n_gpu_layers
     info!(target: "server_config", "n_gpu_layers: {}", cli.n_gpu_layers);
-  
+
     // log no_mmap
-    info!(target: "server_config", "no_mmap: {}", cli.no_mmap);
+    if let Some(no_mmap) = &cli.no_mmap {
+        info!(
+            "[INFO] Disable memory mapping for file access : {}",
+            no_mmap.clone()
+        );
+    }
 
     // log temperature
     info!(target: "server_config", "temp: {}", cli.temp);
@@ -302,7 +307,7 @@ async fn main() -> Result<(), ServerError> {
                     n_predict: Some(metadata_chat.n_predict),
                     reverse_prompt: metadata_chat.reverse_prompt.clone(),
                     n_gpu_layers: Some(metadata_chat.n_gpu_layers),
-                    use_mmap: Some(metadata_chat.use_mmap),
+                    use_mmap: metadata_chat.use_mmap,
                     temperature: Some(metadata_chat.temperature),
                     top_p: Some(metadata_chat.top_p),
                     repeat_penalty: Some(metadata_chat.repeat_penalty),
@@ -348,7 +353,7 @@ async fn main() -> Result<(), ServerError> {
             n_predict: Some(metadata_chat.n_predict),
             reverse_prompt: metadata_chat.reverse_prompt.clone(),
             n_gpu_layers: Some(metadata_chat.n_gpu_layers),
-            use_mmap: Some(metadata_chat.use_mmap),
+            use_mmap: metadata_chat.use_mmap,
             temperature: Some(metadata_chat.temperature),
             top_p: Some(metadata_chat.top_p),
             repeat_penalty: Some(metadata_chat.repeat_penalty),

--- a/api-server/llama-api-server/src/main.rs
+++ b/api-server/llama-api-server/src/main.rs
@@ -63,6 +63,9 @@ struct Cli {
     /// Number of layers to run on the GPU
     #[arg(short = 'g', long, default_value = "100")]
     n_gpu_layers: u64,
+    /// Disable memory mapping for file access
+    #[arg(long)]
+    no_mmap: bool,
     /// Temperature for sampling
     #[arg(long, default_value = "1.0")]
     temp: f64,
@@ -201,6 +204,10 @@ async fn main() -> Result<(), ServerError> {
         "[INFO] Number of layers to run on the GPU: {}",
         &cli.n_gpu_layers
     ));
+    log(format!(
+        "[INFO] Disable memory mapping for file access : {}",
+        &cli.no_mmap
+    ));
     log(format!("[INFO] Temperature for sampling: {}", &cli.temp));
     log(format!(
         "[INFO] Top-p sampling (1.0 = disabled): {}",
@@ -268,6 +275,7 @@ async fn main() -> Result<(), ServerError> {
                 .with_batch_size(cli.batch_size[0])
                 .with_n_predict(cli.n_predict)
                 .with_n_gpu_layers(cli.n_gpu_layers)
+                .disable_mmap(cli.no_mmap)
                 .with_temperature(cli.temp)
                 .with_top_p(cli.top_p)
                 .with_repeat_penalty(cli.repeat_penalty)
@@ -290,6 +298,7 @@ async fn main() -> Result<(), ServerError> {
                     n_predict: Some(metadata_chat.n_predict),
                     reverse_prompt: metadata_chat.reverse_prompt.clone(),
                     n_gpu_layers: Some(metadata_chat.n_gpu_layers),
+                    use_mmap: Some(metadata_chat.use_mmap),
                     temperature: Some(metadata_chat.temperature),
                     top_p: Some(metadata_chat.top_p),
                     repeat_penalty: Some(metadata_chat.repeat_penalty),
@@ -313,6 +322,7 @@ async fn main() -> Result<(), ServerError> {
         .with_batch_size(cli.batch_size[0])
         .with_n_predict(cli.n_predict)
         .with_n_gpu_layers(cli.n_gpu_layers)
+        .disable_mmap(cli.no_mmap)
         .with_temperature(cli.temp)
         .with_top_p(cli.top_p)
         .with_repeat_penalty(cli.repeat_penalty)
@@ -335,6 +345,7 @@ async fn main() -> Result<(), ServerError> {
             n_predict: Some(metadata_chat.n_predict),
             reverse_prompt: metadata_chat.reverse_prompt.clone(),
             n_gpu_layers: Some(metadata_chat.n_gpu_layers),
+            use_mmap: Some(metadata_chat.use_mmap),
             temperature: Some(metadata_chat.temperature),
             top_p: Some(metadata_chat.top_p),
             repeat_penalty: Some(metadata_chat.repeat_penalty),
@@ -494,6 +505,8 @@ pub(crate) struct ModelConfig {
     pub reverse_prompt: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub n_gpu_layers: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub use_mmap: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/api-server/llama-core/src/lib.rs
+++ b/api-server/llama-core/src/lib.rs
@@ -81,7 +81,7 @@ pub struct Metadata {
     // #[serde(rename = "tensor-split")]
     // pub tensor_split: String,
     #[serde(skip_serializing_if = "Option::is_none", rename = "use-mmap")]
-    use_mmap: Option<bool>,
+    pub use_mmap: Option<bool>,
     // * Context parameters (used by the llama context):
     #[serde(rename = "ctx-size")]
     pub ctx_size: u64,
@@ -115,7 +115,7 @@ impl Default for Metadata {
             mmproj: None,
             image: None,
             n_gpu_layers: 100,
-            use_mmap: True,
+            use_mmap: Some(true),
             ctx_size: 512,
             batch_size: 512,
             temperature: 1.0,
@@ -204,8 +204,8 @@ impl MetadataBuilder {
         self
     }
 
-    pub fn disable_mmap(mut self, disable: bool) -> Self {
-        self.metadata.use_mmap = !disable;
+    pub fn disable_mmap(mut self, disable: Option<bool>) -> Self {
+        self.metadata.use_mmap = disable.map(|v| !v);
         self
     }
 

--- a/api-server/llama-core/src/lib.rs
+++ b/api-server/llama-core/src/lib.rs
@@ -76,7 +76,8 @@ pub struct Metadata {
     // pub main_gpu: u64,
     // #[serde(rename = "tensor-split")]
     // pub tensor_split: String,
-
+    #[serde(skip_serializing_if = "Option::is_none", rename = "use-mmap")]
+    use_mmap: Option<bool>,
     // * Context parameters (used by the llama context):
     #[serde(rename = "ctx-size")]
     pub ctx_size: u64,
@@ -110,6 +111,7 @@ impl Default for Metadata {
             mmproj: None,
             image: None,
             n_gpu_layers: 100,
+            use_mmap: True,
             ctx_size: 512,
             batch_size: 512,
             temperature: 1.0,
@@ -195,6 +197,11 @@ impl MetadataBuilder {
 
     pub fn with_n_gpu_layers(mut self, n: u64) -> Self {
         self.metadata.n_gpu_layers = n;
+        self
+    }
+
+    pub fn disable_mmap(mut self, disable: bool) -> Self {
+        self.metadata.use_mmap = !disable;
         self
     }
 

--- a/chat/README.md
+++ b/chat/README.md
@@ -125,6 +125,8 @@ Options:
           Number of tokens to predict [default: 1024]
   -g, --n-gpu-layers <N_GPU_LAYERS>
           Number of layers to run on the GPU [default: 100]
+  --no-mmap
+          Disable memory mapping for file access
   -b, --batch-size <BATCH_SIZE>
           Batch size for prompt processing [default: 512]
       --temp <TEMP>

--- a/chat/README.md
+++ b/chat/README.md
@@ -126,7 +126,7 @@ Options:
   -g, --n-gpu-layers <N_GPU_LAYERS>
           Number of layers to run on the GPU [default: 100]
   --no-mmap
-          Disable memory mapping for file access
+          Disable memory mapping for file access of chat models
   -b, --batch-size <BATCH_SIZE>
           Batch size for prompt processing [default: 512]
       --temp <TEMP>

--- a/chat/src/main.rs
+++ b/chat/src/main.rs
@@ -28,7 +28,7 @@ struct Cli {
     /// Number of layers to run on the GPU
     #[arg(short = 'g', long, default_value = "100")]
     n_gpu_layers: u64,
-    /// Disable memory mapping for file access
+    /// Disable memory mapping for file access of chat models
     #[arg(long)]
     no_mmap: Option<bool>,
     /// Batch size for prompt processing
@@ -118,7 +118,7 @@ async fn main() -> anyhow::Result<()> {
     // no_mmap
     if let Some(no_mmap) = &cli.no_mmap {
         log(format!(
-            "[INFO] Disable memory mapping for file access : {}",
+            "[INFO] Disable memory mapping for file access of chat models : {}",
             &no_mmap
         ));
     }

--- a/chat/src/main.rs
+++ b/chat/src/main.rs
@@ -30,7 +30,7 @@ struct Cli {
     n_gpu_layers: u64,
     /// Disable memory mapping for file access
     #[arg(long)]
-    no_mmap: bool,
+    no_mmap: Option<bool>,
     /// Batch size for prompt processing
     #[arg(short, long, default_value = "512")]
     batch_size: u64,
@@ -116,10 +116,12 @@ async fn main() -> anyhow::Result<()> {
         &cli.n_gpu_layers
     ));
     // no_mmap
-    log(format!(
-        "[INFO] Disable memory mapping for file access : {}",
-        &cli.no_mmap
-    ));
+    if let Some(no_mmap) = &cli.no_mmap {
+        log(format!(
+            "[INFO] Disable memory mapping for file access : {}",
+            &no_mmap
+        ));
+    }
     // batch size
     log(format!(
         "[INFO] Batch size for prompt processing: {}",

--- a/chat/src/main.rs
+++ b/chat/src/main.rs
@@ -28,6 +28,9 @@ struct Cli {
     /// Number of layers to run on the GPU
     #[arg(short = 'g', long, default_value = "100")]
     n_gpu_layers: u64,
+    /// Disable memory mapping for file access
+    #[arg(long)]
+    no_mmap: bool,
     /// Batch size for prompt processing
     #[arg(short, long, default_value = "512")]
     batch_size: u64,
@@ -112,6 +115,11 @@ async fn main() -> anyhow::Result<()> {
         "[INFO] Number of layers to run on the GPU: {}",
         &cli.n_gpu_layers
     ));
+    // no_mmap
+    log(format!(
+        "[INFO] Disable memory mapping for file access : {}",
+        &cli.no_mmap
+    ));
     // batch size
     log(format!(
         "[INFO] Batch size for prompt processing: {}",
@@ -151,6 +159,7 @@ async fn main() -> anyhow::Result<()> {
         .with_ctx_size(cli.ctx_size)
         .with_n_predict(cli.n_predict)
         .with_n_gpu_layers(cli.n_gpu_layers)
+        .disable_mmap(cli.no_mmap)
         .with_batch_size(cli.batch_size)
         .with_repeat_penalty(cli.repeat_penalty)
         .with_presence_penalty(cli.presence_penalty)
@@ -382,6 +391,8 @@ pub struct Metadata {
     // pub main_gpu: u64,
     // #[serde(rename = "tensor-split")]
     // pub tensor_split: String,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "use-mmap")]
+    use_mmap: Option<bool>,
 
     // * Context parameters (used by the llama context):
     #[serde(rename = "ctx-size")]

--- a/simple/README.md
+++ b/simple/README.md
@@ -50,6 +50,8 @@ wasmedge --dir .:. --nn-preload default:GGML:AUTO:llama-2-7b-chat.Q5_K_M.gguf ll
             Number of tokens to predict [default: 1024]
     -g, --n-gpu-layers <N_GPU_LAYERS>
             Number of layers to run on the GPU [default: 100]
+        --no-mmap
+            Disable memory mapping for file access
     -b, --batch-size <BATCH_SIZE>
             Batch size for prompt processing [default: 4096]
     -r, --reverse-prompt <REVERSE_PROMPT>

--- a/simple/README.md
+++ b/simple/README.md
@@ -51,7 +51,7 @@ wasmedge --dir .:. --nn-preload default:GGML:AUTO:llama-2-7b-chat.Q5_K_M.gguf ll
     -g, --n-gpu-layers <N_GPU_LAYERS>
             Number of layers to run on the GPU [default: 100]
         --no-mmap
-            Disable memory mapping for file access
+            Disable memory mapping for file access of chat models
     -b, --batch-size <BATCH_SIZE>
             Batch size for prompt processing [default: 4096]
     -r, --reverse-prompt <REVERSE_PROMPT>

--- a/simple/src/main.rs
+++ b/simple/src/main.rs
@@ -118,7 +118,7 @@ fn main() -> Result<(), String> {
     // no_mmap
     let no_mmap = matches.get_flag("no_mmap");
     println!("[INFO] no mmap: {nommap}", nommap = !no_mmap);
-    options.use_mmap = !no_mmap;
+    options.use_mmap = Some(!no_mmap);
 
     // batch size
     let batch_size = matches.get_one::<u32>("batch_size").unwrap();

--- a/simple/src/main.rs
+++ b/simple/src/main.rs
@@ -55,7 +55,7 @@ fn main() -> Result<(), String> {
             Arg::new("no_mmap")
                 .long("no-mmap")
                 .value_name("NO_MMAP")
-                .help("Disable memory mapping for file access")
+                .help("Disable memory mapping for file access of chat models")
                 .action(ArgAction::SetFalse),
         )
         .arg(

--- a/simple/src/main.rs
+++ b/simple/src/main.rs
@@ -52,6 +52,13 @@ fn main() -> Result<(), String> {
                 .default_value("100"),
         )
         .arg(
+            Arg::new("no_mmap")
+                .long("no-mmap")
+                .value_name("NO_MMAP")
+                .help("Disable memory mapping for file access")
+                .action(ArgAction::SetFalse),
+        )
+        .arg(
             Arg::new("batch_size")
                 .short('b')
                 .long("batch-size")
@@ -107,6 +114,11 @@ fn main() -> Result<(), String> {
         n = n_gpu_layers
     );
     options.n_gpu_layers = *n_gpu_layers as u64;
+
+    // no_mmap
+    let no_mmap = matches.get_flag("no_mmap");
+    println!("[INFO] no mmap: {nommap}", nommap = !no_mmap);
+    options.use_mmap = !no_mmap;
 
     // batch size
     let batch_size = matches.get_one::<u32>("batch_size").unwrap();
@@ -183,6 +195,8 @@ struct Options {
     n_predict: u64,
     #[serde(rename = "n-gpu-layers")]
     n_gpu_layers: u64,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "use-mmap")]
+    use_mmap: Option<bool>,
     #[serde(rename = "batch-size")]
     batch_size: u64,
     #[serde(skip_serializing_if = "Option::is_none", rename = "reverse-prompt")]


### PR DESCRIPTION
This pull request is to support parameter `--no-mmap` from llama.cpp. It addresses part of  https://github.com/WasmEdge/WasmEdge/issues/3314 .
In [llama.cpp](https://github.com/ggerganov/llama.cpp/blob/0e8d8bfd6caf1d0a8cbdf9d3d5c06fbbb9dfced8/common/common.h#L167), `use-mmap` is set true by default, to enable memory mapping while reading weight file of model. It will be set false if flag `--no-mmap` is passed to the end program.
In this pull request, logic of parsing `--no-mmap` which controls `use_mmap` in model parameter has been added to examples and core. Corresponding logic for parsing `use_mmap` in metadata passed to WasmEdge had been added in https://github.com/WasmEdge/WasmEdge/pull/3436 .
