### PR TITLE
Release 0.12.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,13 +42,13 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly
-          target: wasm32-wasi
+          target: wasm32-wasi, wasm32-wasip1
           components: rustfmt, clippy
 
       - name: Install Rust-stable
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          target: wasm32-wasi
+          target: wasm32-wasi, wasm32-wasip1
 
       - name: Build simple
         id: build_simple

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,42 +42,42 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly
-          target: wasm32-wasi, wasm32-wasip1
+          target: wasm32-wasip1
           components: rustfmt, clippy
 
       - name: Install Rust-stable
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          target: wasm32-wasi, wasm32-wasip1
+          target: wasm32-wasip1
 
       - name: Build simple
         id: build_simple
         run: |
           cd simple
           cargo +nightly fmt --all -- --check
-          cargo +nightly clippy --target wasm32-wasi -- -D warnings
-          cargo build --target wasm32-wasi --release
+          cargo +nightly clippy --target wasm32-wasip1 -- -D warnings
+          cargo build --target wasm32-wasip1 --release
 
       - name: Build chat
         id: build_chat
         run: |
           cd chat
           cargo +nightly fmt --all -- --check
-          cargo +nightly clippy --target wasm32-wasi -- -D warnings
-          cargo build --target wasm32-wasi --release
+          cargo +nightly clippy --target wasm32-wasip1 -- -D warnings
+          cargo build --target wasm32-wasip1 --release
 
       - name: Build api-server
         id: build_api_server
         run: |
           cd api-server
           cargo +nightly fmt --all -- --check
-          cargo +nightly clippy --target wasm32-wasi -- -D warnings
-          cargo build --target wasm32-wasi --release
+          cargo +nightly clippy --target wasm32-wasip1 -- -D warnings
+          cargo build --target wasm32-wasip1 --release
 
       - name: Build api-server-full
         id: build_api_server_full
         run: |
           cd api-server
           cargo +nightly fmt --all -- --check
-          cargo +nightly clippy --target wasm32-wasi --features full -- -D warnings
-          cargo build --target wasm32-wasi --release --features full
+          cargo +nightly clippy --target wasm32-wasip1 --features full -- -D warnings
+          cargo build --target wasm32-wasip1 --release --features full

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,37 +24,37 @@ jobs:
         id: rustup
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          target: wasm32-wasi
+          target: wasm32-wasip1
 
       - name: Build simple
         id: build_simple
         run: |
           cd simple
-          cargo build --target wasm32-wasi --release
-          cp ./target/wasm32-wasi/release/llama-simple.wasm ../llama-simple.wasm
+          cargo build --target wasm32-wasip1 --release
+          cp ./target/wasm32-wasip1/release/llama-simple.wasm ../llama-simple.wasm
 
       - name: Build chat
         id: build_chat
         run: |
           cd chat
-          cargo build --target wasm32-wasi --release
-          cp ./target/wasm32-wasi/release/llama-chat.wasm ../llama-chat.wasm
+          cargo build --target wasm32-wasip1 --release
+          cp ./target/wasm32-wasip1/release/llama-chat.wasm ../llama-chat.wasm
 
       - name: Build api-server
         id: build_api_server
         run: |
           cd api-server
           cargo clean
-          cargo build --target wasm32-wasi --release
-          cp ./target/wasm32-wasi/release/llama-api-server.wasm ../llama-api-server.wasm
+          cargo build --target wasm32-wasip1 --release
+          cp ./target/wasm32-wasip1/release/llama-api-server.wasm ../llama-api-server.wasm
 
       - name: Build api-server-full
         id: build_api_server_full
         run: |
           cd api-server
           cargo clean
-          cargo build --target wasm32-wasi --release --features full
-          cp ./target/wasm32-wasi/release/llama-api-server.wasm ../llama-api-server-full.wasm
+          cargo build --target wasm32-wasip1 --release --features full
+          cp ./target/wasm32-wasip1/release/llama-api-server.wasm ../llama-api-server-full.wasm
 
       - name: Calculate checksum
         id: checksum

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2"
 
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 endpoints = { path = "endpoints", version = "^0.8" }
 chat-prompts = { path = "chat-prompts", version = "^0.8" }
 thiserror = "1"

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-endpoints = { path = "endpoints", version = "^0.8" }
+endpoints = { path = "endpoints", version = "^0.9" }
 chat-prompts = { path = "chat-prompts", version = "^0.8" }
 thiserror = "1"
 uuid = { version = "1.4", features = ["v4", "fast-rng", "macro-diagnostics"] }

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -441,6 +441,8 @@ Options:
           Number of tokens to predict [default: 1024]
   -g, --n-gpu-layers <N_GPU_LAYERS>
           Number of layers to run on the GPU [default: 100]
+      --no-mmap
+          Disable memory mapping for file access of chat models
       --temp <TEMP>
           Temperature for sampling [default: 1.0]
       --top-p <TOP_P>

--- a/api-server/endpoints/Cargo.toml
+++ b/api-server/endpoints/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endpoints"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/api-server/endpoints/Cargo.toml
+++ b/api-server/endpoints/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endpoints"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/api-server/endpoints/Cargo.toml
+++ b/api-server/endpoints/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endpoints"
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/api-server/endpoints/src/audio.rs
+++ b/api-server/endpoints/src/audio.rs
@@ -1,0 +1,139 @@
+//! Types for turning audio into text.
+
+use crate::files::FileObject;
+use serde::{Deserialize, Serialize};
+
+/// Transcribes audio into the input language.
+#[derive(Debug, Deserialize, Serialize, Default)]
+pub struct TranscriptionRequest {
+    /// The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+    pub file: FileObject,
+    /// ID of the model to use.
+    pub model: String,
+    /// The language of the input audio. Supplying the input language in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format will improve accuracy and latency.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+    /// An optional text to guide the model's style or continue a previous audio segment. The prompt should match the audio language.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
+    /// The format of the transcript output, in one of these options: `json`, `text`, `srt`, `verbose_json`, or `vtt`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_format: Option<String>,
+    /// The sampling temperature, between 0 and 1. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. If set to 0, the model will use [log probability](https://en.wikipedia.org/wiki/Log_probability) to automatically increase the temperature until certain thresholds are hit.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f64>,
+    /// The timestamp granularities to populate for this transcription.
+    /// `response_format` must be set `verbose_json` to use timestamp granularities. Either or both of these options are supported: `word`, or `segment`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp_granularities: Option<Vec<TimestampGranularity>>,
+}
+
+/// The timestamp granularities to populate for the transcription.
+#[derive(Debug, Deserialize, Serialize)]
+pub enum TimestampGranularity {
+    /// The model will return timestamps for each word.
+    Word,
+    /// The model will return timestamps for each segment.
+    Segment,
+}
+
+/// Represents a transcription response returned by model, based on the provided input.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TranscriptionObject {
+    /// The transcribed text.
+    pub text: String,
+}
+
+#[test]
+fn test_serialize_transcription_request() {
+    let obj = TranscriptionObject {
+        text: String::from("Imagine the wildest idea that you've ever had, and you're curious about how it might scale to something that's a 100, a 1,000 times bigger. This is a place where you can get to do that."),
+    };
+
+    let json = serde_json::to_string(&obj).unwrap();
+    assert_eq!(
+        json,
+        r#"{"text":"Imagine the wildest idea that you've ever had, and you're curious about how it might scale to something that's a 100, a 1,000 times bigger. This is a place where you can get to do that."}"#
+    );
+}
+
+/// Represents a verbose json transcription response returned by model, based on the provided input.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct VerboseTranscriptionObject {
+    /// The language of the input audio.
+    pub language: String,
+    /// The duration of the input audio.
+    pub duration: String,
+    /// The transcribed text.
+    pub text: String,
+    /// Extracted words and their corresponding timestamps.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub words: Option<Vec<Word>>,
+    /// Segments of the transcribed text and their corresponding details.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub segments: Option<Vec<Segment>>,
+}
+
+#[test]
+fn test_serialize_verbose_transcription_request() {
+    let obj = VerboseTranscriptionObject {
+        language: String::from("english"),
+        duration: String::from("8.470000267028809"),
+        text: String::from("The beach was a popular spot on a hot summer day. People were swimming in the ocean, building sandcastles, and playing beach volleyball."),
+        words: None,
+        segments: Some(vec![
+            Segment {
+                id: 0,
+                seek: 0,
+                start: 0.0,
+                end: 3.319999933242798,
+                text: String::from("The beach was a popular spot on a hot summer day."),
+                tokens: vec![50364, 440, 7534, 390, 257, 3743, 4008, 322, 257, 2368, 4266, 786, 13, 50530],
+                temperature: 0.0,
+                avg_logprob: -0.2860786020755768,
+                compression_ratio: 1.2363636493682861,
+                no_speech_prob: 0.00985979475080967,
+            }
+        ]),
+    };
+
+    let json = serde_json::to_string(&obj).unwrap();
+    assert_eq!(
+        json,
+        r#"{"language":"english","duration":"8.470000267028809","text":"The beach was a popular spot on a hot summer day. People were swimming in the ocean, building sandcastles, and playing beach volleyball.","segments":[{"id":0,"seek":0,"start":0.0,"end":3.319999933242798,"text":"The beach was a popular spot on a hot summer day.","tokens":[50364,440,7534,390,257,3743,4008,322,257,2368,4266,786,13,50530],"temperature":0.0,"avg_logprob":-0.2860786020755768,"compression_ratio":1.2363636493682861,"no_speech_prob":0.00985979475080967}]}"#
+    );
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Word {
+    /// The text content of the word.
+    pub text: String,
+    /// Start time of the word in seconds.
+    pub start: f64,
+    /// End time of the word in seconds.
+    pub end: f64,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Segment {
+    /// Unique identifier of the segment.
+    pub id: u64,
+    /// Seek offset of the segment.
+    pub seek: u64,
+    /// Start time of the segment in seconds.
+    pub start: f64,
+    /// End time of the segment in seconds.
+    pub end: f64,
+    /// Text content of the segment.
+    pub text: String,
+    /// Array of token IDs for the text content.
+    pub tokens: Vec<u64>,
+    /// Temperature parameter used for generating the segment.
+    pub temperature: f64,
+    /// Average logprob of the segment. If the value is lower than -1, consider the logprobs failed.
+    pub avg_logprob: f64,
+    /// Compression ratio of the segment. If the value is greater than 2.4, consider the compression failed.
+    pub compression_ratio: f64,
+    /// Probability of no speech in the segment. If the value is higher than 1.0 and the `avg_logprob` is below -1, consider this segment silent.
+    pub no_speech_prob: f64,
+}

--- a/api-server/endpoints/src/audio/mod.rs
+++ b/api-server/endpoints/src/audio/mod.rs
@@ -1,0 +1,5 @@
+//! Define types for turning audio into text or text into audio.
+
+pub mod speech;
+pub mod transcription;
+pub mod translation;

--- a/api-server/endpoints/src/audio/speech.rs
+++ b/api-server/endpoints/src/audio/speech.rs
@@ -1,0 +1,20 @@
+//! Define types for audio generation from the input text.
+
+use serde::{Deserialize, Serialize};
+
+/// Represents a request for generating audio from text.
+#[derive(Debug, Deserialize, Serialize, Default)]
+pub struct SpeechRequest {
+    /// Model name.
+    pub model: String,
+    /// The text to generate audio for.
+    pub input: String,
+    /// The voice to use when generating the audio. Supported voices are `alloy`, `echo`, `fable`, `onyx`, `nova`, and `shimmer`.
+    pub voice: String,
+    /// The format to audio in. Supported formats are `mp3`, `opus`, `aac`, `flac`, `wav`, and `pcm`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_format: Option<String>,
+    /// The speed of the generated audio. Select a value from `0.25` to `4.0`. `1.0` is the default.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub speed: Option<f64>,
+}

--- a/api-server/endpoints/src/audio/transcription.rs
+++ b/api-server/endpoints/src/audio/transcription.rs
@@ -1,9 +1,9 @@
-//! Types for turning audio into text.
+//! Define types for audio transcription.
 
 use crate::files::FileObject;
 use serde::{Deserialize, Serialize};
 
-/// Transcribes audio into the input language.
+/// Represents a rquest for audio transcription into the input language.
 #[derive(Debug, Deserialize, Serialize, Default)]
 pub struct TranscriptionRequest {
     /// The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
@@ -104,6 +104,7 @@ fn test_serialize_verbose_transcription_request() {
     );
 }
 
+/// Represents a word and its corresponding timestamps.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Word {
     /// The text content of the word.
@@ -114,6 +115,7 @@ pub struct Word {
     pub end: f64,
 }
 
+/// Represents a segment of the transcribed text and its corresponding details.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Segment {
     /// Unique identifier of the segment.

--- a/api-server/endpoints/src/audio/translation.rs
+++ b/api-server/endpoints/src/audio/translation.rs
@@ -1,0 +1,29 @@
+//! Define types for translating audio into English.
+
+use crate::files::FileObject;
+use serde::{Deserialize, Serialize};
+
+/// Represents a rquest for translating audio into English.
+#[derive(Debug, Deserialize, Serialize, Default)]
+pub struct TranslationRequest {
+    /// The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+    pub file: FileObject,
+    /// ID of the model to use.
+    pub model: String,
+    /// An optional text to guide the model's style or continue a previous audio segment. The prompt should be in English.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
+    /// The format of the transcript output, in one of these options: `json`, `text`, `srt`, `verbose_json`, or `vtt`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_format: Option<String>,
+    /// The sampling temperature, between 0 and 1. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. If set to 0, the model will use [log probability](https://en.wikipedia.org/wiki/Log_probability) to automatically increase the temperature until certain thresholds are hit.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f64>,
+}
+
+/// Represents a translation object.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TranslationObject {
+    /// The translated text.
+    pub text: String,
+}

--- a/api-server/endpoints/src/lib.rs
+++ b/api-server/endpoints/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod audio;
 pub mod chat;
 pub mod common;
 pub mod completions;

--- a/api-server/endpoints/src/rag.rs
+++ b/api-server/endpoints/src/rag.rs
@@ -351,7 +351,7 @@ pub struct ChunksResponse {
     pub chunks: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct RetrieveObject {
     /// The retrieved sources.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/api-server/llama-api-server/Cargo.toml
+++ b/api-server/llama-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-api-server"
-version = "0.11.3"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/api-server/llama-api-server/Cargo.toml
+++ b/api-server/llama-api-server/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 llama-core = { path = "../llama-core", features = ["logging"] }
 futures = { version = "0.3.6", default-features = false, features = ["async-await", "std"] }
 serde.workspace = true
-serde_json = "1.0"
+serde_json.workspace = true
 endpoints.workspace = true
 chat-prompts.workspace = true
 serde_yaml = "0.9"

--- a/api-server/llama-api-server/src/main.rs
+++ b/api-server/llama-api-server/src/main.rs
@@ -545,7 +545,9 @@ pub struct AppState {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct ServerInfo {
+    #[serde(rename = "api_server_version")]
     version: String,
+    #[serde(rename = "ggml_plugin_version")]
     plugin_version: String,
     port: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/api-server/llama-api-server/src/main.rs
+++ b/api-server/llama-api-server/src/main.rs
@@ -68,6 +68,9 @@ struct Cli {
     /// Number of layers to run on the GPU
     #[arg(short = 'g', long, default_value = "100")]
     n_gpu_layers: u64,
+    /// Disable memory mapping for file access of chat models
+    #[arg(long)]
+    no_mmap: Option<bool>,
     /// Temperature for sampling
     #[arg(long, default_value = "1.0")]
     temp: f64,
@@ -212,6 +215,14 @@ async fn main() -> Result<(), ServerError> {
     // log n_gpu_layers
     info!(target: "server_config", "n_gpu_layers: {}", cli.n_gpu_layers);
 
+    // log no_mmap
+    if let Some(no_mmap) = &cli.no_mmap {
+        info!(
+            "[INFO] Disable memory mapping for file access of chat models : {}",
+            no_mmap.clone()
+        );
+    }
+
     // log temperature
     info!(target: "server_config", "temp: {}", cli.temp);
 
@@ -274,6 +285,7 @@ async fn main() -> Result<(), ServerError> {
                 .with_batch_size(cli.batch_size[0])
                 .with_n_predict(cli.n_predict)
                 .with_n_gpu_layers(cli.n_gpu_layers)
+                .disable_mmap(cli.no_mmap)
                 .with_temperature(cli.temp)
                 .with_top_p(cli.top_p)
                 .with_repeat_penalty(cli.repeat_penalty)
@@ -295,6 +307,7 @@ async fn main() -> Result<(), ServerError> {
                     n_predict: Some(metadata_chat.n_predict),
                     reverse_prompt: metadata_chat.reverse_prompt.clone(),
                     n_gpu_layers: Some(metadata_chat.n_gpu_layers),
+                    use_mmap: metadata_chat.use_mmap,
                     temperature: Some(metadata_chat.temperature),
                     top_p: Some(metadata_chat.top_p),
                     repeat_penalty: Some(metadata_chat.repeat_penalty),
@@ -318,6 +331,7 @@ async fn main() -> Result<(), ServerError> {
         .with_batch_size(cli.batch_size[0])
         .with_n_predict(cli.n_predict)
         .with_n_gpu_layers(cli.n_gpu_layers)
+        .disable_mmap(cli.no_mmap)
         .with_temperature(cli.temp)
         .with_top_p(cli.top_p)
         .with_repeat_penalty(cli.repeat_penalty)
@@ -339,6 +353,7 @@ async fn main() -> Result<(), ServerError> {
             n_predict: Some(metadata_chat.n_predict),
             reverse_prompt: metadata_chat.reverse_prompt.clone(),
             n_gpu_layers: Some(metadata_chat.n_gpu_layers),
+            use_mmap: metadata_chat.use_mmap,
             temperature: Some(metadata_chat.temperature),
             top_p: Some(metadata_chat.top_p),
             repeat_penalty: Some(metadata_chat.repeat_penalty),
@@ -556,6 +571,8 @@ pub(crate) struct ModelConfig {
     pub reverse_prompt: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub n_gpu_layers: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub use_mmap: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/api-server/llama-core/Cargo.toml
+++ b/api-server/llama-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-core"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/api-server/llama-core/Cargo.toml
+++ b/api-server/llama-core/Cargo.toml
@@ -12,7 +12,7 @@ description = "The core component of LlamaEdge"
 [dependencies]
 endpoints.workspace = true
 chat-prompts.workspace = true
-wasmedge-wasi-nn = { git = "https://github.com/second-state/wasmedge-wasi-nn.git", branch = "burn" }
+wasmedge-wasi-nn = "0.7.1"
 thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/api-server/llama-core/Cargo.toml
+++ b/api-server/llama-core/Cargo.toml
@@ -12,7 +12,7 @@ description = "The core component of LlamaEdge"
 [dependencies]
 endpoints.workspace = true
 chat-prompts.workspace = true
-wasmedge-wasi-nn = "0.7.0"
+wasmedge-wasi-nn = { git = "https://github.com/second-state/wasmedge-wasi-nn.git", branch = "burn" }
 thiserror.workspace = true
 serde.workspace = true
 serde_json = "1.0"

--- a/api-server/llama-core/Cargo.toml
+++ b/api-server/llama-core/Cargo.toml
@@ -15,7 +15,7 @@ chat-prompts.workspace = true
 wasmedge-wasi-nn = { git = "https://github.com/second-state/wasmedge-wasi-nn.git", branch = "burn" }
 thiserror.workspace = true
 serde.workspace = true
-serde_json = "1.0"
+serde_json.workspace = true
 uuid.workspace = true
 once_cell = "1.18"
 futures = { version = "0.3.6", default-features = false, features = ["async-await", "std"] }

--- a/api-server/llama-core/src/chat.rs
+++ b/api-server/llama-core/src/chat.rs
@@ -25,6 +25,8 @@ use endpoints::{
     common::{FinishReason, Usage},
 };
 use error::{BackendError, LlamaCoreError};
+#[cfg(feature = "https")]
+use futures::StreamExt;
 use std::{
     pin::Pin,
     sync::Mutex,
@@ -859,7 +861,7 @@ async fn download_image(image_url: impl AsRef<str>) -> Result<String, LlamaCoreE
     })?;
 
     let mut content = response.bytes_stream();
-    while let Some(item) = content.try_next().await.unwrap() {
+    while let Ok(item) = content.next().await.unwrap() {
         std::io::copy(&mut item.as_ref(), &mut dest).map_err(|e| {
             let err_msg = format!(
                 "Fail to write the image content to the file: {}. Reason: {}",

--- a/api-server/llama-core/src/chat.rs
+++ b/api-server/llama-core/src/chat.rs
@@ -1411,7 +1411,6 @@ fn compute_stream(
 
             match chat_graphs.get_mut(model_name) {
                 Some(graph) => {
-                    info!(target: "llama_core", "Compute the chat completion by the model named {}.", graph.name());
                     // compute
                     match graph.compute_single() {
                         Ok(_) => {

--- a/api-server/llama-core/src/chat.rs
+++ b/api-server/llama-core/src/chat.rs
@@ -1450,8 +1450,8 @@ fn compute_stream(
                                         }
                                         Err(_) => {
                                             // TODO This is a temp check. In case, infinite cached encodings happen.
-                                            if cached_encodings.len() > 3 {
-                                                let err_msg = "The length of the invalid utf8 bytes exceed 3.";
+                                            if cached_encodings.len() > 4 {
+                                                let err_msg = "The length of the invalid utf8 bytes exceed 4.";
 
                                                 #[cfg(feature = "logging")]
                                                 error!(target: "llama_core", "{}", &err_msg);
@@ -1975,8 +1975,8 @@ fn compute_stream(
                                         }
                                         Err(_) => {
                                             // TODO This is a temp check. In case, infinite cached encodings happen.
-                                            if cached_encodings.len() > 3 {
-                                                let err_msg = "The length of the invalid utf8 bytes exceed 3.";
+                                            if cached_encodings.len() > 4 {
+                                                let err_msg = "The length of the invalid utf8 bytes exceed 4.";
 
                                                 #[cfg(feature = "logging")]
                                                 error!(target: "llama_core", "{}", &err_msg);

--- a/api-server/llama-core/src/chat.rs
+++ b/api-server/llama-core/src/chat.rs
@@ -25,12 +25,10 @@ use endpoints::{
     common::{FinishReason, Usage},
 };
 use error::{BackendError, LlamaCoreError};
-use futures::{
-    future,
-    stream::{self, TryStreamExt},
-};
 use std::{
-    sync::{Arc, Mutex},
+    pin::Pin,
+    sync::Mutex,
+    task::{Context, Poll},
     time::SystemTime,
 };
 
@@ -63,8 +61,6 @@ pub async fn chat_completions_stream(
     #[cfg(feature = "logging")]
     info!(target: "llama_core", "user: {}", &id);
 
-    let ref_id = Arc::new(id.clone());
-
     // parse the `include_usage` option
     let include_usage = match chat_request.stream_options {
         Some(ref stream_options) => stream_options.include_usage.unwrap_or_default(),
@@ -89,1070 +85,8 @@ pub async fn chat_completions_stream(
     // set prompt
     set_prompt(chat_request.model.as_ref(), &prompt)?;
 
-    // init state machine
-    let mut stream_state = match include_usage {
-        true => StreamState::Usage,
-        false => StreamState::Done,
-    };
-    let mut context_full_state = ContextFullState::Message;
-    let mut prompt_too_long_state = PromptTooLongState::Message;
-
-    let stream = stream::repeat_with(move || {
-        let id_cloned = ref_id.clone();
-        let id = (*id_cloned).clone();
-
-        // get graph
-        match &model_name {
-            Some(model_name) => {
-                let chat_graphs = match CHAT_GRAPHS
-                            .get() {
-                            Some(chat_graphs) => chat_graphs,
-                            None => {
-                                let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
-
-                                #[cfg(feature = "logging")]
-                                error!(target: "llama_core", "{}", &err_msg);
-
-                                return Err(LlamaCoreError::Operation(err_msg.into()));
-                            }
-                        };
-
-                let mut chat_graphs = chat_graphs.lock().map_err(|e| {
-                    let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
-
-                    #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
-
-                    LlamaCoreError::Operation(err_msg)
-                })?;
-
-                match chat_graphs.get_mut(model_name) {
-                    Some(graph) => {
-                        // compute
-                        match graph.compute_single() {
-                            Ok(_) => {
-                                // Retrieve the output
-                                let output_buffer = get_output_buffer_single(graph, OUTPUT_TENSOR)?;
-
-                                // decode the output buffer to a utf8 string
-                                let output = match String::from_utf8(output_buffer.clone())
-                                {
-                                    Ok(token) => token,
-                                    Err(_) => {
-                                        let mutex = CACHED_UTF8_ENCODINGS.get_or_init(|| Mutex::new(Vec::new()));
-                                        let mut cached_encodings = mutex.lock().map_err(|e| {
-                                            let err_msg = format!(
-                                                "Fail to acquire the lock of `UTF8_ENCODINGS`. Reason: {}",
-                                                e
-                                            );
-
-                                            #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
-
-
-                                            LlamaCoreError::Operation(err_msg)
-                                        })?;
-
-                                        // cache the bytes for future decoding
-                                        cached_encodings.extend_from_slice(&output_buffer[..]);
-
-                                        match String::from_utf8(cached_encodings.to_vec()) {
-                                            Ok(token) => {
-                                                // clear encodings
-                                                cached_encodings.clear();
-
-                                                token
-                                            }
-                                            Err(_) => {
-                                                // TODO This is a temp check. In case, infinite cached encodings happen.
-                                                if cached_encodings.len() > 3 {
-
-                                                    let err_msg = "The length of the invalid utf8 bytes exceed 3.";
-
-                                                    #[cfg(feature = "logging")]
-                                                    error!(target: "llama_core", "{}", &err_msg);
-
-                                                    return Err(LlamaCoreError::Operation(err_msg.into()));
-                                                }
-
-                                                String::new()
-                                            }
-                                        }
-                                    }
-                                };
-
-                                let created = SystemTime::now()
-                                    .duration_since(std::time::UNIX_EPOCH)
-                                    .map_err(|e| {
-                                        let err_msg = format!(
-                                            "Failed to get the current time. Reason: {}",
-                                            e
-                                        );
-
-                                        #[cfg(feature = "logging")]
-                                        error!(target: "llama_core", "{}", &err_msg);
-
-                                        LlamaCoreError::Operation(err_msg)
-                                    })?;
-
-                                let chat_completion_chunk = ChatCompletionChunk {
-                                    id,
-                                    object: "chat.completion.chunk".to_string(),
-                                    created: created.as_secs(),
-                                    model: graph.name().to_owned(),
-                                    system_fingerprint: "fp_44709d6fcb".to_string(),
-                                    choices: vec![ChatCompletionChunkChoice {
-                                        index: 0,
-                                        delta: ChatCompletionChunkChoiceDelta {
-                                            role: Some(ChatCompletionRole::Assistant),
-                                            content: Some(output),
-                                            function_call: None,
-                                            tool_calls: None,
-                                        },
-                                        logprobs: None,
-                                        finish_reason: None,
-                                    }],
-                                    usage: None,
-                                };
-
-                                // serialize chat completion chunk
-                                let chunk_str =
-                                serde_json::to_string(&chat_completion_chunk).map_err(|e| {
-                                    let err_msg = format!(
-                                        "Failed to serialize chat completion chunk. Reason: {}",
-                                        e
-                                    );
-
-                                    #[cfg(feature = "logging")]
-                                    error!(target: "llama_core", "{}", &err_msg);
-
-                                    LlamaCoreError::Operation(err_msg)
-                                })?;
-
-                                Ok(format!("data: {}\n\n", chunk_str))
-                            }
-                            Err(wasmedge_wasi_nn::Error::BackendError(
-                                wasmedge_wasi_nn::BackendError::EndOfSequence,
-                            )) => {
-                                match stream_state {
-                                    StreamState::Usage => {
-                                        stream_state = StreamState::Done;
-
-                                        // retrieve the number of prompt and completion tokens
-                                        let token_info = get_token_info_by_graph(graph)?;
-
-                                        let usage = Some(Usage {
-                                            prompt_tokens: token_info.prompt_tokens,
-                                            completion_tokens: token_info.completion_tokens,
-                                            total_tokens: token_info.prompt_tokens + token_info.completion_tokens,
-                                        });
-
-                                        #[cfg(feature = "logging")]
-                                        info!(target: "llama_core", "token_info: {} prompt tokens, {} completion tokens", token_info.prompt_tokens, token_info.completion_tokens);
-
-                                        let created = SystemTime::now()
-                                        .duration_since(std::time::UNIX_EPOCH)
-                                        .map_err(|e| {
-                                            let err_msg = format!(
-                                                "Failed to get the current time. Reason: {}",
-                                                e
-                                            );
-
-                                            #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
-
-                                            LlamaCoreError::Operation(err_msg)
-                                        })?;
-
-                                        let chat_completion_chunk = ChatCompletionChunk {
-                                            id,
-                                            object: "chat.completion.chunk".to_string(),
-                                            created: created.as_secs(),
-                                            model: graph.name().to_owned(),
-                                            system_fingerprint: "fp_44709d6fcb".to_string(),
-                                            choices: vec![],
-                                            usage,
-                                        };
-
-                                        // serialize chat completion chunk
-                                        let chunk_str =
-                                        serde_json::to_string(&chat_completion_chunk).map_err(|e| {
-                                            let err_msg = format!(
-                                                "Failed to serialize chat completion chunk. Reason: {}",
-                                                e
-                                            );
-
-                                            #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
-
-                                            LlamaCoreError::Operation(err_msg)
-                                        })?;
-
-                                        Ok(format!("data: {}\n\n", chunk_str))
-                                    }
-                                    StreamState::Done => {
-                                        stream_state = StreamState::EndOfSequence;
-
-                                        Ok("data: [DONE]\n\n".to_string())
-                                    }
-                                    StreamState::EndOfSequence => {
-                                        // clear context
-                                        if let Err(e) = graph.finish_single() {
-                                            let err_msg = format!(
-                                                "Failed to clean up the context. Reason: {}",
-                                                e
-                                            );
-
-                                            #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
-
-                                            return Err(LlamaCoreError::Backend(BackendError::FinishSingle(
-                                                err_msg,
-                                            )));
-                                        }
-
-                                        Ok("[GGML] End of sequence".to_string())
-                                    }
-                                }
-                            }
-                            Err(wasmedge_wasi_nn::Error::BackendError(
-                                wasmedge_wasi_nn::BackendError::ContextFull,
-                            )) => {
-                                match context_full_state {
-                                    ContextFullState::Message => {
-                                        match include_usage {
-                                            true => context_full_state = ContextFullState::Usage,
-                                            false => context_full_state = ContextFullState::Done,
-                                        }
-
-                                        let created = SystemTime::now()
-                                            .duration_since(std::time::UNIX_EPOCH)
-                                            .map_err(|e| {
-                                                let err_msg = format!(
-                                                    "Failed to get the current time. Reason: {}",
-                                                    e
-                                                );
-
-                                                #[cfg(feature = "logging")]
-                                                error!(target: "llama_core", "{}", &err_msg);
-
-                                                LlamaCoreError::Operation(err_msg)
-                                            })?;
-
-                                        let chat_completion_chunk = ChatCompletionChunk {
-                                            id,
-                                            object: "chat.completion.chunk".to_string(),
-                                            created: created.as_secs(),
-                                            model: graph.name().to_owned(),
-                                            system_fingerprint: "fp_44709d6fcb".to_string(),
-                                            choices: vec![ChatCompletionChunkChoice {
-                                                index: 0,
-                                                delta: ChatCompletionChunkChoiceDelta {
-                                                    role: Some(ChatCompletionRole::Assistant),
-                                                    content: Some("<|WASMEDGE-GGML-CONTEXT-FULL|>".to_string()),
-                                                    function_call: None,
-                                                    tool_calls: None,
-                                                },
-                                                logprobs: None,
-                                                finish_reason: Some(FinishReason::length),
-                                            }],
-                                            usage: None,
-                                        };
-
-                                        // serialize chat completion chunk
-                                        let chunk_str =
-                                            serde_json::to_string(&chat_completion_chunk).map_err(|e| {
-                                                let err_msg = format!(
-                                                    "Failed to serialize chat completion chunk. Reason: {}",
-                                                    e
-                                                );
-
-                                                #[cfg(feature = "logging")]
-                                                error!(target: "llama_core", "{}", &err_msg);
-
-                                                LlamaCoreError::Operation(err_msg)
-                                            })?;
-
-                                        Ok(format!("data: {}\n\n", chunk_str))
-                                    }
-                                    ContextFullState::Usage => {
-                                        context_full_state = ContextFullState::Done;
-
-                                        // retrieve the number of prompt and completion tokens
-                                        let token_info = get_token_info_by_graph(graph)?;
-
-                                        let usage = Some(Usage {
-                                            prompt_tokens: token_info.prompt_tokens,
-                                            completion_tokens: token_info.completion_tokens,
-                                            total_tokens: token_info.prompt_tokens + token_info.completion_tokens,
-                                        });
-
-                                        let created = SystemTime::now()
-                                        .duration_since(std::time::UNIX_EPOCH)
-                                        .map_err(|e| {
-                                            let err_msg = format!(
-                                                "Failed to get the current time. Reason: {}",
-                                                e
-                                            );
-
-                                            #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
-
-                                            LlamaCoreError::Operation(err_msg)
-                                        })?;
-
-                                        let chat_completion_chunk = ChatCompletionChunk {
-                                            id,
-                                            object: "chat.completion.chunk".to_string(),
-                                            created: created.as_secs(),
-                                            model: graph.name().to_owned(),
-                                            system_fingerprint: "fp_44709d6fcb".to_string(),
-                                            choices: vec![],
-                                            usage,
-                                        };
-
-                                        // serialize chat completion chunk
-                                        let chunk_str =
-                                        serde_json::to_string(&chat_completion_chunk).map_err(|e| {
-                                            let err_msg = format!(
-                                                "Failed to serialize chat completion chunk. Reason: {}",
-                                                e
-                                            );
-
-                                            #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
-
-                                            LlamaCoreError::Operation(err_msg)
-                                        })?;
-
-                                        Ok(format!("data: {}\n\n", chunk_str))
-
-                                    }
-                                    ContextFullState::Done => {
-                                        context_full_state = ContextFullState::EndOfSequence;
-
-                                        Ok("data: [DONE]\n\n".to_string())
-                                    }
-                                    ContextFullState::EndOfSequence => {
-                                        // clear context
-                                        if let Err(e) = graph.finish_single() {
-                                            let err_msg = format!(
-                                                "Failed to clean up the context. Reason: {}",
-                                                e
-                                            );
-
-                                            #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
-
-                                            return Err(LlamaCoreError::Backend(BackendError::FinishSingle(
-                                                err_msg,
-                                            )));
-                                        }
-
-                                        Ok("[GGML] End of sequence".to_string())
-                                    }
-                                }
-                            }
-                            Err(wasmedge_wasi_nn::Error::BackendError(
-                                wasmedge_wasi_nn::BackendError::PromptTooLong,
-                            )) => {
-                                match prompt_too_long_state {
-                                    PromptTooLongState::Message => {
-                                        match include_usage {
-                                            true => prompt_too_long_state = PromptTooLongState::Usage,
-                                            false => prompt_too_long_state = PromptTooLongState::Done,
-                                        }
-
-                                        let created = SystemTime::now()
-                                            .duration_since(std::time::UNIX_EPOCH)
-                                            .map_err(|e| {
-                                                let err_msg = format!(
-                                                    "Failed to get the current time. Reason: {}",
-                                                    e
-                                                );
-
-                                                #[cfg(feature = "logging")]
-                                                error!(target: "llama_core", "{}", &err_msg);
-
-                                                LlamaCoreError::Operation(err_msg)
-                                            })?;
-
-                                        let chat_completion_chunk = ChatCompletionChunk {
-                                            id,
-                                            object: "chat.completion.chunk".to_string(),
-                                            created: created.as_secs(),
-                                            model: graph.name().to_owned(),
-                                            system_fingerprint: "fp_44709d6fcb".to_string(),
-                                            choices: vec![ChatCompletionChunkChoice {
-                                                index: 0,
-                                                delta: ChatCompletionChunkChoiceDelta {
-                                                    role: Some(ChatCompletionRole::Assistant),
-                                                    content: None,
-                                                    function_call: None,
-                                                    tool_calls: None,
-                                                },
-                                                logprobs: None,
-                                                finish_reason: Some(FinishReason::length),
-                                            }],
-                                            usage: None,
-                                        };
-
-                                        // serialize chat completion chunk
-                                        let chunk_str =
-                                        serde_json::to_string(&chat_completion_chunk).map_err(|e| {
-                                            let err_msg = format!(
-                                                "Failed to serialize chat completion chunk. Reason: {}",
-                                                e
-                                            );
-
-                                            #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
-
-                                            LlamaCoreError::Operation(err_msg)
-                                        })?;
-
-                                        Ok(format!("data: {}\n\n", chunk_str))
-                                    }
-                                    PromptTooLongState::Usage => {
-                                        prompt_too_long_state = PromptTooLongState::Done;
-
-                                        // retrieve the number of prompt and completion tokens
-                                        let token_info = get_token_info_by_graph(graph)?;
-
-                                        let usage = Some(Usage {
-                                            prompt_tokens: token_info.prompt_tokens,
-                                            completion_tokens: token_info.completion_tokens,
-                                            total_tokens: token_info.prompt_tokens + token_info.completion_tokens,
-                                        });
-
-                                        let created = SystemTime::now()
-                                        .duration_since(std::time::UNIX_EPOCH)
-                                        .map_err(|e| {
-                                            let err_msg = format!(
-                                                "Failed to get the current time. Reason: {}",
-                                                e
-                                            );
-
-                                            #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
-
-                                            LlamaCoreError::Operation(err_msg)
-                                        })?;
-
-                                        let chat_completion_chunk = ChatCompletionChunk {
-                                            id,
-                                            object: "chat.completion.chunk".to_string(),
-                                            created: created.as_secs(),
-                                            model: graph.name().to_owned(),
-                                            system_fingerprint: "fp_44709d6fcb".to_string(),
-                                            choices: vec![],
-                                            usage,
-                                        };
-
-                                        // serialize chat completion chunk
-                                        let chunk_str =
-                                        serde_json::to_string(&chat_completion_chunk).map_err(|e| {
-                                            let err_msg = format!(
-                                                "Failed to serialize chat completion chunk. Reason: {}",
-                                                e
-                                            );
-
-                                            #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
-
-                                            LlamaCoreError::Operation(err_msg)
-                                        })?;
-
-                                        Ok(format!("data: {}\n\n", chunk_str))
-                                    }
-                                    PromptTooLongState::Done => {
-                                        prompt_too_long_state = PromptTooLongState::EndOfSequence;
-
-                                        Ok("data: [DONE]\n\n".to_string())
-                                    }
-                                    PromptTooLongState::EndOfSequence => {
-                                        // clear context
-                                        if let Err(e) = graph.finish_single() {
-                                            let err_msg = format!(
-                                                "Failed to clean up the context. Reason: {}",
-                                                e
-                                            );
-
-                                            #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
-
-                                            return Err(LlamaCoreError::Backend(BackendError::FinishSingle(
-                                                err_msg,
-                                            )));
-                                        }
-
-                                        Ok("[GGML] End of sequence".to_string())
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                // clear context
-                                if let Err(e) = graph.finish_single() {
-                                    let err_msg = format!(
-                                        "Failed to clean up the context. Reason: {}",
-                                        e
-                                    );
-
-                                    #[cfg(feature = "logging")]
-                                    error!(target: "llama_core", "{}", &err_msg);
-
-                                    return Err(LlamaCoreError::Backend(BackendError::FinishSingle(
-                                        err_msg,
-                                    )));
-                                }
-
-                                let err_msg = format!("Failed to compute the chat completion. Reason: {}", e);
-
-                                #[cfg(feature = "logging")]
-                                error!(target: "llama_core", "{}", &err_msg);
-
-                                Err(LlamaCoreError::Backend(BackendError::ComputeSingle(
-                                    err_msg,
-                                )))
-                            }
-                        }
-                    }
-                    None => {
-                        let err_msg = format!(
-                            "The model `{}` does not exist in the chat graphs.",
-                            &model_name
-                        );
-
-                        #[cfg(feature = "logging")]
-                        error!(target: "llama_core", "{}", &err_msg);
-
-
-                        Err(LlamaCoreError::Operation(err_msg))
-                    }
-                }
-            }
-            None => {
-                let chat_graphs = match CHAT_GRAPHS.get() {
-                    Some(chat_graphs) => chat_graphs,
-                    None => {
-                        let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
-
-                        #[cfg(feature = "logging")]
-                        error!(target: "llama_core", "{}", &err_msg);
-
-                        return Err(LlamaCoreError::Operation(err_msg.into()));
-                    }
-                };
-
-                let mut chat_graphs = chat_graphs.lock().map_err(|e| {
-                    let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
-
-                    #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
-
-                    LlamaCoreError::Operation(err_msg)
-                })?;
-
-                match chat_graphs.iter_mut().next() {
-                    Some((_, graph)) => {
-                        // compute
-                        match graph.compute_single() {
-                            Ok(_) => {
-                                // Retrieve the output
-                                let output_buffer = get_output_buffer_single(graph, OUTPUT_TENSOR)?;
-                                // decode the output buffer to a utf8 string
-                                let output = match String::from_utf8(output_buffer.clone())
-                                {
-                                    Ok(token) => token,
-                                    Err(_) => {
-                                        let mutex = CACHED_UTF8_ENCODINGS.get_or_init(|| Mutex::new(Vec::new()));
-                                        let mut cached_encodings = mutex.lock().map_err(|e| {
-                                            let err_msg = format!(
-                                                "Fail to acquire the lock of `UTF8_ENCODINGS`. Reason: {}",
-                                                e
-                                            );
-
-                                            #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
-
-                                            LlamaCoreError::Operation(err_msg)
-                                        })?;
-
-                                        cached_encodings.extend_from_slice(&output_buffer[..]);
-
-                                        match String::from_utf8(cached_encodings.to_vec()) {
-                                            Ok(token) => {
-                                                // clear encodings
-                                                cached_encodings.clear();
-
-                                                token
-                                            }
-                                            Err(_) => {
-                                                // TODO This is a temp check. In case, infinite cached encodings happen.
-                                                if cached_encodings.len() > 3 {
-                                                    let err_msg = "The length of the invalid utf8 bytes exceed 3.";
-
-                                                    #[cfg(feature = "logging")]
-                                                    error!(target: "llama_core", "{}", &err_msg);
-
-                                                    return Err(LlamaCoreError::Operation(err_msg.into()));
-                                                }
-
-                                                String::new()
-                                            }
-                                        }
-                                    }
-                                };
-
-                                let created = SystemTime::now()
-                                    .duration_since(std::time::UNIX_EPOCH)
-                                    .map_err(|e| {
-                                        let err_msg = format!(
-                                            "Failed to get the current time. Reason: {}",
-                                            e
-                                        );
-
-                                        #[cfg(feature = "logging")]
-                                        error!(target: "llama_core", "{}", &err_msg);
-
-                                        LlamaCoreError::Operation(err_msg)
-                                    })?;
-
-                                let chat_completion_chunk = ChatCompletionChunk {
-                                    id,
-                                    object: "chat.completion.chunk".to_string(),
-                                    created: created.as_secs(),
-                                    model: graph.name().to_owned(),
-                                    system_fingerprint: "fp_44709d6fcb".to_string(),
-                                    choices: vec![ChatCompletionChunkChoice {
-                                        index: 0,
-                                        delta: ChatCompletionChunkChoiceDelta {
-                                            role: Some(ChatCompletionRole::Assistant),
-                                            content: Some(output),
-                                            function_call: None,
-                                            tool_calls: None,
-                                        },
-                                        logprobs: None,
-                                        finish_reason: None,
-                                    }],
-                                    usage: None,
-                                };
-
-                                // serialize chat completion chunk
-                                let chunk_str =
-                                serde_json::to_string(&chat_completion_chunk).map_err(|e| {
-                                    let err_msg = format!(
-                                        "Failed to serialize chat completion chunk. Reason: {}",
-                                        e
-                                    );
-
-                                    #[cfg(feature = "logging")]
-                                    error!(target: "llama_core", "{}", &err_msg);
-
-                                    LlamaCoreError::Operation(err_msg)
-                                })?;
-
-                                Ok(format!("data: {}\n\n", chunk_str))
-                            }
-                            Err(wasmedge_wasi_nn::Error::BackendError(
-                                wasmedge_wasi_nn::BackendError::EndOfSequence,
-                            )) => {
-                                match stream_state {
-                                    StreamState::Usage => {
-                                        stream_state = StreamState::Done;
-
-                                        // retrieve the number of prompt and completion tokens
-                                        let token_info = get_token_info_by_graph(graph)?;
-
-                                        let usage = Some(Usage {
-                                            prompt_tokens: token_info.prompt_tokens,
-                                            completion_tokens: token_info.completion_tokens,
-                                            total_tokens: token_info.prompt_tokens + token_info.completion_tokens,
-                                        });
-
-                                        #[cfg(feature = "logging")]
-                                        info!(target: "llama_core", "token_info: {} prompt tokens, {} completion tokens", token_info.prompt_tokens, token_info.completion_tokens);
-
-                                        let created = SystemTime::now()
-                                        .duration_since(std::time::UNIX_EPOCH)
-                                        .map_err(|e| {
-                                            let err_msg = format!(
-                                                "Failed to get the current time. Reason: {}",
-                                                e
-                                            );
-
-                                            #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
-
-                                            LlamaCoreError::Operation(err_msg)
-                                        })?;
-
-                                        let chat_completion_chunk = ChatCompletionChunk {
-                                            id,
-                                            object: "chat.completion.chunk".to_string(),
-                                            created: created.as_secs(),
-                                            model: graph.name().to_owned(),
-                                            system_fingerprint: "fp_44709d6fcb".to_string(),
-                                            choices: vec![],
-                                            usage,
-                                        };
-
-                                        // serialize chat completion chunk
-                                        let chunk_str =
-                                        serde_json::to_string(&chat_completion_chunk).map_err(|e| {
-                                            let err_msg = format!(
-                                                "Failed to serialize chat completion chunk. Reason: {}",
-                                                e
-                                            );
-
-                                            #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
-
-                                            LlamaCoreError::Operation(err_msg)
-                                        })?;
-
-                                        Ok(format!("data: {}\n\n", chunk_str))
-                                    }
-                                    StreamState::Done => {
-                                        stream_state = StreamState::EndOfSequence;
-
-                                        Ok("data: [DONE]\n\n".to_string())
-                                    }
-                                    StreamState::EndOfSequence => {
-                                        // clear context
-                                        if let Err(e) = graph.finish_single() {
-                                            let err_msg = format!(
-                                                "Failed to clean up the context. Reason: {}",
-                                                e
-                                            );
-
-                                            #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
-
-                                            return Err(LlamaCoreError::Backend(BackendError::FinishSingle(
-                                                err_msg,
-                                            )));
-                                        }
-
-                                        Ok("[GGML] End of sequence".to_string())
-                                    }
-                                }
-                            }
-                            Err(wasmedge_wasi_nn::Error::BackendError(
-                                wasmedge_wasi_nn::BackendError::ContextFull,
-                            )) => {
-                                match context_full_state {
-                                    ContextFullState::Message => {
-                                        match include_usage {
-                                            true => context_full_state = ContextFullState::Usage,
-                                            false => context_full_state = ContextFullState::Done,
-                                        }
-
-                                        let created = SystemTime::now()
-                                            .duration_since(std::time::UNIX_EPOCH)
-                                            .map_err(|e| {
-                                                let err_msg = format!(
-                                                    "Failed to get the current time. Reason: {}",
-                                                    e
-                                                );
-
-                                                #[cfg(feature = "logging")]
-                                                error!(target: "llama_core", "{}", &err_msg);
-
-                                                LlamaCoreError::Operation(err_msg)
-                                            })?;
-
-                                        let chat_completion_chunk = ChatCompletionChunk {
-                                            id,
-                                            object: "chat.completion.chunk".to_string(),
-                                            created: created.as_secs(),
-                                            model: graph.name().to_owned(),
-                                            system_fingerprint: "fp_44709d6fcb".to_string(),
-                                            choices: vec![ChatCompletionChunkChoice {
-                                                index: 0,
-                                                delta: ChatCompletionChunkChoiceDelta {
-                                                    role: Some(ChatCompletionRole::Assistant),
-                                                    content: Some("<|WASMEDGE-GGML-CONTEXT-FULL|>".to_string()),
-                                                    function_call: None,
-                                                    tool_calls: None,
-                                                },
-                                                logprobs: None,
-                                                finish_reason: Some(FinishReason::length),
-                                            }],
-                                            usage: None,
-                                        };
-
-                                        // serialize chat completion chunk
-                                        let chunk_str =
-                                            serde_json::to_string(&chat_completion_chunk).map_err(|e| {
-                                                let err_msg = format!(
-                                                    "Failed to serialize chat completion chunk. Reason: {}",
-                                                    e
-                                                );
-
-                                                #[cfg(feature = "logging")]
-                                                error!(target: "llama_core", "{}", &err_msg);
-
-                                                LlamaCoreError::Operation(err_msg)
-                                            })?;
-
-                                        Ok(format!("data: {}\n\n", chunk_str))
-                                    }
-                                    ContextFullState::Usage => {
-                                        context_full_state = ContextFullState::Done;
-
-                                        // retrieve the number of prompt and completion tokens
-                                        let token_info = get_token_info_by_graph(graph)?;
-
-                                        let usage = Some(Usage {
-                                            prompt_tokens: token_info.prompt_tokens,
-                                            completion_tokens: token_info.completion_tokens,
-                                            total_tokens: token_info.prompt_tokens + token_info.completion_tokens,
-                                        });
-
-                                        let created = SystemTime::now()
-                                        .duration_since(std::time::UNIX_EPOCH)
-                                        .map_err(|e| {
-                                            let err_msg = format!(
-                                                "Failed to get the current time. Reason: {}",
-                                                e
-                                            );
-
-                                            #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
-
-                                            LlamaCoreError::Operation(err_msg)
-                                        })?;
-
-                                        let chat_completion_chunk = ChatCompletionChunk {
-                                            id,
-                                            object: "chat.completion.chunk".to_string(),
-                                            created: created.as_secs(),
-                                            model: graph.name().to_owned(),
-                                            system_fingerprint: "fp_44709d6fcb".to_string(),
-                                            choices: vec![],
-                                            usage,
-                                        };
-
-                                        // serialize chat completion chunk
-                                        let chunk_str =
-                                        serde_json::to_string(&chat_completion_chunk).map_err(|e| {
-                                            let err_msg = format!(
-                                                "Failed to serialize chat completion chunk. Reason: {}",
-                                                e
-                                            );
-
-                                            #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
-
-                                            LlamaCoreError::Operation(err_msg)
-                                        })?;
-
-                                        Ok(format!("data: {}\n\n", chunk_str))
-
-                                    }
-                                    ContextFullState::Done => {
-                                        context_full_state = ContextFullState::EndOfSequence;
-
-                                        Ok("data: [DONE]\n\n".to_string())
-                                    }
-                                    ContextFullState::EndOfSequence => {
-                                        // clear context
-                                        if let Err(e) = graph.finish_single() {
-                                            let err_msg = format!(
-                                                "Failed to clean up the context. Reason: {}",
-                                                e
-                                            );
-
-                                            #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
-
-                                            return Err(LlamaCoreError::Backend(BackendError::FinishSingle(
-                                                err_msg,
-                                            )));
-                                        }
-
-                                        Ok("[GGML] End of sequence".to_string())
-                                    }
-                                }
-                            }
-                            Err(wasmedge_wasi_nn::Error::BackendError(
-                                wasmedge_wasi_nn::BackendError::PromptTooLong,
-                            )) => {
-                                match prompt_too_long_state {
-                                    PromptTooLongState::Message => {
-                                        match include_usage {
-                                            true => prompt_too_long_state = PromptTooLongState::Usage,
-                                            false => prompt_too_long_state = PromptTooLongState::Done,
-                                        }
-
-                                        let created = SystemTime::now()
-                                            .duration_since(std::time::UNIX_EPOCH)
-                                            .map_err(|e| {
-                                                let err_msg = format!(
-                                                    "Failed to get the current time. Reason: {}",
-                                                    e
-                                                );
-
-                                                #[cfg(feature = "logging")]
-                                                error!(target: "llama_core", "{}", &err_msg);
-
-                                                LlamaCoreError::Operation(err_msg)
-                                            })?;
-
-                                        let chat_completion_chunk = ChatCompletionChunk {
-                                            id,
-                                            object: "chat.completion.chunk".to_string(),
-                                            created: created.as_secs(),
-                                            model: graph.name().to_owned(),
-                                            system_fingerprint: "fp_44709d6fcb".to_string(),
-                                            choices: vec![ChatCompletionChunkChoice {
-                                                index: 0,
-                                                delta: ChatCompletionChunkChoiceDelta {
-                                                    role: Some(ChatCompletionRole::Assistant),
-                                                    content: None,
-                                                    function_call: None,
-                                                    tool_calls: None,
-                                                },
-                                                logprobs: None,
-                                                finish_reason: Some(FinishReason::length),
-                                            }],
-                                            usage: None,
-                                        };
-
-                                        // serialize chat completion chunk
-                                        let chunk_str =
-                                        serde_json::to_string(&chat_completion_chunk).map_err(|e| {
-                                            let err_msg = format!(
-                                                "Failed to serialize chat completion chunk. Reason: {}",
-                                                e
-                                            );
-
-                                            #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
-
-                                            LlamaCoreError::Operation(err_msg)
-                                        })?;
-
-                                        Ok(format!("data: {}\n\n", chunk_str))
-                                    }
-                                    PromptTooLongState::Usage => {
-                                        prompt_too_long_state = PromptTooLongState::Done;
-
-                                        // retrieve the number of prompt and completion tokens
-                                        let token_info = get_token_info_by_graph(graph)?;
-
-                                        let usage = Some(Usage {
-                                            prompt_tokens: token_info.prompt_tokens,
-                                            completion_tokens: token_info.completion_tokens,
-                                            total_tokens: token_info.prompt_tokens + token_info.completion_tokens,
-                                        });
-
-                                        let created = SystemTime::now()
-                                        .duration_since(std::time::UNIX_EPOCH)
-                                        .map_err(|e| {
-                                            let err_msg = format!(
-                                                "Failed to get the current time. Reason: {}",
-                                                e
-                                            );
-
-                                            #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
-
-                                            LlamaCoreError::Operation(err_msg)
-                                        })?;
-
-                                        let chat_completion_chunk = ChatCompletionChunk {
-                                            id,
-                                            object: "chat.completion.chunk".to_string(),
-                                            created: created.as_secs(),
-                                            model: graph.name().to_owned(),
-                                            system_fingerprint: "fp_44709d6fcb".to_string(),
-                                            choices: vec![],
-                                            usage,
-                                        };
-
-                                        // serialize chat completion chunk
-                                        let chunk_str =
-                                        serde_json::to_string(&chat_completion_chunk).map_err(|e| {
-                                            let err_msg = format!(
-                                                "Failed to serialize chat completion chunk. Reason: {}",
-                                                e
-                                            );
-
-                                            #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
-
-                                            LlamaCoreError::Operation(err_msg)
-                                        })?;
-
-                                        Ok(format!("data: {}\n\n", chunk_str))
-                                    }
-                                    PromptTooLongState::Done => {
-                                        prompt_too_long_state = PromptTooLongState::EndOfSequence;
-
-                                        Ok("data: [DONE]\n\n".to_string())
-                                    }
-                                    PromptTooLongState::EndOfSequence => {
-                                        // clear context
-                                        if let Err(e) = graph.finish_single() {
-                                            let err_msg = format!(
-                                                "Failed to clean up the context. Reason: {}",
-                                                e
-                                            );
-
-                                            #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
-
-                                            return Err(LlamaCoreError::Backend(BackendError::FinishSingle(
-                                                err_msg,
-                                            )));
-                                        }
-
-                                        Ok("[GGML] End of sequence".to_string())
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                // clear context
-                                if let Err(e) = graph.finish_single() {
-                                    let err_msg = format!(
-                                        "Failed to clean up the context. Reason: {}",
-                                        e
-                                    );
-
-                                    #[cfg(feature = "logging")]
-                                    error!(target: "llama_core", "{}", &err_msg);
-
-                                    return Err(LlamaCoreError::Backend(BackendError::FinishSingle(
-                                        err_msg,
-                                    )));
-                                }
-
-                                let err_msg = format!("Failed to compute the chat completion. Reason: {}", e);
-
-                                #[cfg(feature = "logging")]
-                                error!(target: "llama_core", "{}", &err_msg);
-
-                                Err(LlamaCoreError::Backend(BackendError::ComputeSingle(
-                                    err_msg,
-                                )))
-                            }
-                        }
-                    }
-                    None => {
-                        let err_msg = "There is no model available in the chat graphs.";
-
-                        #[cfg(feature = "logging")]
-                        error!(target: "llama_core", "{}", &err_msg);
-
-                        Err(LlamaCoreError::Operation(err_msg.into()))
-                    }
-                }
-            }
-        }
-    })
-    .try_take_while(|x| future::ready(Ok(x != "[GGML] End of sequence" && !x.is_empty())));
+    // create chat stream
+    let stream = ChatStream::new(model_name, id, include_usage);
 
     #[cfg(feature = "logging")]
     info!(target: "llama_core", "End of the chat completion stream.");
@@ -2230,7 +1164,7 @@ fn update_model_metadata(
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ContextFullState {
     Message,
     Usage,
@@ -2238,17 +1172,1271 @@ enum ContextFullState {
     EndOfSequence,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum StreamState {
     Usage,
     Done,
     EndOfSequence,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PromptTooLongState {
     Message,
     Usage,
     Done,
     EndOfSequence,
+}
+
+struct ChatStream {
+    id: String,
+    model: Option<String>,
+    include_usage: bool,
+    context_full_state: ContextFullState,
+    prompt_too_long_state: PromptTooLongState,
+    stream_state: StreamState,
+}
+impl ChatStream {
+    fn new(model: Option<String>, id: String, include_usage: bool) -> Self {
+        let stream_state = if include_usage {
+            StreamState::Usage
+        } else {
+            StreamState::Done
+        };
+
+        ChatStream {
+            id,
+            model,
+            include_usage,
+            context_full_state: ContextFullState::Message,
+            prompt_too_long_state: PromptTooLongState::Message,
+            stream_state,
+        }
+    }
+}
+impl Drop for ChatStream {
+    fn drop(&mut self) {
+        match &self.model {
+            Some(model_name) => {
+                match CHAT_GRAPHS.get() {
+                    Some(chat_graphs) => match chat_graphs.lock() {
+                        Ok(mut chat_graphs) => match chat_graphs.get_mut(model_name) {
+                            Some(graph) => {
+                                if let Err(e) = graph.finish_single() {
+                                    let err_msg =
+                                        format!("Failed to clean up the context. Reason: {}", e);
+
+                                    #[cfg(feature = "logging")]
+                                    error!(target: "llama_core", "{}", &err_msg);
+
+                                    #[cfg(not(feature = "logging"))]
+                                    println!(
+                                        "[ERROR][llama_core] Failed to clean up the context. Reason: {}",
+                                        &err_msg
+                                    );
+                                }
+                            }
+                            None => {
+                                let err_msg = format!(
+                                    "The model `{}` does not exist in the chat graphs.",
+                                    &model_name
+                                );
+
+                                #[cfg(feature = "logging")]
+                                error!(target: "llama_core", "{}", &err_msg);
+
+                                #[cfg(not(feature = "logging"))]
+                                println!(
+                                    "[ERROR][llama_core] Failed to clean up the context. Reason: {}",
+                                    &err_msg
+                                );
+                            }
+                        },
+                        Err(e) => {
+                            let err_msg =
+                                format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
+
+                            #[cfg(feature = "logging")]
+                            error!(target: "llama_core", "{}", &err_msg);
+
+                            #[cfg(not(feature = "logging"))]
+                            println!(
+                                "[ERROR][llama_core] Failed to clean up the context. Reason: {}",
+                                &err_msg
+                            );
+                        }
+                    },
+                    None => {
+                        let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
+
+                        #[cfg(feature = "logging")]
+                        error!(target: "llama_core", "{}", &err_msg);
+
+                        #[cfg(not(feature = "logging"))]
+                        println!(
+                            "[ERROR][llama_core] Failed to clean up the context. Reason: {}",
+                            &err_msg
+                        );
+                    }
+                };
+            }
+            None => {
+                match CHAT_GRAPHS.get() {
+                    Some(chat_graphs) => match chat_graphs.lock() {
+                        Ok(mut chat_graphs) => match chat_graphs.iter_mut().next() {
+                            Some((_, graph)) => {
+                                if let Err(e) = graph.finish_single() {
+                                    let err_msg =
+                                        format!("Failed to clean up the context. Reason: {}", e);
+
+                                    #[cfg(feature = "logging")]
+                                    error!(target: "llama_core", "{}", &err_msg);
+
+                                    #[cfg(not(feature = "logging"))]
+                                    println!(
+                                        "[ERROR][llama_core] Failed to clean up the context. Reason: {}",
+                                        &err_msg
+                                    );
+                                }
+                            }
+                            None => {
+                                let err_msg = "There is no model available in the chat graphs.";
+
+                                #[cfg(feature = "logging")]
+                                error!(target: "llama_core", "{}", err_msg);
+
+                                #[cfg(not(feature = "logging"))]
+                                println!(
+                                    "[ERROR][llama_core] Failed to clean up the context. Reason: {}",
+                                    err_msg
+                                );
+                            }
+                        },
+                        Err(e) => {
+                            let err_msg =
+                                format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
+
+                            #[cfg(feature = "logging")]
+                            error!(target: "llama_core", "{}", &err_msg);
+
+                            #[cfg(not(feature = "logging"))]
+                            println!(
+                                "[ERROR][llama_core] Failed to clean up the context. Reason: {}",
+                                &err_msg
+                            );
+                        }
+                    },
+                    None => {
+                        let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
+
+                        #[cfg(feature = "logging")]
+                        error!(target: "llama_core", "{}", &err_msg);
+
+                        #[cfg(not(feature = "logging"))]
+                        println!(
+                            "[ERROR][llama_core] Failed to clean up the context. Reason: {}",
+                            &err_msg
+                        );
+                    }
+                };
+            }
+        }
+    }
+}
+impl futures::Stream for ChatStream {
+    type Item = Result<String, LlamaCoreError>;
+
+    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        let x = compute_stream(
+            this.model.clone(),
+            this.id.clone(),
+            this.include_usage,
+            &mut this.prompt_too_long_state,
+            &mut this.context_full_state,
+            &mut this.stream_state,
+        );
+
+        match x {
+            Ok(x) => {
+                if x != "[GGML] End of sequence" && !x.is_empty() {
+                    Poll::Ready(Some(Ok(x)))
+                } else {
+                    // stopped
+                    Poll::Ready(None)
+                }
+            }
+            Err(e) => Poll::Ready(Some(Err(e))),
+        }
+    }
+}
+
+fn compute_stream(
+    model_name: Option<String>,
+    id: String,
+    include_usage: bool,
+    prompt_too_long_state: &mut PromptTooLongState,
+    context_full_state: &mut ContextFullState,
+    stream_state: &mut StreamState,
+) -> Result<String, LlamaCoreError> {
+    if *prompt_too_long_state == PromptTooLongState::EndOfSequence
+        || *context_full_state == ContextFullState::EndOfSequence
+        || *stream_state == StreamState::EndOfSequence
+    {
+        return Ok("[GGML] End of sequence".to_string());
+    }
+
+    // get graph
+    match &model_name {
+        Some(model_name) => {
+            let chat_graphs = match CHAT_GRAPHS.get() {
+                Some(chat_graphs) => chat_graphs,
+                None => {
+                    let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
+
+                    #[cfg(feature = "logging")]
+                    error!(target: "llama_core", "{}", &err_msg);
+
+                    return Err(LlamaCoreError::Operation(err_msg.into()));
+                }
+            };
+
+            let mut chat_graphs = chat_graphs.lock().map_err(|e| {
+                let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
+
+                #[cfg(feature = "logging")]
+                error!(target: "llama_core", "{}", &err_msg);
+
+                LlamaCoreError::Operation(err_msg)
+            })?;
+
+            match chat_graphs.get_mut(model_name) {
+                Some(graph) => {
+                    info!(target: "llama_core", "Compute the chat completion by the model named {}.", graph.name());
+                    // compute
+                    match graph.compute_single() {
+                        Ok(_) => {
+                            // Retrieve the output
+                            let output_buffer = get_output_buffer_single(graph, OUTPUT_TENSOR)?;
+
+                            // decode the output buffer to a utf8 string
+                            let output = match String::from_utf8(output_buffer.clone()) {
+                                Ok(token) => token,
+                                Err(_) => {
+                                    let mutex = CACHED_UTF8_ENCODINGS
+                                        .get_or_init(|| Mutex::new(Vec::new()));
+                                    let mut cached_encodings = mutex.lock().map_err(|e| {
+                                            let err_msg = format!(
+                                                "Fail to acquire the lock of `UTF8_ENCODINGS`. Reason: {}",
+                                                e
+                                            );
+
+                                            #[cfg(feature = "logging")]
+                                            error!(target: "llama_core", "{}", &err_msg);
+
+
+                                            LlamaCoreError::Operation(err_msg)
+                                        })?;
+
+                                    // cache the bytes for future decoding
+                                    cached_encodings.extend_from_slice(&output_buffer[..]);
+
+                                    match String::from_utf8(cached_encodings.to_vec()) {
+                                        Ok(token) => {
+                                            // clear encodings
+                                            cached_encodings.clear();
+
+                                            token
+                                        }
+                                        Err(_) => {
+                                            // TODO This is a temp check. In case, infinite cached encodings happen.
+                                            if cached_encodings.len() > 3 {
+                                                let err_msg = "The length of the invalid utf8 bytes exceed 3.";
+
+                                                #[cfg(feature = "logging")]
+                                                error!(target: "llama_core", "{}", &err_msg);
+
+                                                return Err(LlamaCoreError::Operation(
+                                                    err_msg.into(),
+                                                ));
+                                            }
+
+                                            String::new()
+                                        }
+                                    }
+                                }
+                            };
+
+                            let created = SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .map_err(|e| {
+                                let err_msg =
+                                    format!("Failed to get the current time. Reason: {}", e);
+
+                                #[cfg(feature = "logging")]
+                                error!(target: "llama_core", "{}", &err_msg);
+
+                                LlamaCoreError::Operation(err_msg)
+                            })?;
+
+                            let chat_completion_chunk = ChatCompletionChunk {
+                                id,
+                                object: "chat.completion.chunk".to_string(),
+                                created: created.as_secs(),
+                                model: graph.name().to_owned(),
+                                system_fingerprint: "fp_44709d6fcb".to_string(),
+                                choices: vec![ChatCompletionChunkChoice {
+                                    index: 0,
+                                    delta: ChatCompletionChunkChoiceDelta {
+                                        role: Some(ChatCompletionRole::Assistant),
+                                        content: Some(output),
+                                        function_call: None,
+                                        tool_calls: None,
+                                    },
+                                    logprobs: None,
+                                    finish_reason: None,
+                                }],
+                                usage: None,
+                            };
+
+                            // serialize chat completion chunk
+                            let chunk_str =
+                                serde_json::to_string(&chat_completion_chunk).map_err(|e| {
+                                    let err_msg = format!(
+                                        "Failed to serialize chat completion chunk. Reason: {}",
+                                        e
+                                    );
+
+                                    #[cfg(feature = "logging")]
+                                    error!(target: "llama_core", "{}", &err_msg);
+
+                                    LlamaCoreError::Operation(err_msg)
+                                })?;
+
+                            Ok(format!("data: {}\n\n", chunk_str))
+                        }
+                        Err(wasmedge_wasi_nn::Error::BackendError(
+                            wasmedge_wasi_nn::BackendError::EndOfSequence,
+                        )) => {
+                            match stream_state {
+                                StreamState::Usage => {
+                                    *stream_state = StreamState::Done;
+
+                                    // retrieve the number of prompt and completion tokens
+                                    let token_info = get_token_info_by_graph(graph)?;
+
+                                    let usage = Some(Usage {
+                                        prompt_tokens: token_info.prompt_tokens,
+                                        completion_tokens: token_info.completion_tokens,
+                                        total_tokens: token_info.prompt_tokens
+                                            + token_info.completion_tokens,
+                                    });
+
+                                    #[cfg(feature = "logging")]
+                                    info!(target: "llama_core", "token_info: {} prompt tokens, {} completion tokens", token_info.prompt_tokens, token_info.completion_tokens);
+
+                                    let created = SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .map_err(|e| {
+                                            let err_msg = format!(
+                                                "Failed to get the current time. Reason: {}",
+                                                e
+                                            );
+
+                                            #[cfg(feature = "logging")]
+                                            error!(target: "llama_core", "{}", &err_msg);
+
+                                            LlamaCoreError::Operation(err_msg)
+                                        })?;
+
+                                    let chat_completion_chunk = ChatCompletionChunk {
+                                        id,
+                                        object: "chat.completion.chunk".to_string(),
+                                        created: created.as_secs(),
+                                        model: graph.name().to_owned(),
+                                        system_fingerprint: "fp_44709d6fcb".to_string(),
+                                        choices: vec![],
+                                        usage,
+                                    };
+
+                                    // serialize chat completion chunk
+                                    let chunk_str = serde_json::to_string(&chat_completion_chunk)
+                                        .map_err(|e| {
+                                        let err_msg = format!(
+                                            "Failed to serialize chat completion chunk. Reason: {}",
+                                            e
+                                        );
+
+                                        #[cfg(feature = "logging")]
+                                        error!(target: "llama_core", "{}", &err_msg);
+
+                                        LlamaCoreError::Operation(err_msg)
+                                    })?;
+
+                                    Ok(format!("data: {}\n\n", chunk_str))
+                                }
+                                StreamState::Done => {
+                                    *stream_state = StreamState::EndOfSequence;
+
+                                    Ok("data: [DONE]\n\n".to_string())
+                                }
+                                StreamState::EndOfSequence => {
+                                    // clear context
+                                    if let Err(e) = graph.finish_single() {
+                                        let err_msg = format!(
+                                            "Failed to clean up the context. Reason: {}",
+                                            e
+                                        );
+
+                                        #[cfg(feature = "logging")]
+                                        error!(target: "llama_core", "{}", &err_msg);
+
+                                        return Err(LlamaCoreError::Backend(
+                                            BackendError::FinishSingle(err_msg),
+                                        ));
+                                    }
+
+                                    Ok("[GGML] End of sequence".to_string())
+                                }
+                            }
+                        }
+                        Err(wasmedge_wasi_nn::Error::BackendError(
+                            wasmedge_wasi_nn::BackendError::ContextFull,
+                        )) => {
+                            match context_full_state {
+                                ContextFullState::Message => {
+                                    match include_usage {
+                                        true => *context_full_state = ContextFullState::Usage,
+                                        false => *context_full_state = ContextFullState::Done,
+                                    }
+
+                                    let created = SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .map_err(|e| {
+                                            let err_msg = format!(
+                                                "Failed to get the current time. Reason: {}",
+                                                e
+                                            );
+
+                                            #[cfg(feature = "logging")]
+                                            error!(target: "llama_core", "{}", &err_msg);
+
+                                            LlamaCoreError::Operation(err_msg)
+                                        })?;
+
+                                    let chat_completion_chunk = ChatCompletionChunk {
+                                        id,
+                                        object: "chat.completion.chunk".to_string(),
+                                        created: created.as_secs(),
+                                        model: graph.name().to_owned(),
+                                        system_fingerprint: "fp_44709d6fcb".to_string(),
+                                        choices: vec![ChatCompletionChunkChoice {
+                                            index: 0,
+                                            delta: ChatCompletionChunkChoiceDelta {
+                                                role: Some(ChatCompletionRole::Assistant),
+                                                content: Some(
+                                                    "<|WASMEDGE-GGML-CONTEXT-FULL|>".to_string(),
+                                                ),
+                                                function_call: None,
+                                                tool_calls: None,
+                                            },
+                                            logprobs: None,
+                                            finish_reason: Some(FinishReason::length),
+                                        }],
+                                        usage: None,
+                                    };
+
+                                    // serialize chat completion chunk
+                                    let chunk_str = serde_json::to_string(&chat_completion_chunk)
+                                        .map_err(|e| {
+                                        let err_msg = format!(
+                                            "Failed to serialize chat completion chunk. Reason: {}",
+                                            e
+                                        );
+
+                                        #[cfg(feature = "logging")]
+                                        error!(target: "llama_core", "{}", &err_msg);
+
+                                        LlamaCoreError::Operation(err_msg)
+                                    })?;
+
+                                    Ok(format!("data: {}\n\n", chunk_str))
+                                }
+                                ContextFullState::Usage => {
+                                    *context_full_state = ContextFullState::Done;
+
+                                    // retrieve the number of prompt and completion tokens
+                                    let token_info = get_token_info_by_graph(graph)?;
+
+                                    let usage = Some(Usage {
+                                        prompt_tokens: token_info.prompt_tokens,
+                                        completion_tokens: token_info.completion_tokens,
+                                        total_tokens: token_info.prompt_tokens
+                                            + token_info.completion_tokens,
+                                    });
+
+                                    let created = SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .map_err(|e| {
+                                            let err_msg = format!(
+                                                "Failed to get the current time. Reason: {}",
+                                                e
+                                            );
+
+                                            #[cfg(feature = "logging")]
+                                            error!(target: "llama_core", "{}", &err_msg);
+
+                                            LlamaCoreError::Operation(err_msg)
+                                        })?;
+
+                                    let chat_completion_chunk = ChatCompletionChunk {
+                                        id,
+                                        object: "chat.completion.chunk".to_string(),
+                                        created: created.as_secs(),
+                                        model: graph.name().to_owned(),
+                                        system_fingerprint: "fp_44709d6fcb".to_string(),
+                                        choices: vec![],
+                                        usage,
+                                    };
+
+                                    // serialize chat completion chunk
+                                    let chunk_str = serde_json::to_string(&chat_completion_chunk)
+                                        .map_err(|e| {
+                                        let err_msg = format!(
+                                            "Failed to serialize chat completion chunk. Reason: {}",
+                                            e
+                                        );
+
+                                        #[cfg(feature = "logging")]
+                                        error!(target: "llama_core", "{}", &err_msg);
+
+                                        LlamaCoreError::Operation(err_msg)
+                                    })?;
+
+                                    Ok(format!("data: {}\n\n", chunk_str))
+                                }
+                                ContextFullState::Done => {
+                                    *context_full_state = ContextFullState::EndOfSequence;
+
+                                    Ok("data: [DONE]\n\n".to_string())
+                                }
+                                ContextFullState::EndOfSequence => {
+                                    // clear context
+                                    if let Err(e) = graph.finish_single() {
+                                        let err_msg = format!(
+                                            "Failed to clean up the context. Reason: {}",
+                                            e
+                                        );
+
+                                        #[cfg(feature = "logging")]
+                                        error!(target: "llama_core", "{}", &err_msg);
+
+                                        return Err(LlamaCoreError::Backend(
+                                            BackendError::FinishSingle(err_msg),
+                                        ));
+                                    }
+
+                                    Ok("[GGML] End of sequence".to_string())
+                                }
+                            }
+                        }
+                        Err(wasmedge_wasi_nn::Error::BackendError(
+                            wasmedge_wasi_nn::BackendError::PromptTooLong,
+                        )) => {
+                            match prompt_too_long_state {
+                                PromptTooLongState::Message => {
+                                    match include_usage {
+                                        true => *prompt_too_long_state = PromptTooLongState::Usage,
+                                        false => *prompt_too_long_state = PromptTooLongState::Done,
+                                    }
+
+                                    let created = SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .map_err(|e| {
+                                            let err_msg = format!(
+                                                "Failed to get the current time. Reason: {}",
+                                                e
+                                            );
+
+                                            #[cfg(feature = "logging")]
+                                            error!(target: "llama_core", "{}", &err_msg);
+
+                                            LlamaCoreError::Operation(err_msg)
+                                        })?;
+
+                                    let chat_completion_chunk = ChatCompletionChunk {
+                                        id,
+                                        object: "chat.completion.chunk".to_string(),
+                                        created: created.as_secs(),
+                                        model: graph.name().to_owned(),
+                                        system_fingerprint: "fp_44709d6fcb".to_string(),
+                                        choices: vec![ChatCompletionChunkChoice {
+                                            index: 0,
+                                            delta: ChatCompletionChunkChoiceDelta {
+                                                role: Some(ChatCompletionRole::Assistant),
+                                                content: None,
+                                                function_call: None,
+                                                tool_calls: None,
+                                            },
+                                            logprobs: None,
+                                            finish_reason: Some(FinishReason::length),
+                                        }],
+                                        usage: None,
+                                    };
+
+                                    // serialize chat completion chunk
+                                    let chunk_str = serde_json::to_string(&chat_completion_chunk)
+                                        .map_err(|e| {
+                                        let err_msg = format!(
+                                            "Failed to serialize chat completion chunk. Reason: {}",
+                                            e
+                                        );
+
+                                        #[cfg(feature = "logging")]
+                                        error!(target: "llama_core", "{}", &err_msg);
+
+                                        LlamaCoreError::Operation(err_msg)
+                                    })?;
+
+                                    Ok(format!("data: {}\n\n", chunk_str))
+                                }
+                                PromptTooLongState::Usage => {
+                                    *prompt_too_long_state = PromptTooLongState::Done;
+
+                                    // retrieve the number of prompt and completion tokens
+                                    let token_info = get_token_info_by_graph(graph)?;
+
+                                    let usage = Some(Usage {
+                                        prompt_tokens: token_info.prompt_tokens,
+                                        completion_tokens: token_info.completion_tokens,
+                                        total_tokens: token_info.prompt_tokens
+                                            + token_info.completion_tokens,
+                                    });
+
+                                    let created = SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .map_err(|e| {
+                                            let err_msg = format!(
+                                                "Failed to get the current time. Reason: {}",
+                                                e
+                                            );
+
+                                            #[cfg(feature = "logging")]
+                                            error!(target: "llama_core", "{}", &err_msg);
+
+                                            LlamaCoreError::Operation(err_msg)
+                                        })?;
+
+                                    let chat_completion_chunk = ChatCompletionChunk {
+                                        id,
+                                        object: "chat.completion.chunk".to_string(),
+                                        created: created.as_secs(),
+                                        model: graph.name().to_owned(),
+                                        system_fingerprint: "fp_44709d6fcb".to_string(),
+                                        choices: vec![],
+                                        usage,
+                                    };
+
+                                    // serialize chat completion chunk
+                                    let chunk_str = serde_json::to_string(&chat_completion_chunk)
+                                        .map_err(|e| {
+                                        let err_msg = format!(
+                                            "Failed to serialize chat completion chunk. Reason: {}",
+                                            e
+                                        );
+
+                                        #[cfg(feature = "logging")]
+                                        error!(target: "llama_core", "{}", &err_msg);
+
+                                        LlamaCoreError::Operation(err_msg)
+                                    })?;
+
+                                    Ok(format!("data: {}\n\n", chunk_str))
+                                }
+                                PromptTooLongState::Done => {
+                                    *prompt_too_long_state = PromptTooLongState::EndOfSequence;
+
+                                    Ok("data: [DONE]\n\n".to_string())
+                                }
+                                PromptTooLongState::EndOfSequence => {
+                                    // clear context
+                                    if let Err(e) = graph.finish_single() {
+                                        let err_msg = format!(
+                                            "Failed to clean up the context. Reason: {}",
+                                            e
+                                        );
+
+                                        #[cfg(feature = "logging")]
+                                        error!(target: "llama_core", "{}", &err_msg);
+
+                                        return Err(LlamaCoreError::Backend(
+                                            BackendError::FinishSingle(err_msg),
+                                        ));
+                                    }
+
+                                    Ok("[GGML] End of sequence".to_string())
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            // clear context
+                            if let Err(e) = graph.finish_single() {
+                                let err_msg =
+                                    format!("Failed to clean up the context. Reason: {}", e);
+
+                                #[cfg(feature = "logging")]
+                                error!(target: "llama_core", "{}", &err_msg);
+
+                                return Err(LlamaCoreError::Backend(BackendError::FinishSingle(
+                                    err_msg,
+                                )));
+                            }
+
+                            let err_msg =
+                                format!("Failed to compute the chat completion. Reason: {}", e);
+
+                            #[cfg(feature = "logging")]
+                            error!(target: "llama_core", "{}", &err_msg);
+
+                            Err(LlamaCoreError::Backend(BackendError::ComputeSingle(
+                                err_msg,
+                            )))
+                        }
+                    }
+                }
+                None => {
+                    let err_msg = format!(
+                        "The model `{}` does not exist in the chat graphs.",
+                        &model_name
+                    );
+
+                    #[cfg(feature = "logging")]
+                    error!(target: "llama_core", "{}", &err_msg);
+
+                    Err(LlamaCoreError::Operation(err_msg))
+                }
+            }
+        }
+        None => {
+            let chat_graphs = match CHAT_GRAPHS.get() {
+                Some(chat_graphs) => chat_graphs,
+                None => {
+                    let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
+
+                    #[cfg(feature = "logging")]
+                    error!(target: "llama_core", "{}", &err_msg);
+
+                    return Err(LlamaCoreError::Operation(err_msg.into()));
+                }
+            };
+
+            let mut chat_graphs = chat_graphs.lock().map_err(|e| {
+                let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
+
+                #[cfg(feature = "logging")]
+                error!(target: "llama_core", "{}", &err_msg);
+
+                LlamaCoreError::Operation(err_msg)
+            })?;
+
+            match chat_graphs.iter_mut().next() {
+                Some((_, graph)) => {
+                    // compute
+                    match graph.compute_single() {
+                        Ok(_) => {
+                            // Retrieve the output
+                            let output_buffer = get_output_buffer_single(graph, OUTPUT_TENSOR)?;
+                            // decode the output buffer to a utf8 string
+                            let output = match String::from_utf8(output_buffer.clone()) {
+                                Ok(token) => token,
+                                Err(_) => {
+                                    let mutex = CACHED_UTF8_ENCODINGS
+                                        .get_or_init(|| Mutex::new(Vec::new()));
+                                    let mut cached_encodings = mutex.lock().map_err(|e| {
+                                            let err_msg = format!(
+                                                "Fail to acquire the lock of `UTF8_ENCODINGS`. Reason: {}",
+                                                e
+                                            );
+
+                                            #[cfg(feature = "logging")]
+                                            error!(target: "llama_core", "{}", &err_msg);
+
+                                            LlamaCoreError::Operation(err_msg)
+                                        })?;
+
+                                    cached_encodings.extend_from_slice(&output_buffer[..]);
+
+                                    match String::from_utf8(cached_encodings.to_vec()) {
+                                        Ok(token) => {
+                                            // clear encodings
+                                            cached_encodings.clear();
+
+                                            token
+                                        }
+                                        Err(_) => {
+                                            // TODO This is a temp check. In case, infinite cached encodings happen.
+                                            if cached_encodings.len() > 3 {
+                                                let err_msg = "The length of the invalid utf8 bytes exceed 3.";
+
+                                                #[cfg(feature = "logging")]
+                                                error!(target: "llama_core", "{}", &err_msg);
+
+                                                return Err(LlamaCoreError::Operation(
+                                                    err_msg.into(),
+                                                ));
+                                            }
+
+                                            String::new()
+                                        }
+                                    }
+                                }
+                            };
+
+                            let created = SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .map_err(|e| {
+                                let err_msg =
+                                    format!("Failed to get the current time. Reason: {}", e);
+
+                                #[cfg(feature = "logging")]
+                                error!(target: "llama_core", "{}", &err_msg);
+
+                                LlamaCoreError::Operation(err_msg)
+                            })?;
+
+                            let chat_completion_chunk = ChatCompletionChunk {
+                                id,
+                                object: "chat.completion.chunk".to_string(),
+                                created: created.as_secs(),
+                                model: graph.name().to_owned(),
+                                system_fingerprint: "fp_44709d6fcb".to_string(),
+                                choices: vec![ChatCompletionChunkChoice {
+                                    index: 0,
+                                    delta: ChatCompletionChunkChoiceDelta {
+                                        role: Some(ChatCompletionRole::Assistant),
+                                        content: Some(output),
+                                        function_call: None,
+                                        tool_calls: None,
+                                    },
+                                    logprobs: None,
+                                    finish_reason: None,
+                                }],
+                                usage: None,
+                            };
+
+                            // serialize chat completion chunk
+                            let chunk_str =
+                                serde_json::to_string(&chat_completion_chunk).map_err(|e| {
+                                    let err_msg = format!(
+                                        "Failed to serialize chat completion chunk. Reason: {}",
+                                        e
+                                    );
+
+                                    #[cfg(feature = "logging")]
+                                    error!(target: "llama_core", "{}", &err_msg);
+
+                                    LlamaCoreError::Operation(err_msg)
+                                })?;
+
+                            Ok(format!("data: {}\n\n", chunk_str))
+                        }
+                        Err(wasmedge_wasi_nn::Error::BackendError(
+                            wasmedge_wasi_nn::BackendError::EndOfSequence,
+                        )) => {
+                            match stream_state {
+                                StreamState::Usage => {
+                                    *stream_state = StreamState::Done;
+
+                                    // retrieve the number of prompt and completion tokens
+                                    let token_info = get_token_info_by_graph(graph)?;
+
+                                    let usage = Some(Usage {
+                                        prompt_tokens: token_info.prompt_tokens,
+                                        completion_tokens: token_info.completion_tokens,
+                                        total_tokens: token_info.prompt_tokens
+                                            + token_info.completion_tokens,
+                                    });
+
+                                    #[cfg(feature = "logging")]
+                                    info!(target: "llama_core", "token_info: {} prompt tokens, {} completion tokens", token_info.prompt_tokens, token_info.completion_tokens);
+
+                                    let created = SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .map_err(|e| {
+                                            let err_msg = format!(
+                                                "Failed to get the current time. Reason: {}",
+                                                e
+                                            );
+
+                                            #[cfg(feature = "logging")]
+                                            error!(target: "llama_core", "{}", &err_msg);
+
+                                            LlamaCoreError::Operation(err_msg)
+                                        })?;
+
+                                    let chat_completion_chunk = ChatCompletionChunk {
+                                        id,
+                                        object: "chat.completion.chunk".to_string(),
+                                        created: created.as_secs(),
+                                        model: graph.name().to_owned(),
+                                        system_fingerprint: "fp_44709d6fcb".to_string(),
+                                        choices: vec![],
+                                        usage,
+                                    };
+
+                                    // serialize chat completion chunk
+                                    let chunk_str = serde_json::to_string(&chat_completion_chunk)
+                                        .map_err(|e| {
+                                        let err_msg = format!(
+                                            "Failed to serialize chat completion chunk. Reason: {}",
+                                            e
+                                        );
+
+                                        #[cfg(feature = "logging")]
+                                        error!(target: "llama_core", "{}", &err_msg);
+
+                                        LlamaCoreError::Operation(err_msg)
+                                    })?;
+
+                                    Ok(format!("data: {}\n\n", chunk_str))
+                                }
+                                StreamState::Done => {
+                                    *stream_state = StreamState::EndOfSequence;
+
+                                    Ok("data: [DONE]\n\n".to_string())
+                                }
+                                StreamState::EndOfSequence => {
+                                    // clear context
+                                    if let Err(e) = graph.finish_single() {
+                                        let err_msg = format!(
+                                            "Failed to clean up the context. Reason: {}",
+                                            e
+                                        );
+
+                                        #[cfg(feature = "logging")]
+                                        error!(target: "llama_core", "{}", &err_msg);
+
+                                        return Err(LlamaCoreError::Backend(
+                                            BackendError::FinishSingle(err_msg),
+                                        ));
+                                    }
+
+                                    Ok("[GGML] End of sequence".to_string())
+                                }
+                            }
+                        }
+                        Err(wasmedge_wasi_nn::Error::BackendError(
+                            wasmedge_wasi_nn::BackendError::ContextFull,
+                        )) => {
+                            match context_full_state {
+                                ContextFullState::Message => {
+                                    match include_usage {
+                                        true => *context_full_state = ContextFullState::Usage,
+                                        false => *context_full_state = ContextFullState::Done,
+                                    }
+
+                                    let created = SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .map_err(|e| {
+                                            let err_msg = format!(
+                                                "Failed to get the current time. Reason: {}",
+                                                e
+                                            );
+
+                                            #[cfg(feature = "logging")]
+                                            error!(target: "llama_core", "{}", &err_msg);
+
+                                            LlamaCoreError::Operation(err_msg)
+                                        })?;
+
+                                    let chat_completion_chunk = ChatCompletionChunk {
+                                        id,
+                                        object: "chat.completion.chunk".to_string(),
+                                        created: created.as_secs(),
+                                        model: graph.name().to_owned(),
+                                        system_fingerprint: "fp_44709d6fcb".to_string(),
+                                        choices: vec![ChatCompletionChunkChoice {
+                                            index: 0,
+                                            delta: ChatCompletionChunkChoiceDelta {
+                                                role: Some(ChatCompletionRole::Assistant),
+                                                content: Some(
+                                                    "<|WASMEDGE-GGML-CONTEXT-FULL|>".to_string(),
+                                                ),
+                                                function_call: None,
+                                                tool_calls: None,
+                                            },
+                                            logprobs: None,
+                                            finish_reason: Some(FinishReason::length),
+                                        }],
+                                        usage: None,
+                                    };
+
+                                    // serialize chat completion chunk
+                                    let chunk_str = serde_json::to_string(&chat_completion_chunk)
+                                        .map_err(|e| {
+                                        let err_msg = format!(
+                                            "Failed to serialize chat completion chunk. Reason: {}",
+                                            e
+                                        );
+
+                                        #[cfg(feature = "logging")]
+                                        error!(target: "llama_core", "{}", &err_msg);
+
+                                        LlamaCoreError::Operation(err_msg)
+                                    })?;
+
+                                    Ok(format!("data: {}\n\n", chunk_str))
+                                }
+                                ContextFullState::Usage => {
+                                    *context_full_state = ContextFullState::Done;
+
+                                    // retrieve the number of prompt and completion tokens
+                                    let token_info = get_token_info_by_graph(graph)?;
+
+                                    let usage = Some(Usage {
+                                        prompt_tokens: token_info.prompt_tokens,
+                                        completion_tokens: token_info.completion_tokens,
+                                        total_tokens: token_info.prompt_tokens
+                                            + token_info.completion_tokens,
+                                    });
+
+                                    let created = SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .map_err(|e| {
+                                            let err_msg = format!(
+                                                "Failed to get the current time. Reason: {}",
+                                                e
+                                            );
+
+                                            #[cfg(feature = "logging")]
+                                            error!(target: "llama_core", "{}", &err_msg);
+
+                                            LlamaCoreError::Operation(err_msg)
+                                        })?;
+
+                                    let chat_completion_chunk = ChatCompletionChunk {
+                                        id,
+                                        object: "chat.completion.chunk".to_string(),
+                                        created: created.as_secs(),
+                                        model: graph.name().to_owned(),
+                                        system_fingerprint: "fp_44709d6fcb".to_string(),
+                                        choices: vec![],
+                                        usage,
+                                    };
+
+                                    // serialize chat completion chunk
+                                    let chunk_str = serde_json::to_string(&chat_completion_chunk)
+                                        .map_err(|e| {
+                                        let err_msg = format!(
+                                            "Failed to serialize chat completion chunk. Reason: {}",
+                                            e
+                                        );
+
+                                        #[cfg(feature = "logging")]
+                                        error!(target: "llama_core", "{}", &err_msg);
+
+                                        LlamaCoreError::Operation(err_msg)
+                                    })?;
+
+                                    Ok(format!("data: {}\n\n", chunk_str))
+                                }
+                                ContextFullState::Done => {
+                                    *context_full_state = ContextFullState::EndOfSequence;
+
+                                    Ok("data: [DONE]\n\n".to_string())
+                                }
+                                ContextFullState::EndOfSequence => {
+                                    // clear context
+                                    if let Err(e) = graph.finish_single() {
+                                        let err_msg = format!(
+                                            "Failed to clean up the context. Reason: {}",
+                                            e
+                                        );
+
+                                        #[cfg(feature = "logging")]
+                                        error!(target: "llama_core", "{}", &err_msg);
+
+                                        return Err(LlamaCoreError::Backend(
+                                            BackendError::FinishSingle(err_msg),
+                                        ));
+                                    }
+
+                                    Ok("[GGML] End of sequence".to_string())
+                                }
+                            }
+                        }
+                        Err(wasmedge_wasi_nn::Error::BackendError(
+                            wasmedge_wasi_nn::BackendError::PromptTooLong,
+                        )) => {
+                            match prompt_too_long_state {
+                                PromptTooLongState::Message => {
+                                    match include_usage {
+                                        true => *prompt_too_long_state = PromptTooLongState::Usage,
+                                        false => *prompt_too_long_state = PromptTooLongState::Done,
+                                    }
+
+                                    let created = SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .map_err(|e| {
+                                            let err_msg = format!(
+                                                "Failed to get the current time. Reason: {}",
+                                                e
+                                            );
+
+                                            #[cfg(feature = "logging")]
+                                            error!(target: "llama_core", "{}", &err_msg);
+
+                                            LlamaCoreError::Operation(err_msg)
+                                        })?;
+
+                                    let chat_completion_chunk = ChatCompletionChunk {
+                                        id,
+                                        object: "chat.completion.chunk".to_string(),
+                                        created: created.as_secs(),
+                                        model: graph.name().to_owned(),
+                                        system_fingerprint: "fp_44709d6fcb".to_string(),
+                                        choices: vec![ChatCompletionChunkChoice {
+                                            index: 0,
+                                            delta: ChatCompletionChunkChoiceDelta {
+                                                role: Some(ChatCompletionRole::Assistant),
+                                                content: None,
+                                                function_call: None,
+                                                tool_calls: None,
+                                            },
+                                            logprobs: None,
+                                            finish_reason: Some(FinishReason::length),
+                                        }],
+                                        usage: None,
+                                    };
+
+                                    // serialize chat completion chunk
+                                    let chunk_str = serde_json::to_string(&chat_completion_chunk)
+                                        .map_err(|e| {
+                                        let err_msg = format!(
+                                            "Failed to serialize chat completion chunk. Reason: {}",
+                                            e
+                                        );
+
+                                        #[cfg(feature = "logging")]
+                                        error!(target: "llama_core", "{}", &err_msg);
+
+                                        LlamaCoreError::Operation(err_msg)
+                                    })?;
+
+                                    Ok(format!("data: {}\n\n", chunk_str))
+                                }
+                                PromptTooLongState::Usage => {
+                                    *prompt_too_long_state = PromptTooLongState::Done;
+
+                                    // retrieve the number of prompt and completion tokens
+                                    let token_info = get_token_info_by_graph(graph)?;
+
+                                    let usage = Some(Usage {
+                                        prompt_tokens: token_info.prompt_tokens,
+                                        completion_tokens: token_info.completion_tokens,
+                                        total_tokens: token_info.prompt_tokens
+                                            + token_info.completion_tokens,
+                                    });
+
+                                    let created = SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .map_err(|e| {
+                                            let err_msg = format!(
+                                                "Failed to get the current time. Reason: {}",
+                                                e
+                                            );
+
+                                            #[cfg(feature = "logging")]
+                                            error!(target: "llama_core", "{}", &err_msg);
+
+                                            LlamaCoreError::Operation(err_msg)
+                                        })?;
+
+                                    let chat_completion_chunk = ChatCompletionChunk {
+                                        id,
+                                        object: "chat.completion.chunk".to_string(),
+                                        created: created.as_secs(),
+                                        model: graph.name().to_owned(),
+                                        system_fingerprint: "fp_44709d6fcb".to_string(),
+                                        choices: vec![],
+                                        usage,
+                                    };
+
+                                    // serialize chat completion chunk
+                                    let chunk_str = serde_json::to_string(&chat_completion_chunk)
+                                        .map_err(|e| {
+                                        let err_msg = format!(
+                                            "Failed to serialize chat completion chunk. Reason: {}",
+                                            e
+                                        );
+
+                                        #[cfg(feature = "logging")]
+                                        error!(target: "llama_core", "{}", &err_msg);
+
+                                        LlamaCoreError::Operation(err_msg)
+                                    })?;
+
+                                    Ok(format!("data: {}\n\n", chunk_str))
+                                }
+                                PromptTooLongState::Done => {
+                                    *prompt_too_long_state = PromptTooLongState::EndOfSequence;
+
+                                    Ok("data: [DONE]\n\n".to_string())
+                                }
+                                PromptTooLongState::EndOfSequence => {
+                                    // clear context
+                                    if let Err(e) = graph.finish_single() {
+                                        let err_msg = format!(
+                                            "Failed to clean up the context. Reason: {}",
+                                            e
+                                        );
+
+                                        #[cfg(feature = "logging")]
+                                        error!(target: "llama_core", "{}", &err_msg);
+
+                                        return Err(LlamaCoreError::Backend(
+                                            BackendError::FinishSingle(err_msg),
+                                        ));
+                                    }
+
+                                    Ok("[GGML] End of sequence".to_string())
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            // clear context
+                            if let Err(e) = graph.finish_single() {
+                                let err_msg =
+                                    format!("Failed to clean up the context. Reason: {}", e);
+
+                                #[cfg(feature = "logging")]
+                                error!(target: "llama_core", "{}", &err_msg);
+
+                                return Err(LlamaCoreError::Backend(BackendError::FinishSingle(
+                                    err_msg,
+                                )));
+                            }
+
+                            let err_msg =
+                                format!("Failed to compute the chat completion. Reason: {}", e);
+
+                            #[cfg(feature = "logging")]
+                            error!(target: "llama_core", "{}", &err_msg);
+
+                            Err(LlamaCoreError::Backend(BackendError::ComputeSingle(
+                                err_msg,
+                            )))
+                        }
+                    }
+                }
+                None => {
+                    let err_msg = "There is no model available in the chat graphs.";
+
+                    #[cfg(feature = "logging")]
+                    error!(target: "llama_core", "{}", &err_msg);
+
+                    Err(LlamaCoreError::Operation(err_msg.into()))
+                }
+            }
+        }
+    }
 }

--- a/api-server/llama-core/src/lib.rs
+++ b/api-server/llama-core/src/lib.rs
@@ -80,7 +80,8 @@ pub struct Metadata {
     // pub main_gpu: u64,
     // #[serde(rename = "tensor-split")]
     // pub tensor_split: String,
-
+    #[serde(skip_serializing_if = "Option::is_none", rename = "use-mmap")]
+    pub use_mmap: Option<bool>,
     // * Context parameters (used by the llama context):
     #[serde(rename = "ctx-size")]
     pub ctx_size: u64,
@@ -114,6 +115,7 @@ impl Default for Metadata {
             mmproj: None,
             image: None,
             n_gpu_layers: 100,
+            use_mmap: Some(true),
             ctx_size: 512,
             batch_size: 512,
             temperature: 1.0,
@@ -199,6 +201,11 @@ impl MetadataBuilder {
 
     pub fn with_n_gpu_layers(mut self, n: u64) -> Self {
         self.metadata.n_gpu_layers = n;
+        self
+    }
+
+    pub fn disable_mmap(mut self, disable: Option<bool>) -> Self {
+        self.metadata.use_mmap = disable.map(|v| !v);
         self
     }
 

--- a/api-server/llama-core/src/utils.rs
+++ b/api-server/llama-core/src/utils.rs
@@ -160,7 +160,7 @@ pub(crate) fn get_output_buffer(graph: &Graph, index: usize) -> Result<Vec<u8>, 
     let mut output_buffer: Vec<u8> = Vec::with_capacity(MAX_BUFFER_SIZE);
 
     let output_size: usize = graph.get_output(index, &mut output_buffer).map_err(|e| {
-        let err_msg = format!("Fail to get plugin metadata. {msg}", msg = e);
+        let err_msg = format!("Fail to get the generated output tensor. {msg}", msg = e);
 
         #[cfg(feature = "logging")]
         error!(target: "llama-core", "{}", &err_msg);

--- a/chat/Cargo.toml
+++ b/chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-chat"
-version = "0.11.3"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/chat/Cargo.toml
+++ b/chat/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 chat-prompts = { path = "../api-server/chat-prompts" }
 endpoints = { path = "../api-server/endpoints" }
 llama-core = { path = "../api-server/llama-core" }
-wasmedge-wasi-nn = "0.7.0"
+wasmedge-wasi-nn = "0.7.1"
 clap = { version = "4.4.6", features = ["cargo"] }
 once_cell = "1.18"
 serde = { version = "1.0", features = ["derive"] }

--- a/chat/README.md
+++ b/chat/README.md
@@ -125,6 +125,8 @@ Options:
           Number of tokens to predict [default: 1024]
   -g, --n-gpu-layers <N_GPU_LAYERS>
           Number of layers to run on the GPU [default: 100]
+  --no-mmap
+          Disable memory mapping for file access of chat models
   -b, --batch-size <BATCH_SIZE>
           Batch size for prompt processing [default: 512]
       --temp <TEMP>

--- a/chat/src/main.rs
+++ b/chat/src/main.rs
@@ -28,6 +28,9 @@ struct Cli {
     /// Number of layers to run on the GPU
     #[arg(short = 'g', long, default_value = "100")]
     n_gpu_layers: u64,
+    /// Disable memory mapping for file access of chat models
+    #[arg(long)]
+    no_mmap: Option<bool>,
     /// Batch size for prompt processing
     #[arg(short, long, default_value = "512")]
     batch_size: u64,
@@ -112,6 +115,13 @@ async fn main() -> anyhow::Result<()> {
         "[INFO] Number of layers to run on the GPU: {}",
         &cli.n_gpu_layers
     ));
+    // no_mmap
+    if let Some(no_mmap) = &cli.no_mmap {
+        log(format!(
+            "[INFO] Disable memory mapping for file access of chat models : {}",
+            &no_mmap
+        ));
+    }
     // batch size
     log(format!(
         "[INFO] Batch size for prompt processing: {}",
@@ -151,6 +161,7 @@ async fn main() -> anyhow::Result<()> {
         .with_ctx_size(cli.ctx_size)
         .with_n_predict(cli.n_predict)
         .with_n_gpu_layers(cli.n_gpu_layers)
+        .disable_mmap(cli.no_mmap)
         .with_batch_size(cli.batch_size)
         .with_repeat_penalty(cli.repeat_penalty)
         .with_presence_penalty(cli.presence_penalty)
@@ -382,6 +393,8 @@ pub struct Metadata {
     // pub main_gpu: u64,
     // #[serde(rename = "tensor-split")]
     // pub tensor_split: String,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "use-mmap")]
+    use_mmap: Option<bool>,
 
     // * Context parameters (used by the llama context):
     #[serde(rename = "ctx-size")]

--- a/simple/Cargo.toml
+++ b/simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-simple"
-version = "0.11.3"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/simple/README.md
+++ b/simple/README.md
@@ -50,6 +50,8 @@ wasmedge --dir .:. --nn-preload default:GGML:AUTO:llama-2-7b-chat.Q5_K_M.gguf ll
             Number of tokens to predict [default: 1024]
     -g, --n-gpu-layers <N_GPU_LAYERS>
             Number of layers to run on the GPU [default: 100]
+        --no-mmap
+            Disable memory mapping for file access of chat models
     -b, --batch-size <BATCH_SIZE>
             Batch size for prompt processing [default: 4096]
     -r, --reverse-prompt <REVERSE_PROMPT>

--- a/simple/src/main.rs
+++ b/simple/src/main.rs
@@ -52,6 +52,13 @@ fn main() -> Result<(), String> {
                 .default_value("100"),
         )
         .arg(
+            Arg::new("no_mmap")
+                .long("no-mmap")
+                .value_name("NO_MMAP")
+                .help("Disable memory mapping for file access of chat models")
+                .action(ArgAction::SetFalse),
+        )
+        .arg(
             Arg::new("batch_size")
                 .short('b')
                 .long("batch-size")
@@ -107,6 +114,11 @@ fn main() -> Result<(), String> {
         n = n_gpu_layers
     );
     options.n_gpu_layers = *n_gpu_layers as u64;
+
+    // no_mmap
+    let no_mmap = matches.get_flag("no_mmap");
+    println!("[INFO] no mmap: {nommap}", nommap = !no_mmap);
+    options.use_mmap = Some(!no_mmap);
 
     // batch size
     let batch_size = matches.get_one::<u32>("batch_size").unwrap();
@@ -183,6 +195,8 @@ struct Options {
     n_predict: u64,
     #[serde(rename = "n-gpu-layers")]
     n_gpu_layers: u64,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "use-mmap")]
+    use_mmap: Option<bool>,
     #[serde(rename = "batch-size")]
     batch_size: u64,
     #[serde(skip_serializing_if = "Option::is_none", rename = "reverse-prompt")]


### PR DESCRIPTION
Major changes:

- llama-api-server
  - (BREAKING) Update the response data of the `/v1/info` endpoint
  - New `--no-mmap` CLI option to enable/disable the `mmap` feature of `WasmEdge ggml plugin` (#176)

- llama-core
  - Introduce custom stream `ChatStream`
  - Improve the length of cached encodings to support emoji (#187)

- endpoints
  - Introduce `audio` mod to support OpenAI `translation`, `speech`, and `transcription`.
  