### PR TITLE
Release 0.12.3

### DIFF
--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 endpoints = { path = "endpoints", version = "^0.10" }
-chat-prompts = { path = "chat-prompts", version = "^0.9" }
+chat-prompts = { path = "chat-prompts", version = "^0.10" }
 thiserror = "1"
 uuid = { version = "1.4", features = ["v4", "fast-rng", "macro-diagnostics"] }
 clap = { version = "4.4.6", features = ["cargo", "derive"] }

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -185,7 +185,7 @@ Here is the response from LlamaEdge API server:
 
 `/v1/files` endpoint is used for uploading text and markdown files to LlamaEdge API server.
 
-<details> <summary> Example </summary>
+<details> <summary> Example: Upload files </summary>
 
 The following command upload a text file [paris.txt](https://huggingface.co/datasets/gaianet/paris/raw/main/paris.txt) to the API server via the `/v1/files` endpoint:
 
@@ -209,6 +209,79 @@ If the command is successful, you should see the similar output as below in your
 The `id` and `filename` fields are important for the next step, for example, to segment the uploaded file to chunks for computing embeddings.
 
 If you'd like to build a RAG chatbot, it's strongly recommended to visit [LlamaEdge-RAG API Server](https://github.com/LlamaEdge/rag-api-server).
+
+</details>
+
+<details> <summary> Example: List files </summary>
+
+The following command lists all files on the server via the `/v1/files` endpoint:
+
+```bash
+curl -X GET http://127.0.0.1:8080/v1/files
+```
+
+If the command is successful, you should see the similar output as below in your terminal:
+
+```bash
+[
+    {
+        "id": "33d9188d-5060-4141-8c52-ae148fd15f6a",
+        "bytes": 17039,
+        "created_at": 1718296362,
+        "filename": "test-123.m4a",
+        "object": "file",
+        "purpose": "assistants"
+    },
+    {
+        "id": "8c6439da-df59-4b9a-bb5e-dba4b2f23c04",
+        "bytes": 17039,
+        "created_at": 1718294169,
+        "filename": "test-123.m4a",
+        "object": "file",
+        "purpose": "assistants"
+    },
+    {
+        "id": "6c601277-7deb-44c9-bfb3-57ce9da856c9",
+        "bytes": 17039,
+        "created_at": 1718296350,
+        "filename": "test-123.m4a",
+        "object": "file",
+        "purpose": "assistants"
+    },
+    {
+        "id": "137b1ea2-c01d-44da-83ad-6b4aa2ff71de",
+        "bytes": 244596,
+        "created_at": 1718337557,
+        "filename": "audio16k.wav",
+        "object": "file",
+        "purpose": "assistants"
+    },
+    {
+        "id": "21fde6a7-18dc-4d42-a5bb-1a27d4b7a32e",
+        "bytes": 17039,
+        "created_at": 1718294739,
+        "filename": "test-123.m4a",
+        "object": "file",
+        "purpose": "assistants"
+    },
+    {
+        "id": "b892bc81-35e9-44a6-8c01-ae915c1d3832",
+        "bytes": 2161,
+        "created_at": 1715832065,
+        "filename": "paris.txt",
+        "object": "file",
+        "purpose": "assistants"
+    },
+    {
+        "id": "6a6d8046-fd98-410a-b70e-0a0142ec9a39",
+        "bytes": 17039,
+        "created_at": 1718332593,
+        "filename": "test-123.m4a",
+        "object": "file",
+        "purpose": "assistants"
+    }
+]
+```
 
 </details>
 

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -227,7 +227,7 @@ If the command is successful, you should see the similar output as below in your
     "object": "list",
     "data": [
         {
-            "id": "33d9188d-5060-4141-8c52-ae148fd15f6a",
+            "id": "file_33d9188d-5060-4141-8c52-ae148fd15f6a",
             "bytes": 17039,
             "created_at": 1718296362,
             "filename": "test-123.m4a",
@@ -235,7 +235,7 @@ If the command is successful, you should see the similar output as below in your
             "purpose": "assistants"
         },
         {
-            "id": "8c6439da-df59-4b9a-bb5e-dba4b2f23c04",
+            "id": "file_8c6439da-df59-4b9a-bb5e-dba4b2f23c04",
             "bytes": 17039,
             "created_at": 1718294169,
             "filename": "test-123.m4a",
@@ -243,7 +243,7 @@ If the command is successful, you should see the similar output as below in your
             "purpose": "assistants"
         },
         {
-            "id": "6c601277-7deb-44c9-bfb3-57ce9da856c9",
+            "id": "file_6c601277-7deb-44c9-bfb3-57ce9da856c9",
             "bytes": 17039,
             "created_at": 1718296350,
             "filename": "test-123.m4a",
@@ -251,7 +251,7 @@ If the command is successful, you should see the similar output as below in your
             "purpose": "assistants"
         },
         {
-            "id": "137b1ea2-c01d-44da-83ad-6b4aa2ff71de",
+            "id": "file_137b1ea2-c01d-44da-83ad-6b4aa2ff71de",
             "bytes": 244596,
             "created_at": 1718337557,
             "filename": "audio16k.wav",
@@ -259,7 +259,7 @@ If the command is successful, you should see the similar output as below in your
             "purpose": "assistants"
         },
         {
-            "id": "21fde6a7-18dc-4d42-a5bb-1a27d4b7a32e",
+            "id": "file_21fde6a7-18dc-4d42-a5bb-1a27d4b7a32e",
             "bytes": 17039,
             "created_at": 1718294739,
             "filename": "test-123.m4a",
@@ -267,7 +267,7 @@ If the command is successful, you should see the similar output as below in your
             "purpose": "assistants"
         },
         {
-            "id": "b892bc81-35e9-44a6-8c01-ae915c1d3832",
+            "id": "file_b892bc81-35e9-44a6-8c01-ae915c1d3832",
             "bytes": 2161,
             "created_at": 1715832065,
             "filename": "paris.txt",
@@ -275,7 +275,7 @@ If the command is successful, you should see the similar output as below in your
             "purpose": "assistants"
         },
         {
-            "id": "6a6d8046-fd98-410a-b70e-0a0142ec9a39",
+            "id": "file_6a6d8046-fd98-410a-b70e-0a0142ec9a39",
             "bytes": 17039,
             "created_at": 1718332593,
             "filename": "test-123.m4a",
@@ -293,14 +293,14 @@ If the command is successful, you should see the similar output as below in your
 The following command retrieves information about a specific file on the server via the `/v1/files/{file_id}` endpoint:
 
 ```bash
-curl -X GET http://localhost:10086/v1/files/b892bc81-35e9-44a6-8c01-ae915c1d3832
+curl -X GET http://localhost:10086/v1/files/file_b892bc81-35e9-44a6-8c01-ae915c1d3832
 ```
 
 If the command is successful, you should see the similar output as below in your terminal:
 
 ```bash
 {
-    "id": "b892bc81-35e9-44a6-8c01-ae915c1d3832",
+    "id": "file_b892bc81-35e9-44a6-8c01-ae915c1d3832",
     "bytes": 2161,
     "created_at": 1715832065,
     "filename": "paris.txt",
@@ -316,14 +316,14 @@ If the command is successful, you should see the similar output as below in your
 The following command deletes a specific file on the server via the `/v1/files/{file_id}` endpoint:
 
 ```bash
-curl -X DELETE http://localhost:10086/v1/files/6a6d8046-fd98-410a-b70e-0a0142ec9a39
+curl -X DELETE http://localhost:10086/v1/files/file_6a6d8046-fd98-410a-b70e-0a0142ec9a39
 ```
 
 If the command is successful, you should see the similar output as below in your terminal:
 
 ```bash
 {
-    "id": "6a6d8046-fd98-410a-b70e-0a0142ec9a39",
+    "id": "file_6a6d8046-fd98-410a-b70e-0a0142ec9a39",
     "object": "file",
     "deleted": true
 }

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -117,7 +117,7 @@ The command above starts the API server on the default socket address. Besides, 
 You can use `curl` to test it on a new terminal:
 
 ```bash
-curl -X POST http://localhost:8080/v1/models -H 'accept:application/json'
+curl -X GET http://localhost:8080/v1/models -H 'accept:application/json'
 ```
 
 If the command is successful, you should see the similar output as below in your terminal:

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -285,6 +285,29 @@ If the command is successful, you should see the similar output as below in your
 
 </details>
 
+<details> <summary> Example: Retrieve information about a specific file </summary>
+
+The following command retrieves information about a specific file on the server via the `/v1/files/{file_id}` endpoint:
+
+```bash
+curl -X GET http://localhost:10086/v1/files/b892bc81-35e9-44a6-8c01-ae915c1d3832
+```
+
+If the command is successful, you should see the similar output as below in your terminal:
+
+```bash
+{
+    "id": "b892bc81-35e9-44a6-8c01-ae915c1d3832",
+    "bytes": 2161,
+    "created_at": 1715832065,
+    "filename": "paris.txt",
+    "object": "file",
+    "purpose": "assistants"
+}
+```
+
+</details>
+
 ### `/v1/chunks` endpoint
 
 To segment the uploaded file to chunks for computing embeddings, use the `/v1/chunks` API.

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -223,64 +223,67 @@ curl -X GET http://127.0.0.1:8080/v1/files
 If the command is successful, you should see the similar output as below in your terminal:
 
 ```bash
-[
-    {
-        "id": "33d9188d-5060-4141-8c52-ae148fd15f6a",
-        "bytes": 17039,
-        "created_at": 1718296362,
-        "filename": "test-123.m4a",
-        "object": "file",
-        "purpose": "assistants"
-    },
-    {
-        "id": "8c6439da-df59-4b9a-bb5e-dba4b2f23c04",
-        "bytes": 17039,
-        "created_at": 1718294169,
-        "filename": "test-123.m4a",
-        "object": "file",
-        "purpose": "assistants"
-    },
-    {
-        "id": "6c601277-7deb-44c9-bfb3-57ce9da856c9",
-        "bytes": 17039,
-        "created_at": 1718296350,
-        "filename": "test-123.m4a",
-        "object": "file",
-        "purpose": "assistants"
-    },
-    {
-        "id": "137b1ea2-c01d-44da-83ad-6b4aa2ff71de",
-        "bytes": 244596,
-        "created_at": 1718337557,
-        "filename": "audio16k.wav",
-        "object": "file",
-        "purpose": "assistants"
-    },
-    {
-        "id": "21fde6a7-18dc-4d42-a5bb-1a27d4b7a32e",
-        "bytes": 17039,
-        "created_at": 1718294739,
-        "filename": "test-123.m4a",
-        "object": "file",
-        "purpose": "assistants"
-    },
-    {
-        "id": "b892bc81-35e9-44a6-8c01-ae915c1d3832",
-        "bytes": 2161,
-        "created_at": 1715832065,
-        "filename": "paris.txt",
-        "object": "file",
-        "purpose": "assistants"
-    },
-    {
-        "id": "6a6d8046-fd98-410a-b70e-0a0142ec9a39",
-        "bytes": 17039,
-        "created_at": 1718332593,
-        "filename": "test-123.m4a",
-        "object": "file",
-        "purpose": "assistants"
-    }
-]
+{
+    "object": "list",
+    "data": [
+        {
+            "id": "33d9188d-5060-4141-8c52-ae148fd15f6a",
+            "bytes": 17039,
+            "created_at": 1718296362,
+            "filename": "test-123.m4a",
+            "object": "file",
+            "purpose": "assistants"
+        },
+        {
+            "id": "8c6439da-df59-4b9a-bb5e-dba4b2f23c04",
+            "bytes": 17039,
+            "created_at": 1718294169,
+            "filename": "test-123.m4a",
+            "object": "file",
+            "purpose": "assistants"
+        },
+        {
+            "id": "6c601277-7deb-44c9-bfb3-57ce9da856c9",
+            "bytes": 17039,
+            "created_at": 1718296350,
+            "filename": "test-123.m4a",
+            "object": "file",
+            "purpose": "assistants"
+        },
+        {
+            "id": "137b1ea2-c01d-44da-83ad-6b4aa2ff71de",
+            "bytes": 244596,
+            "created_at": 1718337557,
+            "filename": "audio16k.wav",
+            "object": "file",
+            "purpose": "assistants"
+        },
+        {
+            "id": "21fde6a7-18dc-4d42-a5bb-1a27d4b7a32e",
+            "bytes": 17039,
+            "created_at": 1718294739,
+            "filename": "test-123.m4a",
+            "object": "file",
+            "purpose": "assistants"
+        },
+        {
+            "id": "b892bc81-35e9-44a6-8c01-ae915c1d3832",
+            "bytes": 2161,
+            "created_at": 1715832065,
+            "filename": "paris.txt",
+            "object": "file",
+            "purpose": "assistants"
+        },
+        {
+            "id": "6a6d8046-fd98-410a-b70e-0a0142ec9a39",
+            "bytes": 17039,
+            "created_at": 1718332593,
+            "filename": "test-123.m4a",
+            "object": "file",
+            "purpose": "assistants"
+        }
+    ]
+}
 ```
 
 </details>

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -311,6 +311,26 @@ If the command is successful, you should see the similar output as below in your
 
 </details>
 
+<details> <summary> Example: Delete a specific file </summary>
+
+The following command deletes a specific file on the server via the `/v1/files/{file_id}` endpoint:
+
+```bash
+curl -X DELETE http://localhost:10086/v1/files/6a6d8046-fd98-410a-b70e-0a0142ec9a39
+```
+
+If the command is successful, you should see the similar output as below in your terminal:
+
+```bash
+{
+    "id": "6a6d8046-fd98-410a-b70e-0a0142ec9a39",
+    "object": "file",
+    "deleted": true
+}
+```
+
+</details>
+
 ### `/v1/chunks` endpoint
 
 To segment the uploaded file to chunks for computing embeddings, use the `/v1/chunks` API.

--- a/api-server/chat-prompts/Cargo.toml
+++ b/api-server/chat-prompts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chat-prompts"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/api-server/chat-prompts/README.md
+++ b/api-server/chat-prompts/README.md
@@ -86,6 +86,21 @@ The available prompt templates are listed below:
 
   - Example: [second-state/Deepseek-LLM-7B-Chat-GGUF](https://huggingface.co/second-state/Deepseek-LLM-7B-Chat-GGUF)
 
+- `deepseek-chat-2`
+  - Prompt string
+
+    ```text
+    <|begin_of_sentence|>{system_message}
+
+    User: {user_message_1}
+
+    Assistant: {assistant_message_1}<|end_of_sentence|>User: {user_message_2}
+
+    Assistant:
+    ```
+
+  - Example: [second-state/DeepSeek-Coder-V2-Lite-Instruct-GGUF](https://huggingface.co/second-state/DeepSeek-Coder-V2-Lite-Instruct-GGUF)
+
 - `deepseek-coder`
   - Prompt string
 
@@ -102,21 +117,6 @@ The available prompt templates are listed below:
     ```
 
   - Example: [second-state/Deepseek-Coder-6.7B-Instruct-GGUF](https://huggingface.co/second-state/Deepseek-Coder-6.7B-Instruct-GGUF)
-
-- `deepseek-coder-2`
-  - Prompt string
-
-    ```text
-    <｜begin▁of▁sentence｜>{system_message}
-
-    User: {user_message_1}
-
-    Assistant: {assistant_message_1}<｜end▁of▁sentence｜>User: {user_message_2}
-
-    Assistant:
-    ```
-
-  - Example: [second-state/DeepSeek-Coder-V2-Lite-Instruct-GGUF](https://huggingface.co/second-state/DeepSeek-Coder-V2-Lite-Instruct-GGUF)
 
 - `embedding`
   - Prompt string

--- a/api-server/chat-prompts/README.md
+++ b/api-server/chat-prompts/README.md
@@ -339,3 +339,15 @@ The available prompt templates are listed below:
     ```
 
   - Example: [second-state/Zephyr-7B-Beta-GGUF](https://huggingface.co/second-state/Zephyr-7B-Beta-GGUF)
+
+- `glm-4-chat`
+  - Prompt string
+
+    ```text
+    [gMASK]<|system|>
+    {system_message}<|user|>
+    {user_message_1}<|assistant|>
+    {assistant_message_1}
+    ```
+
+  - Example: [second-state/glm-4-9b-chat-GGUF](https://huggingface.co/second-state/glm-4-9b-chat-GGUF)

--- a/api-server/chat-prompts/src/chat/deepseek.rs
+++ b/api-server/chat-prompts/src/chat/deepseek.rs
@@ -195,3 +195,112 @@ impl BuildChatPrompt for DeepseekCoderPrompt {
         Ok(prompt)
     }
 }
+
+/// Generate prompts for the `DeepSeek-V2` models.
+#[derive(Debug, Default, Clone)]
+pub struct DeepseekChat2Prompt;
+impl DeepseekChat2Prompt {
+    /// Create a system prompt from a chat completion request message.
+    fn create_system_prompt(&self, message: &ChatCompletionSystemMessage) -> String {
+        let content = message.content();
+        match content.is_empty() {
+            true => String::from("<|begin▁of▁sentence|>You are an AI programming assistant, utilizing the DeepSeek Coder model, developed by DeepSeek Company, and you only answer questions related to computer science. For politically sensitive questions, security and privacy issues, and other non-computer science questions, you will refuse to answer."),
+            false => format!("<|begin▁of▁sentence|>{system_message}", system_message=content),
+        }
+    }
+
+    /// Create a user prompt from a chat completion request message.
+    fn append_user_message(
+        &self,
+        chat_history: impl AsRef<str>,
+        system_prompt: impl AsRef<str>,
+        message: &ChatCompletionUserMessage,
+    ) -> String {
+        let content = match message.content() {
+            ChatCompletionUserMessageContent::Text(text) => text.to_string(),
+            ChatCompletionUserMessageContent::Parts(parts) => {
+                let mut content = String::new();
+                for part in parts {
+                    if let ContentPart::Text(text_content) = part {
+                        content.push_str(text_content.text());
+                        content.push('\n');
+                    }
+                }
+                content
+            }
+        };
+
+        match chat_history.as_ref().is_empty() {
+            true => format!(
+                "{system_prompt}\n\nUser: {user_message}",
+                system_prompt = system_prompt.as_ref().trim(),
+                user_message = content.trim(),
+            ),
+            false => format!(
+                "{chat_history}User: {user_message}",
+                chat_history = chat_history.as_ref().trim(),
+                user_message = content.trim(),
+            ),
+        }
+    }
+
+    /// create an assistant prompt from a chat completion request message.
+    fn append_assistant_message(
+        &self,
+        chat_history: impl AsRef<str>,
+        message: &ChatCompletionAssistantMessage,
+    ) -> Result<String> {
+        let content = match message.content() {
+            Some(content) => content.to_string(),
+            // Note that the content is optional if `tool_calls` is specified.
+            None => match message.tool_calls().is_some() {
+                true => String::new(),
+                false => return Err(PromptError::NoAssistantMessage),
+            },
+        };
+
+        Ok(format!(
+            "{chat_histroy}\n\nAssistant: {assistant_message}<|end_of_sentence|>",
+            chat_histroy = chat_history.as_ref().trim(),
+            assistant_message = content.trim(),
+        ))
+    }
+}
+impl BuildChatPrompt for DeepseekChat2Prompt {
+    fn build(&self, messages: &mut Vec<ChatCompletionRequestMessage>) -> Result<String> {
+        if messages.is_empty() {
+            return Err(crate::error::PromptError::NoMessages);
+        }
+
+        // system prompt
+        let system_prompt = match messages[0] {
+            ChatCompletionRequestMessage::System(ref message) => {
+                self.create_system_prompt(message)
+            }
+            _ => String::from("<|begin▁of▁sentence|>You are an AI programming assistant, utilizing the DeepSeek Coder model, developed by DeepSeek Company, and you only answer questions related to computer science. For politically sensitive questions, security and privacy issues, and other non-computer science questions, you will refuse to answer."),
+        };
+
+        // append user/assistant messages
+        if messages.is_empty() {
+            return Err(crate::error::PromptError::NoMessages);
+        }
+
+        // append user/assistant messages
+        let mut prompt = String::new();
+        for message in messages {
+            match message {
+                ChatCompletionRequestMessage::User(message) => {
+                    prompt = self.append_user_message(&prompt, &system_prompt, message);
+                }
+                ChatCompletionRequestMessage::Assistant(message) => {
+                    prompt = self.append_assistant_message(&prompt, message)?;
+                }
+                _ => continue,
+            }
+        }
+
+        prompt.push_str("\n\nAssistant:");
+
+        Ok(prompt)
+    }
+}

--- a/api-server/chat-prompts/src/chat/glm.rs
+++ b/api-server/chat-prompts/src/chat/glm.rs
@@ -1,0 +1,108 @@
+use super::BuildChatPrompt;
+use crate::error::{PromptError, Result};
+use endpoints::chat::{
+    ChatCompletionAssistantMessage, ChatCompletionRequestMessage, ChatCompletionSystemMessage,
+    ChatCompletionUserMessage, ChatCompletionUserMessageContent, ContentPart,
+};
+
+/// Generate chat prompt for the `microsoft/phi-2` model.
+#[derive(Debug, Default, Clone)]
+pub struct Glm4ChatPrompt;
+impl Glm4ChatPrompt {
+    /// Create a system prompt from a chat completion request message.
+    fn create_system_prompt(&self, message: &ChatCompletionSystemMessage) -> String {
+        let content = message.content();
+        match content.is_empty() {
+            true => String::from("[gMASK]<|system|>\nYou are a friendly chatbot."),
+            false => format!("[gMASK]<|system|>\n{content}"),
+        }
+    }
+
+    /// Create a user prompt from a chat completion request message.
+    fn append_user_message(
+        &self,
+        chat_history: impl AsRef<str>,
+        system_prompt: impl AsRef<str>,
+        message: &ChatCompletionUserMessage,
+    ) -> String {
+        let content = match message.content() {
+            ChatCompletionUserMessageContent::Text(text) => text.to_string(),
+            ChatCompletionUserMessageContent::Parts(parts) => {
+                let mut content = String::new();
+                for part in parts {
+                    if let ContentPart::Text(text_content) = part {
+                        content.push_str(text_content.text());
+                        content.push('\n');
+                    }
+                }
+                content
+            }
+        };
+
+        match chat_history.as_ref().is_empty() {
+            true => format!(
+                "{system_prompt}<|user|>\n{user_message}",
+                system_prompt = system_prompt.as_ref().trim(),
+                user_message = content.trim(),
+            ),
+            false => format!(
+                "{chat_history}<|user|>\n{user_message}",
+                chat_history = chat_history.as_ref().trim(),
+                user_message = content.trim(),
+            ),
+        }
+    }
+
+    /// create an assistant prompt from a chat completion request message.
+    fn append_assistant_message(
+        &self,
+        chat_history: impl AsRef<str>,
+        message: &ChatCompletionAssistantMessage,
+    ) -> Result<String> {
+        let content = match message.content() {
+            Some(content) => content.to_string(),
+            // Note that the content is optional if `tool_calls` is specified.
+            None => match message.tool_calls().is_some() {
+                true => String::new(),
+                false => return Err(PromptError::NoAssistantMessage),
+            },
+        };
+
+        Ok(format!(
+            "{chat_history}<|assistant|>\n{assistant_message}",
+            chat_history = chat_history.as_ref().trim(),
+            assistant_message = content.trim(),
+        ))
+    }
+}
+impl BuildChatPrompt for Glm4ChatPrompt {
+    fn build(&self, messages: &mut Vec<ChatCompletionRequestMessage>) -> Result<String> {
+        if messages.is_empty() {
+            return Err(crate::error::PromptError::NoMessages);
+        }
+
+        // system prompt
+        let system_prompt = match messages[0] {
+            ChatCompletionRequestMessage::System(ref message) => self.create_system_prompt(message),
+            _ => String::from("[gMASK]<|system|>\nYou are a friendly chatbot."),
+        };
+
+        // append user/assistant messages
+        let mut prompt = String::new();
+        for message in messages {
+            match message {
+                ChatCompletionRequestMessage::User(message) => {
+                    prompt = self.append_user_message(&prompt, &system_prompt, message);
+                }
+                ChatCompletionRequestMessage::Assistant(message) => {
+                    prompt = self.append_assistant_message(&prompt, message)?;
+                }
+                _ => continue,
+            }
+        }
+
+        prompt.push_str("<|assistant|>");
+
+        Ok(prompt)
+    }
+}

--- a/api-server/chat-prompts/src/chat/mod.rs
+++ b/api-server/chat-prompts/src/chat/mod.rs
@@ -73,6 +73,7 @@ pub enum ChatPrompt {
     NeuralChatPrompt,
     DeepseekChatPrompt,
     DeepseekCoderPrompt,
+    DeepseekChat2Prompt,
     SolarInstructPrompt,
     Phi2ChatPrompt,
     Phi2InstructPrompt,
@@ -116,6 +117,9 @@ impl From<PromptTemplateType> for ChatPrompt {
             PromptTemplateType::DeepseekChat => ChatPrompt::DeepseekChatPrompt(DeepseekChatPrompt),
             PromptTemplateType::DeepseekCoder => {
                 ChatPrompt::DeepseekCoderPrompt(DeepseekCoderPrompt)
+            }
+            PromptTemplateType::DeepseekChat2 => {
+                ChatPrompt::DeepseekChat2Prompt(DeepseekChat2Prompt)
             }
             PromptTemplateType::SolarInstruct => {
                 ChatPrompt::SolarInstructPrompt(SolarInstructPrompt)

--- a/api-server/chat-prompts/src/chat/mod.rs
+++ b/api-server/chat-prompts/src/chat/mod.rs
@@ -3,6 +3,7 @@ pub mod belle;
 pub mod chatml;
 pub mod deepseek;
 pub mod gemma;
+pub mod glm;
 pub mod intel;
 pub mod llama;
 pub mod mistral;
@@ -19,8 +20,9 @@ use baichuan::*;
 use belle::*;
 use chatml::*;
 use deepseek::*;
-use endpoints::chat::ChatCompletionRequestMessage;
+use endpoints::chat::{ChatCompletionRequestMessage, Tool};
 use gemma::*;
+use glm::*;
 use intel::*;
 use llama::*;
 use mistral::*;
@@ -31,8 +33,6 @@ use solar::*;
 use vicuna::*;
 use wizard::*;
 use zephyr::*;
-
-use endpoints::chat::Tool;
 
 /// Trait for building prompts for chat completions.
 #[enum_dispatch::enum_dispatch]
@@ -81,6 +81,7 @@ pub enum ChatPrompt {
     Phi3InstructPrompt,
     GemmaInstructPrompt,
     OctopusPrompt,
+    Glm4ChatPrompt,
 }
 impl From<PromptTemplateType> for ChatPrompt {
     fn from(ty: PromptTemplateType) -> Self {
@@ -132,6 +133,7 @@ impl From<PromptTemplateType> for ChatPrompt {
                 ChatPrompt::GemmaInstructPrompt(GemmaInstructPrompt)
             }
             PromptTemplateType::Octopus => ChatPrompt::OctopusPrompt(OctopusPrompt),
+            PromptTemplateType::Glm4Chat => ChatPrompt::Glm4ChatPrompt(Glm4ChatPrompt),
             PromptTemplateType::Embedding => {
                 panic!("Embedding prompt template is not used for building chat prompts")
             }

--- a/api-server/chat-prompts/src/lib.rs
+++ b/api-server/chat-prompts/src/lib.rs
@@ -71,6 +71,8 @@ pub enum PromptTemplateType {
     GemmaInstruct,
     #[value(name = "octopus")]
     Octopus,
+    #[value(name = "glm-4-chat")]
+    Glm4Chat,
     #[value(name = "embedding")]
     Embedding,
 }
@@ -92,7 +94,8 @@ impl PromptTemplateType {
             | PromptTemplateType::DeepseekCoder
             | PromptTemplateType::DeepseekChat2
             | PromptTemplateType::Octopus
-            | PromptTemplateType::Phi3Chat => true,
+            | PromptTemplateType::Phi3Chat
+            | PromptTemplateType::Glm4Chat => true,
             PromptTemplateType::MistralInstruct
             | PromptTemplateType::MistralTool
             | PromptTemplateType::MistralLite
@@ -145,6 +148,7 @@ impl FromStr for PromptTemplateType {
             "phi-3-instruct" => Ok(PromptTemplateType::Phi3Instruct),
             "gemma-instruct" => Ok(PromptTemplateType::GemmaInstruct),
             "octopus" => Ok(PromptTemplateType::Octopus),
+            "glm-4-chat" => Ok(PromptTemplateType::Glm4Chat),
             "embedding" => Ok(PromptTemplateType::Embedding),
             _ => Err(error::PromptError::UnknownPromptTemplateType(
                 template.to_string(),
@@ -184,6 +188,7 @@ impl std::fmt::Display for PromptTemplateType {
             PromptTemplateType::CodeLlamaSuper => write!(f, "codellama-super-instruct"),
             PromptTemplateType::GemmaInstruct => write!(f, "gemma-instruct"),
             PromptTemplateType::Octopus => write!(f, "octopus"),
+            PromptTemplateType::Glm4Chat => write!(f, "glm-4-chat"),
             PromptTemplateType::Embedding => write!(f, "embedding"),
         }
     }

--- a/api-server/chat-prompts/src/lib.rs
+++ b/api-server/chat-prompts/src/lib.rs
@@ -55,6 +55,8 @@ pub enum PromptTemplateType {
     DeepseekChat,
     #[value(name = "deepseek-coder")]
     DeepseekCoder,
+    #[value(name = "deepseek-chat-2")]
+    DeepseekChat2,
     #[value(name = "solar-instruct")]
     SolarInstruct,
     #[value(name = "phi-2-chat")]
@@ -88,6 +90,7 @@ impl PromptTemplateType {
             | PromptTemplateType::Zephyr
             | PromptTemplateType::IntelNeural
             | PromptTemplateType::DeepseekCoder
+            | PromptTemplateType::DeepseekChat2
             | PromptTemplateType::Octopus
             | PromptTemplateType::Phi3Chat => true,
             PromptTemplateType::MistralInstruct
@@ -134,6 +137,7 @@ impl FromStr for PromptTemplateType {
             "intel-neural" => Ok(PromptTemplateType::IntelNeural),
             "deepseek-chat" => Ok(PromptTemplateType::DeepseekChat),
             "deepseek-coder" => Ok(PromptTemplateType::DeepseekCoder),
+            "deepseek-chat-2" => Ok(PromptTemplateType::DeepseekChat2),
             "solar-instruct" => Ok(PromptTemplateType::SolarInstruct),
             "phi-2-chat" => Ok(PromptTemplateType::Phi2Chat),
             "phi-2-instruct" => Ok(PromptTemplateType::Phi2Instruct),
@@ -171,6 +175,7 @@ impl std::fmt::Display for PromptTemplateType {
             PromptTemplateType::IntelNeural => write!(f, "intel-neural"),
             PromptTemplateType::DeepseekChat => write!(f, "deepseek-chat"),
             PromptTemplateType::DeepseekCoder => write!(f, "deepseek-coder"),
+            PromptTemplateType::DeepseekChat2 => write!(f, "deepseek-chat-2"),
             PromptTemplateType::SolarInstruct => write!(f, "solar-instruct"),
             PromptTemplateType::Phi2Chat => write!(f, "phi-2-chat"),
             PromptTemplateType::Phi2Instruct => write!(f, "phi-2-instruct"),

--- a/api-server/endpoints/Cargo.toml
+++ b/api-server/endpoints/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endpoints"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/api-server/endpoints/src/files.rs
+++ b/api-server/endpoints/src/files.rs
@@ -36,3 +36,14 @@ pub struct ListFilesResponse {
     /// The list of file objects.
     pub data: Vec<FileObject>,
 }
+
+/// Represents the status of a file deletion operation.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DeleteFileStatus {
+    /// The file identifier, which can be referenced in the API endpoints.
+    pub id: String,
+    /// The object type, which is always `file`.
+    pub object: String,
+    /// The status of the deletion operation.
+    pub deleted: bool,
+}

--- a/api-server/endpoints/src/files.rs
+++ b/api-server/endpoints/src/files.rs
@@ -27,3 +27,12 @@ pub struct FileObject {
     /// The intended purpose of the file. Supported values are `fine-tune`, `fine-tune-results`, `assistants`, and `assistants_output`.
     pub purpose: String,
 }
+
+/// List files.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ListFilesResponse {
+    /// The object type, which is always `list`.
+    pub object: String,
+    /// The list of file objects.
+    pub data: Vec<FileObject>,
+}

--- a/api-server/endpoints/src/images.rs
+++ b/api-server/endpoints/src/images.rs
@@ -1,10 +1,10 @@
 //! Define types for image generation.
 
+use crate::files::FileObject;
 use serde::{
     de::{self, MapAccess, SeqAccess, Visitor},
     Deserialize, Deserializer, Serialize,
 };
-// use serde::{de, Deserialize, Deserializer};
 use std::fmt;
 
 /// Builder for creating a `CreateImageRequest` instance.
@@ -321,6 +321,324 @@ fn test_deserialize_create_image_request() {
         assert_eq!(req.response_format, Some(ResponseFormat::Url));
         assert_eq!(req.size, Some("1024x1024".to_string()));
         assert_eq!(req.style, Some("vivid".to_string()));
+        assert_eq!(req.user, Some("user".to_string()));
+    }
+}
+
+pub struct ImageEditRequestBuilder {
+    req: ImageEditRequest,
+}
+impl ImageEditRequestBuilder {
+    /// Create a new builder with the given image, prompt, and mask.
+    pub fn new(model: impl Into<String>, image: FileObject, prompt: impl Into<String>) -> Self {
+        Self {
+            req: ImageEditRequest {
+                image,
+                prompt: prompt.into(),
+                mask: None,
+                model: model.into(),
+                n: Some(1),
+                response_format: Some(ResponseFormat::B64Json),
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Set an additional image whose fully transparent areas (e.g. where alpha is zero) indicate where `image` should be edited. Must have the same dimensions as `image`.
+    pub fn with_mask(mut self, mask: FileObject) -> Self {
+        self.req.mask = Some(mask);
+        self
+    }
+
+    /// Set the number of images to generate.
+    pub fn with_number_of_images(mut self, n: u64) -> Self {
+        self.req.n = Some(n);
+        self
+    }
+
+    /// Set the size of the generated images.
+    pub fn with_size(mut self, size: impl Into<String>) -> Self {
+        self.req.size = Some(size.into());
+        self
+    }
+
+    /// Set the format in which the generated images are returned.
+    pub fn with_response_format(mut self, response_format: ResponseFormat) -> Self {
+        self.req.response_format = Some(response_format);
+        self
+    }
+
+    /// Set the user id
+    pub fn with_user(mut self, user: impl Into<String>) -> Self {
+        self.req.user = Some(user.into());
+        self
+    }
+
+    /// Build the request.
+    pub fn build(self) -> ImageEditRequest {
+        self.req
+    }
+}
+
+/// Request to create an edited or extended image given an original image and a prompt.
+#[derive(Debug, Serialize, Default)]
+pub struct ImageEditRequest {
+    /// The image to edit. If mask is not provided, image must have transparency, which will be used as the mask.
+    pub image: FileObject,
+    /// A text description of the desired image(s).
+    pub prompt: String,
+    /// An additional image whose fully transparent areas (e.g. where alpha is zero) indicate where `image` should be edited. Must have the same dimensions as `image`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mask: Option<FileObject>,
+    /// The model to use for image generation.
+    pub model: String,
+    /// The number of images to generate. Defaults to 1.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub n: Option<u64>,
+    /// The size of the generated images. Defaults to 1024x1024.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size: Option<String>,
+    /// The format in which the generated images are returned. Must be one of `url` or `b64_json`. Defaults to `b64_json`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_format: Option<ResponseFormat>,
+    /// A unique identifier representing your end-user, which can help monitor and detect abuse.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+}
+impl<'de> Deserialize<'de> for ImageEditRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        enum Field {
+            Image,
+            Prompt,
+            Mask,
+            Model,
+            N,
+            Size,
+            ResponseFormat,
+            User,
+        }
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                        formatter.write_str("field identifier")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                    where
+                        E: de::Error,
+                    {
+                        match value {
+                            "image" => Ok(Field::Image),
+                            "prompt" => Ok(Field::Prompt),
+                            "mask" => Ok(Field::Mask),
+                            "model" => Ok(Field::Model),
+                            "n" => Ok(Field::N),
+                            "size" => Ok(Field::Size),
+                            "response_format" => Ok(Field::ResponseFormat),
+                            "user" => Ok(Field::User),
+                            _ => Err(de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct ImageEditRequestVisitor;
+
+        impl<'de> Visitor<'de> for ImageEditRequestVisitor {
+            type Value = ImageEditRequest;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct ImageEditRequest")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<ImageEditRequest, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut image = None;
+                let mut prompt = None;
+                let mut mask = None;
+                let mut model = None;
+                let mut n = None;
+                let mut size = None;
+                let mut response_format = None;
+                let mut user = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::Image => {
+                            if image.is_some() {
+                                return Err(de::Error::duplicate_field("image"));
+                            }
+                            image = Some(map.next_value()?);
+                        }
+                        Field::Prompt => {
+                            if prompt.is_some() {
+                                return Err(de::Error::duplicate_field("prompt"));
+                            }
+                            prompt = Some(map.next_value()?);
+                        }
+                        Field::Mask => {
+                            if mask.is_some() {
+                                return Err(de::Error::duplicate_field("mask"));
+                            }
+                            mask = Some(map.next_value()?);
+                        }
+                        Field::Model => {
+                            if model.is_some() {
+                                return Err(de::Error::duplicate_field("model"));
+                            }
+                            model = Some(map.next_value()?);
+                        }
+                        Field::N => {
+                            if n.is_some() {
+                                return Err(de::Error::duplicate_field("n"));
+                            }
+                            n = Some(map.next_value()?);
+                        }
+                        Field::Size => {
+                            if size.is_some() {
+                                return Err(de::Error::duplicate_field("size"));
+                            }
+                            size = Some(map.next_value()?);
+                        }
+                        Field::ResponseFormat => {
+                            if response_format.is_some() {
+                                return Err(de::Error::duplicate_field("response_format"));
+                            }
+                            response_format = Some(map.next_value()?);
+                        }
+                        Field::User => {
+                            if user.is_some() {
+                                return Err(de::Error::duplicate_field("user"));
+                            }
+                            user = Some(map.next_value()?);
+                        }
+                    }
+                }
+                Ok(ImageEditRequest {
+                    image: image.ok_or_else(|| de::Error::missing_field("image"))?,
+                    prompt: prompt.ok_or_else(|| de::Error::missing_field("prompt"))?,
+                    mask,
+                    model: model.ok_or_else(|| de::Error::missing_field("model"))?,
+                    n: n.unwrap_or(Some(1)),
+                    size,
+                    response_format: response_format.unwrap_or(Some(ResponseFormat::B64Json)),
+                    user,
+                })
+            }
+        }
+
+        const FIELDS: &[&str] = &[
+            "image",
+            "prompt",
+            "mask",
+            "model",
+            "n",
+            "size",
+            "response_format",
+            "user",
+        ];
+        deserializer.deserialize_struct("ImageEditRequest", FIELDS, ImageEditRequestVisitor)
+    }
+}
+
+#[test]
+fn test_serialize_image_edit_request() {
+    {
+        let req = ImageEditRequestBuilder::new(
+            "test-model-name",
+            FileObject {
+                id: "test-image-id".to_string(),
+                bytes: 1024,
+                created_at: 1234567890,
+                filename: "test-image.png".to_string(),
+                object: "file".to_string(),
+                purpose: "fine-tune".to_string(),
+            },
+            "This is a prompt",
+        )
+        .build();
+        let json = serde_json::to_string(&req).unwrap();
+        assert_eq!(
+            json,
+            r#"{"image":{"id":"test-image-id","bytes":1024,"created_at":1234567890,"filename":"test-image.png","object":"file","purpose":"fine-tune"},"prompt":"This is a prompt","model":"test-model-name","n":1,"response_format":"b64_json"}"#
+        );
+    }
+
+    {
+        let req = ImageEditRequestBuilder::new(
+            "test-model-name",
+            FileObject {
+                id: "test-image-id".to_string(),
+                bytes: 1024,
+                created_at: 1234567890,
+                filename: "test-image.png".to_string(),
+                object: "file".to_string(),
+                purpose: "fine-tune".to_string(),
+            },
+            "This is a prompt",
+        )
+        .with_number_of_images(2)
+        .with_response_format(ResponseFormat::Url)
+        .with_size("256x256")
+        .with_user("user")
+        .build();
+        let json = serde_json::to_string(&req).unwrap();
+        assert_eq!(
+            json,
+            r#"{"image":{"id":"test-image-id","bytes":1024,"created_at":1234567890,"filename":"test-image.png","object":"file","purpose":"fine-tune"},"prompt":"This is a prompt","model":"test-model-name","n":2,"size":"256x256","response_format":"url","user":"user"}"#
+        );
+    }
+}
+
+#[test]
+fn test_deserialize_image_edit_request() {
+    {
+        let json = r#"{"image":{"id":"test-image-id","bytes":1024,"created_at":1234567890,"filename":"test-image.png","object":"file","purpose":"fine-tune"},"prompt":"This is a prompt","model":"test-model-name"}"#;
+        let req: ImageEditRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.image.id, "test-image-id");
+        assert_eq!(req.image.bytes, 1024);
+        assert_eq!(req.image.created_at, 1234567890);
+        assert_eq!(req.image.filename, "test-image.png");
+        assert_eq!(req.image.object, "file");
+        assert_eq!(req.image.purpose, "fine-tune");
+        assert_eq!(req.prompt, "This is a prompt");
+        assert!(req.mask.is_none());
+        assert_eq!(req.model, "test-model-name");
+        assert_eq!(req.n, Some(1));
+        assert_eq!(req.response_format, Some(ResponseFormat::B64Json));
+    }
+
+    {
+        let json = r#"{"image":{"id":"test-image-id","bytes":1024,"created_at":1234567890,"filename":"test-image.png","object":"file","purpose":"fine-tune"},"prompt":"This is a prompt","model":"test-model-name","n":2,"size":"256x256","response_format":"url","user":"user"}"#;
+        let req: ImageEditRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.image.id, "test-image-id");
+        assert_eq!(req.image.bytes, 1024);
+        assert_eq!(req.image.created_at, 1234567890);
+        assert_eq!(req.image.filename, "test-image.png");
+        assert_eq!(req.image.object, "file");
+        assert_eq!(req.image.purpose, "fine-tune");
+        assert_eq!(req.prompt, "This is a prompt");
+        assert!(req.mask.is_none());
+        assert_eq!(req.model, "test-model-name");
+        assert_eq!(req.n, Some(2));
+        assert_eq!(req.size, Some("256x256".to_string()));
+        assert_eq!(req.response_format, Some(ResponseFormat::Url));
         assert_eq!(req.user, Some("user".to_string()));
     }
 }

--- a/api-server/endpoints/src/images.rs
+++ b/api-server/endpoints/src/images.rs
@@ -1,0 +1,335 @@
+//! Define types for image generation.
+
+use serde::{
+    de::{self, MapAccess, SeqAccess, Visitor},
+    Deserialize, Deserializer, Serialize,
+};
+// use serde::{de, Deserialize, Deserializer};
+use std::fmt;
+
+/// Builder for creating a `CreateImageRequest` instance.
+pub struct CreateImageRequestBuilder {
+    req: CreateImageRequest,
+}
+impl CreateImageRequestBuilder {
+    /// Create a new builder with the given model and prompt.
+    pub fn new(model: impl Into<String>, prompt: impl Into<String>) -> Self {
+        Self {
+            req: CreateImageRequest {
+                model: model.into(),
+                prompt: prompt.into(),
+                n: Some(1),
+                response_format: Some(ResponseFormat::B64Json),
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Set the number of images to generate.
+    pub fn with_number_of_images(mut self, n: u64) -> Self {
+        self.req.n = Some(n);
+        self
+    }
+
+    /// This param is only supported for OpenAI `dall-e-3`.
+    pub fn with_quality(mut self, quality: impl Into<String>) -> Self {
+        self.req.quality = Some(quality.into());
+        self
+    }
+
+    /// Set the format in which the generated images are returned.
+    pub fn with_response_format(mut self, response_format: ResponseFormat) -> Self {
+        self.req.response_format = Some(response_format);
+        self
+    }
+
+    /// Set the size of the generated images.
+    pub fn with_size(mut self, size: impl Into<String>) -> Self {
+        self.req.size = Some(size.into());
+        self
+    }
+
+    /// This param is only supported for `dall-e-3`.
+    pub fn with_style(mut self, style: impl Into<String>) -> Self {
+        self.req.style = Some(style.into());
+        self
+    }
+
+    /// Set the user id
+    pub fn with_user(mut self, user: impl Into<String>) -> Self {
+        self.req.user = Some(user.into());
+        self
+    }
+
+    /// Build the request.
+    pub fn build(self) -> CreateImageRequest {
+        self.req
+    }
+}
+
+/// Request to create an image by a given prompt.
+#[derive(Debug, Serialize, Default)]
+pub struct CreateImageRequest {
+    /// A text description of the desired image.
+    pub prompt: String,
+    /// Name of the model to use for image generation.
+    pub model: String,
+    /// Number of images to generate. Defaults to 1.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub n: Option<u64>,
+    /// The quality of the image that will be generated. hd creates images with finer details and greater consistency across the image. Defaults to "standard". This param is only supported for OpenAI `dall-e-3`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quality: Option<String>,
+    /// The format in which the generated images are returned. Must be one of `url` or `b64_json`. Defaults to `b64_json`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_format: Option<ResponseFormat>,
+    /// The size of the generated images. Defaults to 1024x1024.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size: Option<String>,
+    /// The style of the generated images. Must be one of `vivid` or `natural`. Vivid causes the model to lean towards generating hyper-real and dramatic images. Natural causes the model to produce more natural, less hyper-real looking images. This param is only supported for `dall-e-3`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub style: Option<String>,
+    /// A unique identifier representing your end-user, which can help monitor and detect abuse.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+}
+impl<'de> Deserialize<'de> for CreateImageRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        enum Field {
+            Prompt,
+            Model,
+            N,
+            Quality,
+            ResponseFormat,
+            Size,
+            Style,
+            User,
+        }
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                        formatter.write_str("field identifier")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                    where
+                        E: de::Error,
+                    {
+                        match value {
+                            "prompt" => Ok(Field::Prompt),
+                            "model" => Ok(Field::Model),
+                            "n" => Ok(Field::N),
+                            "quality" => Ok(Field::Quality),
+                            "response_format" => Ok(Field::ResponseFormat),
+                            "size" => Ok(Field::Size),
+                            "style" => Ok(Field::Style),
+                            "user" => Ok(Field::User),
+                            _ => Err(de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct CreateImageRequestVisitor;
+
+        impl<'de> Visitor<'de> for CreateImageRequestVisitor {
+            type Value = CreateImageRequest;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct CreateImageRequest")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<CreateImageRequest, V::Error>
+            where
+                V: SeqAccess<'de>,
+            {
+                let prompt = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                let model = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                let n = seq.next_element()?.unwrap_or(Some(1));
+                let quality = seq.next_element()?;
+                let response_format = seq.next_element()?.unwrap_or(Some(ResponseFormat::B64Json));
+                let size = seq.next_element()?;
+                let style = seq.next_element()?;
+                let user = seq.next_element()?;
+
+                Ok(CreateImageRequest {
+                    prompt,
+                    model,
+                    n,
+                    quality,
+                    response_format,
+                    size,
+                    style,
+                    user,
+                })
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<CreateImageRequest, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut prompt = None;
+                let mut model = None;
+                let mut n = None;
+                let mut quality = None;
+                let mut response_format = None;
+                let mut size = None;
+                let mut style = None;
+                let mut user = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::Prompt => {
+                            if prompt.is_some() {
+                                return Err(de::Error::duplicate_field("prompt"));
+                            }
+                            prompt = Some(map.next_value()?);
+                        }
+                        Field::Model => {
+                            if model.is_some() {
+                                return Err(de::Error::duplicate_field("model"));
+                            }
+                            model = Some(map.next_value()?);
+                        }
+                        Field::N => {
+                            if n.is_some() {
+                                return Err(de::Error::duplicate_field("n"));
+                            }
+                            n = Some(map.next_value()?);
+                        }
+                        Field::Quality => {
+                            if quality.is_some() {
+                                return Err(de::Error::duplicate_field("quality"));
+                            }
+                            quality = Some(map.next_value()?);
+                        }
+                        Field::ResponseFormat => {
+                            if response_format.is_some() {
+                                return Err(de::Error::duplicate_field("response_format"));
+                            }
+                            response_format = Some(map.next_value()?);
+                        }
+                        Field::Size => {
+                            if size.is_some() {
+                                return Err(de::Error::duplicate_field("size"));
+                            }
+                            size = Some(map.next_value()?);
+                        }
+                        Field::Style => {
+                            if style.is_some() {
+                                return Err(de::Error::duplicate_field("style"));
+                            }
+                            style = Some(map.next_value()?);
+                        }
+                        Field::User => {
+                            if user.is_some() {
+                                return Err(de::Error::duplicate_field("user"));
+                            }
+                            user = Some(map.next_value()?);
+                        }
+                    }
+                }
+                Ok(CreateImageRequest {
+                    prompt: prompt.ok_or_else(|| de::Error::missing_field("prompt"))?,
+                    model: model.ok_or_else(|| de::Error::missing_field("model"))?,
+                    n: n.unwrap_or(Some(1)),
+                    quality,
+                    response_format: response_format.unwrap_or(Some(ResponseFormat::B64Json)),
+                    size,
+                    style,
+                    user,
+                })
+            }
+        }
+
+        const FIELDS: &'static [&'static str] = &[
+            "prompt",
+            "model",
+            "n",
+            "quality",
+            "response_format",
+            "size",
+            "style",
+            "user",
+        ];
+        deserializer.deserialize_struct("CreateImageRequest", FIELDS, CreateImageRequestVisitor)
+    }
+}
+
+#[test]
+fn test_serialize_create_image_request() {
+    {
+        let req = CreateImageRequestBuilder::new("test-model-name", "This is a prompt").build();
+        let json = serde_json::to_string(&req).unwrap();
+        assert_eq!(
+            json,
+            r#"{"prompt":"This is a prompt","model":"test-model-name","n":1,"response_format":"b64_json"}"#
+        );
+    }
+
+    {
+        let req = CreateImageRequestBuilder::new("test-model-name", "This is a prompt")
+            .with_number_of_images(2)
+            .with_response_format(ResponseFormat::Url)
+            .with_size("1024x1024")
+            .with_style("vivid")
+            .with_user("user")
+            .build();
+        let json = serde_json::to_string(&req).unwrap();
+        assert_eq!(
+            json,
+            r#"{"prompt":"This is a prompt","model":"test-model-name","n":2,"response_format":"url","size":"1024x1024","style":"vivid","user":"user"}"#
+        );
+    }
+}
+
+#[test]
+fn test_deserialize_create_image_request() {
+    {
+        let json = r#"{"prompt":"This is a prompt","model":"test-model-name"}"#;
+        let req: CreateImageRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.prompt, "This is a prompt");
+        assert_eq!(req.model, "test-model-name");
+        assert_eq!(req.n, Some(1));
+        assert_eq!(req.response_format, Some(ResponseFormat::B64Json));
+    }
+
+    {
+        let json = r#"{"prompt":"This is a prompt","model":"test-model-name","n":2,"response_format":"url","size":"1024x1024","style":"vivid","user":"user"}"#;
+        let req: CreateImageRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.prompt, "This is a prompt");
+        assert_eq!(req.model, "test-model-name");
+        assert_eq!(req.n, Some(2));
+        assert_eq!(req.response_format, Some(ResponseFormat::Url));
+        assert_eq!(req.size, Some("1024x1024".to_string()));
+        assert_eq!(req.style, Some("vivid".to_string()));
+        assert_eq!(req.user, Some("user".to_string()));
+    }
+}
+
+/// The format in which the generated images are returned.
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
+pub enum ResponseFormat {
+    #[serde(rename = "url")]
+    Url,
+    #[serde(rename = "b64_json")]
+    B64Json,
+}

--- a/api-server/endpoints/src/images.rs
+++ b/api-server/endpoints/src/images.rs
@@ -7,15 +7,15 @@ use serde::{
 };
 use std::fmt;
 
-/// Builder for creating a `CreateImageRequest` instance.
-pub struct CreateImageRequestBuilder {
-    req: CreateImageRequest,
+/// Builder for creating a `ImageCreateRequest` instance.
+pub struct ImageCreateRequestBuilder {
+    req: ImageCreateRequest,
 }
-impl CreateImageRequestBuilder {
+impl ImageCreateRequestBuilder {
     /// Create a new builder with the given model and prompt.
     pub fn new(model: impl Into<String>, prompt: impl Into<String>) -> Self {
         Self {
-            req: CreateImageRequest {
+            req: ImageCreateRequest {
                 model: model.into(),
                 prompt: prompt.into(),
                 n: Some(1),
@@ -62,14 +62,14 @@ impl CreateImageRequestBuilder {
     }
 
     /// Build the request.
-    pub fn build(self) -> CreateImageRequest {
+    pub fn build(self) -> ImageCreateRequest {
         self.req
     }
 }
 
 /// Request to create an image by a given prompt.
 #[derive(Debug, Serialize, Default)]
-pub struct CreateImageRequest {
+pub struct ImageCreateRequest {
     /// A text description of the desired image.
     pub prompt: String,
     /// Name of the model to use for image generation.
@@ -93,7 +93,7 @@ pub struct CreateImageRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<String>,
 }
-impl<'de> Deserialize<'de> for CreateImageRequest {
+impl<'de> Deserialize<'de> for ImageCreateRequest {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -148,13 +148,13 @@ impl<'de> Deserialize<'de> for CreateImageRequest {
         struct CreateImageRequestVisitor;
 
         impl<'de> Visitor<'de> for CreateImageRequestVisitor {
-            type Value = CreateImageRequest;
+            type Value = ImageCreateRequest;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("struct CreateImageRequest")
             }
 
-            fn visit_seq<V>(self, mut seq: V) -> Result<CreateImageRequest, V::Error>
+            fn visit_seq<V>(self, mut seq: V) -> Result<ImageCreateRequest, V::Error>
             where
                 V: SeqAccess<'de>,
             {
@@ -171,7 +171,7 @@ impl<'de> Deserialize<'de> for CreateImageRequest {
                 let style = seq.next_element()?;
                 let user = seq.next_element()?;
 
-                Ok(CreateImageRequest {
+                Ok(ImageCreateRequest {
                     prompt,
                     model,
                     n,
@@ -183,7 +183,7 @@ impl<'de> Deserialize<'de> for CreateImageRequest {
                 })
             }
 
-            fn visit_map<V>(self, mut map: V) -> Result<CreateImageRequest, V::Error>
+            fn visit_map<V>(self, mut map: V) -> Result<ImageCreateRequest, V::Error>
             where
                 V: MapAccess<'de>,
             {
@@ -247,7 +247,7 @@ impl<'de> Deserialize<'de> for CreateImageRequest {
                         }
                     }
                 }
-                Ok(CreateImageRequest {
+                Ok(ImageCreateRequest {
                     prompt: prompt.ok_or_else(|| de::Error::missing_field("prompt"))?,
                     model: model.ok_or_else(|| de::Error::missing_field("model"))?,
                     n: n.unwrap_or(Some(1)),
@@ -275,9 +275,9 @@ impl<'de> Deserialize<'de> for CreateImageRequest {
 }
 
 #[test]
-fn test_serialize_create_image_request() {
+fn test_serialize_image_create_request() {
     {
-        let req = CreateImageRequestBuilder::new("test-model-name", "This is a prompt").build();
+        let req = ImageCreateRequestBuilder::new("test-model-name", "This is a prompt").build();
         let json = serde_json::to_string(&req).unwrap();
         assert_eq!(
             json,
@@ -286,7 +286,7 @@ fn test_serialize_create_image_request() {
     }
 
     {
-        let req = CreateImageRequestBuilder::new("test-model-name", "This is a prompt")
+        let req = ImageCreateRequestBuilder::new("test-model-name", "This is a prompt")
             .with_number_of_images(2)
             .with_response_format(ResponseFormat::Url)
             .with_size("1024x1024")
@@ -302,10 +302,10 @@ fn test_serialize_create_image_request() {
 }
 
 #[test]
-fn test_deserialize_create_image_request() {
+fn test_deserialize_image_create_request() {
     {
         let json = r#"{"prompt":"This is a prompt","model":"test-model-name"}"#;
-        let req: CreateImageRequest = serde_json::from_str(json).unwrap();
+        let req: ImageCreateRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.prompt, "This is a prompt");
         assert_eq!(req.model, "test-model-name");
         assert_eq!(req.n, Some(1));
@@ -314,7 +314,7 @@ fn test_deserialize_create_image_request() {
 
     {
         let json = r#"{"prompt":"This is a prompt","model":"test-model-name","n":2,"response_format":"url","size":"1024x1024","style":"vivid","user":"user"}"#;
-        let req: CreateImageRequest = serde_json::from_str(json).unwrap();
+        let req: ImageCreateRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.prompt, "This is a prompt");
         assert_eq!(req.model, "test-model-name");
         assert_eq!(req.n, Some(2));
@@ -325,6 +325,7 @@ fn test_deserialize_create_image_request() {
     }
 }
 
+/// Builder for creating a `ImageEditRequest` instance.
 pub struct ImageEditRequestBuilder {
     req: ImageEditRequest,
 }

--- a/api-server/endpoints/src/images.rs
+++ b/api-server/endpoints/src/images.rs
@@ -260,7 +260,7 @@ impl<'de> Deserialize<'de> for CreateImageRequest {
             }
         }
 
-        const FIELDS: &'static [&'static str] = &[
+        const FIELDS: &[&str] = &[
             "prompt",
             "model",
             "n",

--- a/api-server/endpoints/src/images.rs
+++ b/api-server/endpoints/src/images.rs
@@ -333,3 +333,17 @@ pub enum ResponseFormat {
     #[serde(rename = "b64_json")]
     B64Json,
 }
+
+/// Represents the url or the content of an image generated.
+#[derive(Debug, Deserialize, Serialize, Default)]
+pub struct ImageObject {
+    /// The base64-encoded JSON of the generated image, if response_format is `b64_json`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub b64_json: Option<String>,
+    /// The URL of the generated image, if response_format is `url`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// The prompt that was used to generate the image, if there was any revision to the prompt.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
+}

--- a/api-server/endpoints/src/lib.rs
+++ b/api-server/endpoints/src/lib.rs
@@ -6,5 +6,6 @@ pub mod common;
 pub mod completions;
 pub mod embeddings;
 pub mod files;
+pub mod images;
 pub mod models;
 pub mod rag;

--- a/api-server/llama-api-server/Cargo.toml
+++ b/api-server/llama-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-api-server"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 
 [dependencies]

--- a/api-server/llama-api-server/Cargo.toml
+++ b/api-server/llama-api-server/Cargo.toml
@@ -24,6 +24,7 @@ multipart-2021 = "0.19.0"
 wasi-logger.workspace = true
 log.workspace = true
 either.workspace = true
+walkdir = "2.5.0"
 
 [features]
 default = []

--- a/api-server/llama-api-server/src/backend/ggml.rs
+++ b/api-server/llama-api-server/src/backend/ggml.rs
@@ -3,7 +3,7 @@ use endpoints::{
     chat::ChatCompletionRequest,
     completions::CompletionRequest,
     embeddings::EmbeddingRequest,
-    files::FileObject,
+    files::{FileObject, ListFilesResponse},
     rag::{ChunksRequest, ChunksResponse},
 };
 use futures_util::TryStreamExt;
@@ -626,6 +626,11 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
             }
 
             info!(target: "files_handler", "Found {} archive files", file_objects.len());
+
+            let file_objects = ListFilesResponse {
+                object: "list".to_string(),
+                data: file_objects,
+            };
 
             // serialize chat completion object
             let s = match serde_json::to_string(&file_objects) {

--- a/api-server/llama-api-server/src/backend/ggml.rs
+++ b/api-server/llama-api-server/src/backend/ggml.rs
@@ -587,10 +587,9 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
                     let id = entry
                         .path()
                         .parent()
-                        .and_then(|p| {
-                            p.file_name()
-                                .and_then(|f| f.to_str().map(|s| s.trim_start_matches("file_")))
-                        })
+                        .and_then(|p| p.file_name())
+                        .unwrap()
+                        .to_str()
                         .unwrap()
                         .to_string();
 
@@ -666,7 +665,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
             }
         } else {
             let id = uri_path.trim_start_matches("/v1/files/");
-            let root = format!("archives/file_{}", id);
+            let root = format!("archives/{}", id);
             let mut file_object: Option<FileObject> = None;
             for entry in WalkDir::new(root).into_iter().filter_map(|e| e.ok()) {
                 if !is_hidden(&entry) && entry.path().is_file() {
@@ -753,7 +752,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
         }
     } else if req.method() == Method::DELETE {
         let id = req.uri().path().trim_start_matches("/v1/files/");
-        let root = format!("archives/file_{}", id);
+        let root = format!("archives/{}", id);
         let status = match fs::remove_dir_all(root) {
             Ok(_) => {
                 info!(target: "files_handler", "Successfully deleted the target file with id {}.", id);

--- a/api-server/llama-api-server/src/backend/mod.rs
+++ b/api-server/llama-api-server/src/backend/mod.rs
@@ -12,6 +12,12 @@ pub(crate) async fn handle_llama_request(req: Request<Body>) -> Response<Body> {
         "/v1/files" => ggml::files_handler(req).await,
         "/v1/chunks" => ggml::chunks_handler(req).await,
         "/v1/info" => ggml::server_info_handler().await,
-        _ => error::invalid_endpoint(req.uri().path()),
+        path => {
+            if path.starts_with("/v1/files/") {
+                ggml::files_handler(req).await
+            } else {
+                error::invalid_endpoint(path)
+            }
+        }
     }
 }

--- a/api-server/llama-api-server/src/main.rs
+++ b/api-server/llama-api-server/src/main.rs
@@ -473,16 +473,12 @@ async fn handle_request(
         let path = req.uri().path().to_string();
         let version = format!("{:?}", req.version());
         if req.method() == hyper::http::Method::POST {
-            let size: u64 = req
-                .headers()
-                .get("content-length")
-                .unwrap()
-                .to_str()
-                .unwrap()
-                .parse()
-                .unwrap();
+            let size: u64 = match req.headers().get("content-length") {
+                Some(content_length) => content_length.to_str().unwrap().parse().unwrap(),
+                None => 0,
+            };
 
-            info!(target: "request", "method: {}, endpoint: {}, http_version: {}, size: {}", method, path, version, size);
+            info!(target: "request", "method: {}, endpoint: {}, http_version: {}, content-length: {}", method, path, version, size);
         } else {
             info!(target: "request", "method: {}, endpoint: {}, http_version: {}", method, path, version);
         }

--- a/api-server/llama-core/Cargo.toml
+++ b/api-server/llama-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-core"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/api-server/llama-core/src/chat.rs
+++ b/api-server/llama-core/src/chat.rs
@@ -887,6 +887,7 @@ fn post_process(
     } else if *template_ty == PromptTemplateType::Zephyr
         || *template_ty == PromptTemplateType::MistralLite
         || *template_ty == PromptTemplateType::MistralTool
+        || *template_ty == PromptTemplateType::MistralInstruct
     {
         if output.as_ref().contains("</s><") {
             output.as_ref().trim_end_matches("</s><").trim().to_owned()

--- a/api-server/llama-core/src/chat.rs
+++ b/api-server/llama-core/src/chat.rs
@@ -611,10 +611,10 @@ fn parse_tool_calls(input: &str, prompt_template: PromptTemplateType) -> Option<
 
                 let mut tool_calls: Vec<ToolCall> = vec![];
                 for value in values.iter() {
-                    let function = Function {
-                        name: value.get("name").unwrap().to_string(),
-                        arguments: value.get("arguments").unwrap().to_string(),
-                    };
+                    let name = value.get("name").unwrap().to_string().replace("\"", "");
+                    let arguments = value.get("arguments").unwrap().to_string();
+
+                    let function = Function { name, arguments };
 
                     let tool_call = ToolCall {
                         id: "call_abc123".to_string(),
@@ -654,10 +654,10 @@ fn parse_tool_calls(input: &str, prompt_template: PromptTemplateType) -> Option<
 
                     let mut tool_calls: Vec<ToolCall> = vec![];
                     for value in values.iter() {
-                        let function = Function {
-                            name: value.get("name").unwrap().to_string(),
-                            arguments: value.get("arguments").unwrap().to_string(),
-                        };
+                        let name = value.get("name").unwrap().to_string().replace("\"", "");
+                        let arguments = value.get("arguments").unwrap().to_string();
+
+                        let function = Function { name, arguments };
 
                         let tool_call = ToolCall {
                             id: "call_abc123".to_string(),

--- a/chat/Cargo.toml
+++ b/chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-chat"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 
 [dependencies]

--- a/simple/Cargo.toml
+++ b/simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-simple"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Major changes:

- llama-api-server
  - Extend `/v1/files` endpoint
    - List files on server
    - Retrieve a specific file
    - Delete a specific file

- `endpoints` crate
  - Introduce `images` mod
  - Introduce `ListFilesResponse` type into `files` mod

- `chat-prompts` crate
  - Introduce `DeepseekChat2Prompt` and `Glm4ChatPrompt`

- `llama-core` crate
  - Code improvements