### PR TITLE
fix(core): allow the `cached_encodings` length to be 4

### DIFF
--- a/api-server/llama-core/src/chat.rs
+++ b/api-server/llama-core/src/chat.rs
@@ -1450,8 +1450,8 @@ fn compute_stream(
                                         }
                                         Err(_) => {
                                             // TODO This is a temp check. In case, infinite cached encodings happen.
-                                            if cached_encodings.len() > 3 {
-                                                let err_msg = "The length of the invalid utf8 bytes exceed 3.";
+                                            if cached_encodings.len() > 4 {
+                                                let err_msg = "The length of the invalid utf8 bytes exceed 4.";
 
                                                 #[cfg(feature = "logging")]
                                                 error!(target: "llama_core", "{}", &err_msg);
@@ -1975,8 +1975,8 @@ fn compute_stream(
                                         }
                                         Err(_) => {
                                             // TODO This is a temp check. In case, infinite cached encodings happen.
-                                            if cached_encodings.len() > 3 {
-                                                let err_msg = "The length of the invalid utf8 bytes exceed 3.";
+                                            if cached_encodings.len() > 4 {
+                                                let err_msg = "The length of the invalid utf8 bytes exceed 4.";
 
                                                 #[cfg(feature = "logging")]
                                                 error!(target: "llama_core", "{}", &err_msg);


### PR DESCRIPTION
UTF-8's longest byte is 4; in some outputs, if there are emojis, the server will return empty, but in fact, it should be allowed to pass.
