### PR TITLE
Release 0.12.5

### DIFF
--- a/.github/workflows/warn_close_issues.yml
+++ b/.github/workflows/warn_close_issues.yml
@@ -1,0 +1,22 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-endpoints = { path = "endpoints", version = "^0.10" }
+endpoints = { path = "endpoints", version = "^0.11" }
 chat-prompts = { path = "chat-prompts", version = "^0.10" }
 thiserror = "1"
 uuid = { version = "1.4", features = ["v4", "fast-rng", "macro-diagnostics"] }

--- a/api-server/chat-prompts/Cargo.toml
+++ b/api-server/chat-prompts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chat-prompts"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/api-server/chat-prompts/Cargo.toml
+++ b/api-server/chat-prompts/Cargo.toml
@@ -13,7 +13,7 @@ description = "Chat prompt template"
 endpoints.workspace = true
 thiserror.workspace = true
 enum_dispatch = "0.3.12"
-image = "0.25.0"
+image = "=0.25.0"
 base64 = "=0.22.0"
 clap.workspace = true
 serde.workspace = true

--- a/api-server/endpoints/Cargo.toml
+++ b/api-server/endpoints/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endpoints"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/api-server/endpoints/src/chat.rs
+++ b/api-server/endpoints/src/chat.rs
@@ -33,7 +33,7 @@
 //! let json = serde_json::to_string(&request).unwrap();
 //! assert_eq!(
 //!     json,
-//!     r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":[{"type":"text","text":"what is in the picture?"},{"type":"image_url","image_url":{"url":"https://example.com/image.png"}}]}],"max_tokens":16,"tool_choice":"none"}"#
+//!     r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":[{"type":"text","text":"what is in the picture?"},{"type":"image_url","image_url":{"url":"https://example.com/image.png"}}]}],"max_tokens":1024,"tool_choice":"none"}"#
 //! );
 //! ```
 //!
@@ -168,7 +168,7 @@ impl ChatCompletionRequestBuilder {
                 stream: None,
                 stream_options: None,
                 stop: None,
-                max_tokens: Some(16),
+                max_tokens: Some(1024),
                 presence_penalty: None,
                 frequency_penalty: None,
                 logit_bias: None,
@@ -327,7 +327,7 @@ pub struct ChatCompletionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stop: Option<Vec<String>>,
     /// The maximum number of tokens to generate. The value should be no less than 1.
-    /// Defaults to 16.
+    /// Defaults to 1024.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_tokens: Option<u64>,
     /// Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.
@@ -435,7 +435,7 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
 
                 // Set default value for `max_tokens` if not provided
                 if max_tokens.is_none() {
-                    max_tokens = Some(16);
+                    max_tokens = Some(1024);
                 }
 
                 // Check tools and tool_choice
@@ -536,7 +536,7 @@ fn test_chat_serialize_chat_request() {
         let json = serde_json::to_string(&request).unwrap();
         assert_eq!(
             json,
-            r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":"Hello, world!"},{"role":"assistant","content":"Hello, world!"}],"temperature":0.8,"top_p":1.0,"n":3,"stream":true,"stream_options":{"include_usage":true},"stop":["stop1","stop2"],"max_tokens":16,"presence_penalty":0.5,"frequency_penalty":0.5,"response_format":{"type":"text"},"tool_choice":"auto"}"#
+            r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":"Hello, world!"},{"role":"assistant","content":"Hello, world!"}],"temperature":0.8,"top_p":1.0,"n":3,"stream":true,"stream_options":{"include_usage":true},"stop":["stop1","stop2"],"max_tokens":1024,"presence_penalty":0.5,"frequency_penalty":0.5,"response_format":{"type":"text"},"tool_choice":"auto"}"#
         );
     }
 
@@ -564,7 +564,7 @@ fn test_chat_serialize_chat_request() {
         let json = serde_json::to_string(&request).unwrap();
         assert_eq!(
             json,
-            r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":[{"type":"text","text":"what is in the picture?"},{"type":"image_url","image_url":{"url":"https://example.com/image.png"}}]}],"max_tokens":16,"tool_choice":"none"}"#
+            r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":[{"type":"text","text":"what is in the picture?"},{"type":"image_url","image_url":{"url":"https://example.com/image.png"}}]}],"max_tokens":1024,"tool_choice":"none"}"#
         );
     }
 
@@ -777,7 +777,7 @@ fn test_chat_deserialize_chat_request() {
             request.stop,
             Some(vec!["stop1".to_string(), "stop2".to_string()])
         );
-        assert_eq!(request.max_tokens, Some(16));
+        assert_eq!(request.max_tokens, Some(1024));
         assert_eq!(request.presence_penalty, Some(0.5));
         assert_eq!(request.frequency_penalty, Some(0.5));
         assert_eq!(request.tool_choice, Some(ToolChoice::None));

--- a/api-server/endpoints/src/chat.rs
+++ b/api-server/endpoints/src/chat.rs
@@ -197,7 +197,7 @@ impl ChatCompletionRequestBuilder {
     /// # Arguments
     ///
     /// * `n` - How many chat completion choices to generate for each input message. If `n` is less than 1, then sets to `1`.
-    pub fn with_n_choices(mut self, n: i32) -> Self {
+    pub fn with_n_choices(mut self, n: u64) -> Self {
         let n_choice = if n < 1 { 1 } else { n };
         self.req.n_choice = Some(n_choice);
         self
@@ -313,7 +313,8 @@ pub struct ChatCompletionRequest {
     /// How many chat completion choices to generate for each input message.
     /// Defaults to 1.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub n_choice: Option<i32>,
+    #[serde(rename = "n")]
+    pub n_choice: Option<u64>,
     /// Whether to stream the results as they are generated. Useful for chatbots.
     /// Defaults to false.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -411,7 +412,7 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
                         "messages" => messages = map.next_value()?,
                         "temperature" => temperature = map.next_value()?,
                         "top_p" => top_p = map.next_value()?,
-                        "n_choice" => n_choice = map.next_value()?,
+                        "n" => n_choice = map.next_value()?,
                         "stream" => stream = map.next_value()?,
                         "stream_options" => stream_options = map.next_value()?,
                         "stop" => stop = map.next_value()?,
@@ -443,6 +444,10 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
                     tool_choice = Some(ToolChoice::None);
                 }
 
+                if n_choice.is_none() {
+                    n_choice = Some(1);
+                }
+
                 // Construct ChatCompletionRequest with all fields
                 Ok(ChatCompletionRequest {
                     model,
@@ -472,7 +477,7 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
             "max_tokens",
             "temperature",
             "top_p",
-            "n_choice",
+            "n",
             "stream",
             "stream_options",
             "stop",
@@ -527,7 +532,7 @@ fn test_chat_serialize_chat_request() {
         let json = serde_json::to_string(&request).unwrap();
         assert_eq!(
             json,
-            r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":"Hello, world!"},{"role":"assistant","content":"Hello, world!"}],"temperature":0.8,"top_p":1.0,"n_choice":3,"stream":true,"stream_options":{"include_usage":true},"stop":["stop1","stop2"],"max_tokens":100,"presence_penalty":0.5,"frequency_penalty":0.5,"response_format":{"type":"text"},"tool_choice":"auto"}"#
+            r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":"Hello, world!"},{"role":"assistant","content":"Hello, world!"}],"temperature":0.8,"top_p":1.0,"n":3,"stream":true,"stream_options":{"include_usage":true},"stop":["stop1","stop2"],"max_tokens":100,"presence_penalty":0.5,"frequency_penalty":0.5,"response_format":{"type":"text"},"tool_choice":"auto"}"#
         );
     }
 
@@ -643,7 +648,7 @@ fn test_chat_serialize_chat_request() {
         let json = serde_json::to_string(&request).unwrap();
         assert_eq!(
             json,
-            r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":"Hello, world!"},{"role":"assistant","content":"Hello, world!"}],"temperature":0.8,"top_p":1.0,"n_choice":3,"stream":true,"stream_options":{"include_usage":true},"stop":["stop1","stop2"],"max_tokens":100,"presence_penalty":0.5,"frequency_penalty":0.5,"response_format":{"type":"text"},"tools":[{"type":"function","function":{"name":"my_function","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"tool_choice":{"type":"function","function":{"name":"my_function"}}}"#
+            r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":"Hello, world!"},{"role":"assistant","content":"Hello, world!"}],"temperature":0.8,"top_p":1.0,"n":3,"stream":true,"stream_options":{"include_usage":true},"stop":["stop1","stop2"],"max_tokens":100,"presence_penalty":0.5,"frequency_penalty":0.5,"response_format":{"type":"text"},"tools":[{"type":"function","function":{"name":"my_function","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"tool_choice":{"type":"function","function":{"name":"my_function"}}}"#
         );
     }
 
@@ -726,7 +731,7 @@ fn test_chat_serialize_chat_request() {
         let json = serde_json::to_string(&request).unwrap();
         assert_eq!(
             json,
-            r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":"Hello, world!"},{"role":"assistant","content":"Hello, world!"}],"temperature":0.8,"top_p":1.0,"n_choice":3,"stream":true,"stream_options":{"include_usage":true},"stop":["stop1","stop2"],"max_tokens":100,"presence_penalty":0.5,"frequency_penalty":0.5,"response_format":{"type":"text"},"tools":[{"type":"function","function":{"name":"my_function","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"tool_choice":"auto"}"#
+            r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":"Hello, world!"},{"role":"assistant","content":"Hello, world!"}],"temperature":0.8,"top_p":1.0,"n":3,"stream":true,"stream_options":{"include_usage":true},"stop":["stop1","stop2"],"max_tokens":100,"presence_penalty":0.5,"frequency_penalty":0.5,"response_format":{"type":"text"},"tools":[{"type":"function","function":{"name":"my_function","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"tool_choice":"auto"}"#
         );
     }
 }
@@ -734,7 +739,7 @@ fn test_chat_serialize_chat_request() {
 #[test]
 fn test_chat_deserialize_chat_request() {
     {
-        let json = r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":"Hello, world!"},{"role":"assistant","content":"Hello, world!"}],"temperature":0.8,"top_p":1.0,"n_choice":3,"stream":true,"stop":["stop1","stop2"],"max_tokens":100,"presence_penalty":0.5,"frequency_penalty":0.5,"response_format":{"type":"text"}}"#;
+        let json = r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":"Hello, world!"},{"role":"assistant","content":"Hello, world!"}],"temperature":0.8,"top_p":1.0,"n":3,"stream":true,"stop":["stop1","stop2"],"max_tokens":100,"presence_penalty":0.5,"frequency_penalty":0.5,"response_format":{"type":"text"}}"#;
         let request: ChatCompletionRequest = serde_json::from_str(json).unwrap();
         assert_eq!(request.model, Some("model-id".to_string()));
         assert_eq!(request.messages.len(), 3);

--- a/api-server/endpoints/src/rag.rs
+++ b/api-server/endpoints/src/rag.rs
@@ -124,7 +124,7 @@ pub struct RagChatCompletionsRequest {
     /// How many chat completion choices to generate for each input message.
     /// Defaults to 1.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub n_choice: Option<i32>,
+    pub n_choice: Option<u64>,
     /// Whether to stream the results as they are generated. Useful for chatbots.
     /// Defaults to false.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -285,7 +285,7 @@ impl RagChatCompletionRequestBuilder {
     /// # Arguments
     ///
     /// * `n` - How many chat completion choices to generate for each input message. If `n` is less than 1, then sets to `1`.
-    pub fn with_n_choices(mut self, n: i32) -> Self {
+    pub fn with_n_choices(mut self, n: u64) -> Self {
         let n_choice = if n < 1 { 1 } else { n };
         self.req.n_choice = Some(n_choice);
         self

--- a/api-server/llama-api-server/Cargo.toml
+++ b/api-server/llama-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-api-server"
-version = "0.12.4"
+version = "0.12.5"
 edition = "2021"
 
 [dependencies]

--- a/api-server/llama-core/Cargo.toml
+++ b/api-server/llama-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-core"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/api-server/llama-core/src/chat.rs
+++ b/api-server/llama-core/src/chat.rs
@@ -82,7 +82,7 @@ async fn chat_stream(
     chat_request: &mut ChatCompletionRequest,
 ) -> Result<impl futures::TryStream<Ok = String, Error = LlamaCoreError>, LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama_core", "Process chat completion request in stream mode.");
+    info!(target: "llama_core", "Process chat completion request in the stream mode.");
 
     let running_mode = running_mode()?;
     if running_mode == RunningMode::Embeddings {
@@ -125,7 +125,7 @@ async fn chat_stream(
     #[cfg(feature = "logging")]
     {
         info!(target: "llama_core", "prompt:\n{}", &prompt);
-        info!(target: "llama_core", "avaible_completion_tokens: {}", avaible_completion_tokens);
+        info!(target: "llama_core", "available_completion_tokens: {}", avaible_completion_tokens);
         info!(target: "llama_core", "tool_use: {}", tool_use);
     }
 
@@ -245,7 +245,7 @@ fn chat_stream_by_graph(
             })?;
 
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "raw generation: {}", output);
+            info!(target: "llama_core", "raw generation:\n{}", output);
 
             // post-process
             let message = post_process(output, &graph.metadata.prompt_template).map_err(|e| {
@@ -253,7 +253,7 @@ fn chat_stream_by_graph(
             })?;
 
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "post-processed generation: {}", &message);
+            info!(target: "llama_core", "post-processed generation:\n{}", &message);
 
             // retrieve the number of prompt and completion tokens
             let token_info = get_token_info_by_graph(graph)?;
@@ -2149,6 +2149,7 @@ impl Drop for ChatStream {
         if self.cache.is_none() {
             #[cfg(feature = "logging")]
             info!(target: "llama_core", "Clean up the context of the stream work environment.");
+
             match &self.model {
                 Some(model_name) => {
                     match CHAT_GRAPHS.get() {
@@ -2278,6 +2279,9 @@ impl Drop for ChatStream {
                     };
                 }
             }
+
+            #[cfg(feature = "logging")]
+            info!(target: "llama_core", "Cleanup done!");
         }
     }
 }
@@ -2334,6 +2338,9 @@ fn compute_stream(
     context_full_state: &mut ContextFullState,
     stream_state: &mut StreamState,
 ) -> Result<String, LlamaCoreError> {
+    #[cfg(feature = "logging")]
+    info!(target: "llama_core", "Compute the chat stream chunk.");
+
     if *prompt_too_long_state == PromptTooLongState::EndOfSequence
         || *context_full_state == ContextFullState::EndOfSequence
         || *stream_state == StreamState::EndOfSequence
@@ -2342,7 +2349,7 @@ fn compute_stream(
     }
 
     // get graph
-    match &model_name {
+    let res = match &model_name {
         Some(model_name) => {
             let chat_graphs = match CHAT_GRAPHS.get() {
                 Some(chat_graphs) => chat_graphs,
@@ -3387,5 +3394,10 @@ fn compute_stream(
                 }
             }
         }
-    }
+    };
+
+    #[cfg(feature = "logging")]
+    info!(target: "llama_core", "Return the chat stream chunk!");
+
+    res
 }

--- a/api-server/llama-core/src/chat.rs
+++ b/api-server/llama-core/src/chat.rs
@@ -1405,7 +1405,7 @@ async fn update_n_predict(
         if !should_update {
             should_update = true;
         }
-    } else if metadata.n_predict > available_completion_tokens {
+    } else if metadata.n_predict < available_completion_tokens {
         #[cfg(feature = "logging")]
         info!(target: "llama_core", "n_predict: current: {}, new: {}", metadata.n_predict, available_completion_tokens);
 

--- a/api-server/llama-core/src/chat.rs
+++ b/api-server/llama-core/src/chat.rs
@@ -1475,9 +1475,12 @@ fn post_process(
                 .trim()
                 .to_owned()
         } else if output.as_ref().contains("<|im_end|>") {
-            output.as_ref().split("<|im_end|>").collect::<Vec<_>>()[0]
-                .trim()
-                .to_owned()
+            let output = output.as_ref().trim_end_matches("<|im_end|>").trim();
+            if output.starts_with(": ") {
+                output.trim_start_matches(": ").to_owned()
+            } else {
+                output.to_owned()
+            }
         } else {
             output.as_ref().trim().to_owned()
         }

--- a/api-server/llama-core/src/chat.rs
+++ b/api-server/llama-core/src/chat.rs
@@ -1688,20 +1688,18 @@ fn build_prompt(
                             // system -> user_1 -> user_latest
 
                             chat_request.messages.remove(1);
-                        } else {
-                            if token_info.prompt_tokens > ctx_size {
-                                let err_msg = format!(
+                        } else if token_info.prompt_tokens > ctx_size {
+                            let err_msg = format!(
                                     "The number of prompt tokens is greater than the context size: {} > {}",
                                     token_info.prompt_tokens, ctx_size
                                 );
 
-                                #[cfg(feature = "logging")]
-                                error!(target: "llama_core", "{}", &err_msg);
+                            #[cfg(feature = "logging")]
+                            error!(target: "llama_core", "{}", &err_msg);
 
-                                return Err(LlamaCoreError::Operation(err_msg));
-                            } else {
-                                return Ok((prompt, ctx_size - token_info.prompt_tokens, tool_use));
-                            }
+                            return Err(LlamaCoreError::Operation(err_msg));
+                        } else {
+                            return Ok((prompt, ctx_size - token_info.prompt_tokens, tool_use));
                         }
                     }
                     ChatCompletionRole::User => {
@@ -1731,20 +1729,18 @@ fn build_prompt(
                         {
                             // deal with "user_1 -> user_latest"
                             chat_request.messages.remove(0);
-                        } else {
-                            if token_info.prompt_tokens > ctx_size {
-                                let err_msg = format!(
+                        } else if token_info.prompt_tokens > ctx_size {
+                            let err_msg = format!(
                                     "The number of prompt tokens is greater than the context size: {} > {}",
                                     token_info.prompt_tokens, ctx_size
                                 );
 
-                                #[cfg(feature = "logging")]
-                                error!(target: "llama_core", "{}", &err_msg);
+                            #[cfg(feature = "logging")]
+                            error!(target: "llama_core", "{}", &err_msg);
 
-                                return Err(LlamaCoreError::Operation(err_msg));
-                            } else {
-                                return Ok((prompt, ctx_size - token_info.prompt_tokens, tool_use));
-                            }
+                            return Err(LlamaCoreError::Operation(err_msg));
+                        } else {
+                            return Ok((prompt, ctx_size - token_info.prompt_tokens, tool_use));
                         }
                     }
                     _ => {

--- a/api-server/llama-core/src/completions.rs
+++ b/api-server/llama-core/src/completions.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use endpoints::{
     common::{FinishReason, Usage},
-    completions::{CompletionChoice, CompletionObject, CompletionRequest},
+    completions::{CompletionChoice, CompletionObject, CompletionPrompt, CompletionRequest},
 };
 use std::time::SystemTime;
 
@@ -30,7 +30,10 @@ pub async fn completions(request: &CompletionRequest) -> Result<CompletionObject
         return Err(LlamaCoreError::Operation(err_msg));
     }
 
-    let prompt = request.prompt.join(" ");
+    let prompt = match &request.prompt {
+        CompletionPrompt::SingleText(prompt) => prompt.to_owned(),
+        CompletionPrompt::MultiText(prompts) => prompts.join(" "),
+    };
 
     compute(prompt.trim(), request.model.as_ref())
 }

--- a/api-server/llama-core/src/utils.rs
+++ b/api-server/llama-core/src/utils.rs
@@ -268,7 +268,7 @@ pub(crate) fn get_token_info_by_graph(graph: &Graph) -> Result<TokenInfo, LlamaC
     };
 
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "prompt tokens: {}, comletion tokens: {}", prompt_tokens, completion_tokens);
+    info!(target: "llama-core", "prompt tokens: {}, completion tokens: {}", prompt_tokens, completion_tokens);
 
     Ok(TokenInfo {
         prompt_tokens,

--- a/chat/Cargo.toml
+++ b/chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-chat"
-version = "0.12.4"
+version = "0.12.5"
 edition = "2021"
 
 [dependencies]

--- a/simple/Cargo.toml
+++ b/simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-simple"
-version = "0.12.4"
+version = "0.12.5"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Major changes:

- llama-core
  - Improve `build_prompt` and `update_n_predict`


- `endpoints` crate
  - Extend `prompt` field of `CompletionRequest` to support both a single `String` and an array of `String`

  - Improve `n_choice` field of `ChatCompletionRequest`
    - Deserialize/serialize `n_choice` field from/to `n`
    - Default `n_choice` to 1

  - Default `max_tokens` field of `ChatCompletionRequest` to 1024 (same as default value of `--n-predict` CLI option)

