### PR TITLE
Hotfix: Update wasmedge installation in `run-llm.sh`

### DIFF
--- a/run-llm.sh
+++ b/run-llm.sh
@@ -61,7 +61,7 @@ function print_usage {
     printf "  --model:        model name\n"
     printf "  --interactive:  run in interactive mode\n"
     printf "  --port:         port number, default is 8080\n"
-    printf "  --ggml-version: ggml version, default is latest\n"
+    printf "  --ggml-version: ggml version (for example, b2963). If the option is not used, then install the latest version.\n"
     printf "Example:\n\n"
     printf '  bash <(curl -sSfL 'https://code.flows.network/webhook/iwYN1SdN3AmPgR5ao5Gt/run-llm.sh')"\n\n'
 }
@@ -265,7 +265,7 @@ if [ -n "$model" ]; then
     printf "[+] Install WasmEdge with wasi-nn_ggml plugin ...\n\n"
 
     if [ "$ggml_version" = "latest" ]; then
-        if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v 0.13.5 --rustls; then
+        if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v 0.13.5; then
             source $HOME/.wasmedge/env
             wasmedge_path=$(which wasmedge)
             printf "\n    The WasmEdge Runtime is installed in %s.\n\n" "$wasmedge_path"
@@ -274,8 +274,7 @@ if [ -n "$model" ]; then
             exit 1
         fi
     else
-        ggml_plugin="wasi_nn-ggml-$ggml_version"
-        if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -v 0.13.5 --plugins $ggml_plugin wasmedge_rustls; then
+        if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v 0.13.5 --ggmlbn=$ggml_version; then
             source $HOME/.wasmedge/env
             wasmedge_path=$(which wasmedge)
             printf "\n    The WasmEdge Runtime is installed in %s.\n\n" "$wasmedge_path"
@@ -328,7 +327,7 @@ elif [ "$interactive" -eq 0 ]; then
     printf "[+] Installing WasmEdge with wasi-nn_ggml plugin ...\n\n"
 
     if [ "$ggml_version" = "latest" ]; then
-        if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v 0.13.5 --rustls; then
+        if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v 0.13.5; then
             source $HOME/.wasmedge/env
             wasmedge_path=$(which wasmedge)
             printf "\n    The WasmEdge Runtime is installed in %s.\n\n" "$wasmedge_path"
@@ -337,8 +336,7 @@ elif [ "$interactive" -eq 0 ]; then
             exit 1
         fi
     else
-        ggml_plugin="wasi_nn-ggml-$ggml_version"
-        if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -v 0.13.5 --plugins $ggml_plugin wasmedge_rustls; then
+        if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v 0.13.5 --ggmlbn=$ggml_version; then
             source $HOME/.wasmedge/env
             wasmedge_path=$(which wasmedge)
             printf "\n    The WasmEdge Runtime is installed in %s.\n\n" "$wasmedge_path"
@@ -435,7 +433,7 @@ elif [ "$interactive" -eq 1 ]; then
     if [[ "$reinstall_wasmedge" == "1" ]]; then
         # install WasmEdge + wasi-nn_ggml plugin
         if [ "$ggml_version" = "latest" ]; then
-            if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v 0.13.5 --rustls; then
+            if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v 0.13.5; then
                 source $HOME/.wasmedge/env
                 wasmedge_path=$(which wasmedge)
                 printf "\n    The WasmEdge Runtime is installed in %s.\n\n" "$wasmedge_path"
@@ -444,8 +442,7 @@ elif [ "$interactive" -eq 1 ]; then
                 exit 1
             fi
         else
-            ggml_plugin="wasi_nn-ggml-$ggml_version"
-            if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -v 0.13.5 --plugins $ggml_plugin wasmedge_rustls; then
+            if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v 0.13.5 --ggmlbn=$ggml_version; then
                 source $HOME/.wasmedge/env
                 wasmedge_path=$(which wasmedge)
                 printf "\n    The WasmEdge Runtime is installed in %s.\n\n" "$wasmedge_path"


### PR DESCRIPTION
Major changes:

- Update the command for WasmEdge installation to use the latest version of [install_v2.sh](https://github.com/WasmEdge/WasmEdge/blob/master/utils/install_v2.sh)