### PR TITLE
Release 0.14.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,30 +54,22 @@ jobs:
         id: build_simple
         run: |
           cd simple
-          cargo +nightly fmt --all -- --check
-          cargo +nightly clippy --target wasm32-wasip1 -- -D warnings
-          cargo build --target wasm32-wasip1 --release
+          RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo +nightly fmt --all -- --check
+          RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo +nightly clippy --target wasm32-wasip1 -- -D warnings
+          RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release
 
       - name: Build chat
         id: build_chat
         run: |
           cd chat
-          cargo +nightly fmt --all -- --check
-          cargo +nightly clippy --target wasm32-wasip1 -- -D warnings
-          cargo build --target wasm32-wasip1 --release
+          RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo +nightly fmt --all -- --check
+          RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo +nightly clippy --target wasm32-wasip1 -- -D warnings
+          RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release
 
       - name: Build api-server
         id: build_api_server
         run: |
           cd api-server
-          cargo +nightly fmt --all -- --check
-          cargo +nightly clippy --target wasm32-wasip1 -- -D warnings
-          cargo build --target wasm32-wasip1 --release
-
-      - name: Build api-server-full
-        id: build_api_server_full
-        run: |
-          cd api-server
-          cargo +nightly fmt --all -- --check
-          cargo +nightly clippy --target wasm32-wasip1 --features full -- -D warnings
-          cargo build --target wasm32-wasip1 --release --features full
+          RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo +nightly fmt --all -- --check
+          RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo +nightly clippy --target wasm32-wasip1 -- -D warnings
+          RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, macos-12, macos-13]
+        os: [ubuntu-22.04, ubuntu-20.04, macos-13, macos-14]
     steps:
       - name: Clone project
         id: checkout
@@ -50,6 +50,20 @@ jobs:
         with:
           target: wasm32-wasip1
 
+      - name: Download wasi-sdk for x86_64-macos
+        if: matrix.os == 'macos-13'
+        run: |
+          curl -LO https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-24/wasi-sdk-24.0-x86_64-macos.tar.gz
+          tar -xzvf wasi-sdk-24.0-x86_64-macos.tar.gz
+          mv wasi-sdk-24.0-x86_64-macos wasi-sdk-24.0
+
+      - name: Download wasi-sdk for arm64-macos
+        if: matrix.os == 'macos-14'
+        run: |
+          curl -LO https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-24/wasi-sdk-24.0-arm64-macos.tar.gz
+          tar -xzvf wasi-sdk-24.0-arm64-macos.tar.gz
+          mv wasi-sdk-24.0-arm64-macos wasi-sdk-24.0
+
       - name: Build simple
         id: build_simple
         run: |
@@ -66,10 +80,26 @@ jobs:
           RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo +nightly clippy --target wasm32-wasip1 -- -D warnings
           RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release
 
-      - name: Build api-server
-        id: build_api_server
+      - name: Build api-server for linux
+        id: build_api_server_linux
+        if: startsWith(matrix.os, 'ubuntu')
+        env:
+          RUSTFLAGS: "--cfg wasmedge --cfg tokio_unstable"
         run: |
           cd api-server
-          RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo +nightly fmt --all -- --check
-          RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo +nightly clippy --target wasm32-wasip1 -- -D warnings
-          RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release
+          cargo +nightly fmt --all -- --check
+          cargo +nightly clippy --target wasm32-wasip1 -- -D warnings
+          cargo build --target wasm32-wasip1 --release
+
+      - name: Build api-server for macos
+        id: build_api_server_macos
+        if: startsWith(matrix.os, 'macos')
+        env:
+          WASI_SDK_PATH: /Users/runner/work/LlamaEdge/LlamaEdge/wasi-sdk-24.0
+          CC: "/Users/runner/work/LlamaEdge/LlamaEdge/wasi-sdk-24.0/bin/clang --sysroot=/Users/runner/work/LlamaEdge/LlamaEdge/wasi-sdk-24.0/share/wasi-sysroot"
+          RUSTFLAGS: "--cfg wasmedge --cfg tokio_unstable"
+        run: |
+          cd api-server
+          cargo +nightly fmt --all -- --check
+          cargo +nightly clippy --target wasm32-wasip1 -- -D warnings
+          cargo build --target wasm32-wasip1 --release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,19 +66,23 @@ jobs:
 
       - name: Build simple
         id: build_simple
+        env:
+          RUSTFLAGS: "--cfg wasmedge --cfg tokio_unstable"
         run: |
           cd simple
-          RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo +nightly fmt --all -- --check
-          RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo +nightly clippy --target wasm32-wasip1 -- -D warnings
-          RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release
+          cargo +nightly fmt --all -- --check
+          cargo +nightly clippy --target wasm32-wasip1 -- -D warnings
+          cargo build --target wasm32-wasip1 --release
 
       - name: Build chat
         id: build_chat
+        env:
+          RUSTFLAGS: "--cfg wasmedge --cfg tokio_unstable"
         run: |
           cd chat
-          RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo +nightly fmt --all -- --check
-          RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo +nightly clippy --target wasm32-wasip1 -- -D warnings
-          RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" cargo build --target wasm32-wasip1 --release
+          cargo +nightly fmt --all -- --check
+          cargo +nightly clippy --target wasm32-wasip1 -- -D warnings
+          cargo build --target wasm32-wasip1 --release
 
       - name: Build api-server for linux
         id: build_api_server_linux

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Build simple
         id: build_simple
+        env:
+          RUSTFLAGS: "--cfg wasmedge --cfg tokio_unstable"
         run: |
           cd simple
           cargo build --target wasm32-wasip1 --release
@@ -35,6 +37,8 @@ jobs:
 
       - name: Build chat
         id: build_chat
+        env:
+          RUSTFLAGS: "--cfg wasmedge --cfg tokio_unstable"
         run: |
           cd chat
           cargo build --target wasm32-wasip1 --release
@@ -42,19 +46,13 @@ jobs:
 
       - name: Build api-server
         id: build_api_server
+        env:
+          RUSTFLAGS: "--cfg wasmedge --cfg tokio_unstable"
         run: |
           cd api-server
           cargo clean
           cargo build --target wasm32-wasip1 --release
           cp ./target/wasm32-wasip1/release/llama-api-server.wasm ../llama-api-server.wasm
-
-      - name: Build api-server-full
-        id: build_api_server_full
-        run: |
-          cd api-server
-          cargo clean
-          cargo build --target wasm32-wasip1 --release --features full
-          cp ./target/wasm32-wasip1/release/llama-api-server.wasm ../llama-api-server-full.wasm
 
       - name: Calculate checksum
         id: checksum
@@ -81,7 +79,6 @@ jobs:
           prerelease: true
           files: |
             llama-api-server.wasm
-            llama-api-server-full.wasm
             llama-chat.wasm
             llama-simple.wasm
             SHA256SUM

--- a/.github/workflows/publish_core_doc.yml
+++ b/.github/workflows/publish_core_doc.yml
@@ -23,9 +23,12 @@ jobs:
           target: wasm32-wasip1
 
       - name: Build API document
+        env:
+          RUSTFLAGS: "--cfg wasmedge --cfg tokio_unstable"
+          RUSTDOCFLAGS: "--cfg docsrs"
         run: |
           cd api-server
-          RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc -p llama-core --no-deps --target wasm32-wasip1 --features full --target-dir=./target
+          cargo +nightly doc -p llama-core --no-deps --target wasm32-wasip1 --features full --target-dir=./target
 
       - name: Deploy API document
         if: github.ref == 'refs/heads/dev'

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-endpoints = { path = "endpoints", version = "^0.12" }
+endpoints = { path = "endpoints", version = "^0.13" }
 chat-prompts = { path = "chat-prompts", version = "^0.11" }
 thiserror = "1"
 uuid = { version = "1.4", features = ["v4", "fast-rng", "macro-diagnostics"] }

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -14,3 +14,9 @@ log = { version = "0.4.21", features = ["std", "kv", "kv_serde"] }
 wasi-logger = { version = "0.1.2", features = ["kv"] }
 either = "1.12.0"
 base64 = "=0.22.0"
+
+[patch.crates-io]
+socket2 = { git = "https://github.com/second-state/socket2.git", branch = "v0.5.x" }
+reqwest = { git = "https://github.com/second-state/wasi_reqwest.git", branch = "0.11.x" }
+hyper = { git = "https://github.com/second-state/wasi_hyper.git", branch = "v0.14.x" }
+tokio = { git = "https://github.com/second-state/wasi_tokio.git", branch = "v1.36.x" }

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -13,3 +13,4 @@ clap = { version = "4.4.6", features = ["cargo", "derive"] }
 log = { version = "0.4.21", features = ["std", "kv", "kv_serde"] }
 wasi-logger = { version = "0.1.2", features = ["kv"] }
 either = "1.12.0"
+base64 = "=0.22.0"

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -564,6 +564,8 @@ Options:
           The main GPU to use
       --tensor-split <TENSOR_SPLIT>
           How split tensors should be distributed accross GPUs. If None the model is not split; otherwise, a comma-separated list of non-negative values, e.g., "3,2" presents 60% of the data to GPU 0 and 40% to GPU 1
+      --threads <THREADS>
+          Number of threads to use during computation [default: 2]
       --no-mmap <NO_MMAP>
           Disable memory mapping for file access of chat models [possible values: true, false]
       --temp <TEMP>

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -578,6 +578,10 @@ Options:
           Repeat alpha presence penalty. 0.0 = disabled [default: 0.0]
       --frequency-penalty <FREQUENCY_PENALTY>
           Repeat alpha frequency penalty. 0.0 = disabled [default: 0.0]
+      --grammar <GRAMMAR>
+          BNF-like grammar to constrain generations (see samples in grammars/ dir) [default: ]
+      --json-schema <JSON_SCHEMA>
+          JSON schema to constrain generations (https://json-schema.org/), e.g. `{}` for any JSON object. For schemas w/ external $refs, use --grammar + example/json_schema_to_grammar.py instead
       --llava-mmproj <LLAVA_MMPROJ>
           Path to the multimodal projector file
       --socket-addr <SOCKET_ADDR>

--- a/api-server/chat-prompts/Cargo.toml
+++ b/api-server/chat-prompts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chat-prompts"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/api-server/chat-prompts/Cargo.toml
+++ b/api-server/chat-prompts/Cargo.toml
@@ -14,7 +14,7 @@ endpoints.workspace = true
 thiserror.workspace = true
 enum_dispatch = "0.3.12"
 image = "=0.25.0"
-base64 = "=0.22.0"
+base64.workspace = true
 clap.workspace = true
 serde.workspace = true
 serde_json = "1.0"

--- a/api-server/endpoints/Cargo.toml
+++ b/api-server/endpoints/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endpoints"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/api-server/endpoints/src/files.rs
+++ b/api-server/endpoints/src/files.rs
@@ -28,7 +28,7 @@ pub struct FileObject {
     pub purpose: String,
 }
 
-/// List files.
+/// Represent the response from the `files` endpoint.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ListFilesResponse {
     /// The object type, which is always `list`.

--- a/api-server/endpoints/src/images.rs
+++ b/api-server/endpoints/src/images.rs
@@ -80,7 +80,7 @@ pub struct ImageCreateRequest {
     /// The quality of the image that will be generated. hd creates images with finer details and greater consistency across the image. Defaults to "standard". This param is only supported for OpenAI `dall-e-3`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quality: Option<String>,
-    /// The format in which the generated images are returned. Must be one of `url` or `b64_json`. Defaults to `b64_json`.
+    /// The format in which the generated images are returned. Must be one of `url` or `b64_json`. Defaults to `Url`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response_format: Option<ResponseFormat>,
     /// The size of the generated images. Defaults to 1024x1024.
@@ -339,7 +339,7 @@ impl ImageEditRequestBuilder {
                 mask: None,
                 model: model.into(),
                 n: Some(1),
-                response_format: Some(ResponseFormat::B64Json),
+                response_format: Some(ResponseFormat::Url),
                 ..Default::default()
             },
         }
@@ -538,7 +538,7 @@ impl<'de> Deserialize<'de> for ImageEditRequest {
                     model: model.ok_or_else(|| de::Error::missing_field("model"))?,
                     n: n.unwrap_or(Some(1)),
                     size,
-                    response_format: response_format.unwrap_or(Some(ResponseFormat::B64Json)),
+                    response_format: response_format.unwrap_or(Some(ResponseFormat::Url)),
                     user,
                 })
             }
@@ -577,7 +577,7 @@ fn test_serialize_image_edit_request() {
         let json = serde_json::to_string(&req).unwrap();
         assert_eq!(
             json,
-            r#"{"image":{"id":"test-image-id","bytes":1024,"created_at":1234567890,"filename":"test-image.png","object":"file","purpose":"fine-tune"},"prompt":"This is a prompt","model":"test-model-name","n":1,"response_format":"b64_json"}"#
+            r#"{"image":{"id":"test-image-id","bytes":1024,"created_at":1234567890,"filename":"test-image.png","object":"file","purpose":"fine-tune"},"prompt":"This is a prompt","model":"test-model-name","n":1,"response_format":"url"}"#
         );
     }
 
@@ -595,14 +595,14 @@ fn test_serialize_image_edit_request() {
             "This is a prompt",
         )
         .with_number_of_images(2)
-        .with_response_format(ResponseFormat::Url)
+        .with_response_format(ResponseFormat::B64Json)
         .with_size("256x256")
         .with_user("user")
         .build();
         let json = serde_json::to_string(&req).unwrap();
         assert_eq!(
             json,
-            r#"{"image":{"id":"test-image-id","bytes":1024,"created_at":1234567890,"filename":"test-image.png","object":"file","purpose":"fine-tune"},"prompt":"This is a prompt","model":"test-model-name","n":2,"size":"256x256","response_format":"url","user":"user"}"#
+            r#"{"image":{"id":"test-image-id","bytes":1024,"created_at":1234567890,"filename":"test-image.png","object":"file","purpose":"fine-tune"},"prompt":"This is a prompt","model":"test-model-name","n":2,"size":"256x256","response_format":"b64_json","user":"user"}"#
         );
     }
 }
@@ -622,11 +622,11 @@ fn test_deserialize_image_edit_request() {
         assert!(req.mask.is_none());
         assert_eq!(req.model, "test-model-name");
         assert_eq!(req.n, Some(1));
-        assert_eq!(req.response_format, Some(ResponseFormat::B64Json));
+        assert_eq!(req.response_format, Some(ResponseFormat::Url));
     }
 
     {
-        let json = r#"{"image":{"id":"test-image-id","bytes":1024,"created_at":1234567890,"filename":"test-image.png","object":"file","purpose":"fine-tune"},"prompt":"This is a prompt","model":"test-model-name","n":2,"size":"256x256","response_format":"url","user":"user"}"#;
+        let json = r#"{"image":{"id":"test-image-id","bytes":1024,"created_at":1234567890,"filename":"test-image.png","object":"file","purpose":"fine-tune"},"prompt":"This is a prompt","model":"test-model-name","n":2,"size":"256x256","response_format":"b64_json","user":"user"}"#;
         let req: ImageEditRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.image.id, "test-image-id");
         assert_eq!(req.image.bytes, 1024);
@@ -639,7 +639,7 @@ fn test_deserialize_image_edit_request() {
         assert_eq!(req.model, "test-model-name");
         assert_eq!(req.n, Some(2));
         assert_eq!(req.size, Some("256x256".to_string()));
-        assert_eq!(req.response_format, Some(ResponseFormat::Url));
+        assert_eq!(req.response_format, Some(ResponseFormat::B64Json));
         assert_eq!(req.user, Some("user".to_string()));
     }
 }

--- a/api-server/endpoints/src/images.rs
+++ b/api-server/endpoints/src/images.rs
@@ -5,7 +5,7 @@ use serde::{
     de::{self, MapAccess, SeqAccess, Visitor},
     Deserialize, Deserializer, Serialize,
 };
-use std::fmt;
+use std::{fmt, str::FromStr};
 
 /// Builder for creating a `ImageCreateRequest` instance.
 pub struct ImageCreateRequestBuilder {
@@ -651,6 +651,29 @@ pub enum ResponseFormat {
     Url,
     #[serde(rename = "b64_json")]
     B64Json,
+}
+impl FromStr for ResponseFormat {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "url" => Ok(ResponseFormat::Url),
+            "b64_json" => Ok(ResponseFormat::B64Json),
+            _ => Err(ParseError),
+        }
+    }
+}
+
+// Custom error type for conversion errors
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParseError;
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "provided string did not match any ResponseFormat variants"
+        )
+    }
 }
 
 /// Represents the url or the content of an image generated.

--- a/api-server/endpoints/src/images.rs
+++ b/api-server/endpoints/src/images.rs
@@ -644,6 +644,153 @@ fn test_deserialize_image_edit_request() {
     }
 }
 
+/// Request to generate an image variation.
+#[derive(Debug, Serialize, Default)]
+pub struct ImageVariationRequest {
+    /// The image to use as the basis for the variation(s).
+    pub image: FileObject,
+    /// Name of the model to use for image generation.
+    pub model: String,
+    /// The number of images to generate. Defaults to 1.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub n: Option<u64>,
+    /// The format in which the generated images are returned. Must be one of `url` or `b64_json`. Defaults to `b64_json`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_format: Option<ResponseFormat>,
+    /// The size of the generated images. Defaults to 1024x1024.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size: Option<String>,
+    /// A unique identifier representing your end-user, which can help monitor and detect abuse.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+}
+impl<'de> Deserialize<'de> for ImageVariationRequest {
+    fn deserialize<D>(deserializer: D) -> Result<ImageVariationRequest, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        enum Field {
+            Image,
+            Model,
+            N,
+            ResponseFormat,
+            Size,
+            User,
+        }
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                        formatter.write_str("field identifier")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                    where
+                        E: de::Error,
+                    {
+                        match value {
+                            "image" => Ok(Field::Image),
+                            "model" => Ok(Field::Model),
+                            "n" => Ok(Field::N),
+                            "response_format" => Ok(Field::ResponseFormat),
+                            "size" => Ok(Field::Size),
+                            "user" => Ok(Field::User),
+                            _ => Err(de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct ImageVariationRequestVisitor;
+
+        impl<'de> Visitor<'de> for ImageVariationRequestVisitor {
+            type Value = ImageVariationRequest;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct ImageVariationRequest")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<ImageVariationRequest, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut image = None;
+                let mut model = None;
+                let mut n = None;
+                let mut response_format = None;
+                let mut size = None;
+                let mut user = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::Image => {
+                            if image.is_some() {
+                                return Err(de::Error::duplicate_field("image"));
+                            }
+                            image = Some(map.next_value()?);
+                        }
+                        Field::Model => {
+                            if model.is_some() {
+                                return Err(de::Error::duplicate_field("model"));
+                            }
+                            model = Some(map.next_value()?);
+                        }
+                        Field::N => {
+                            if n.is_some() {
+                                return Err(de::Error::duplicate_field("n"));
+                            }
+                            n = Some(map.next_value()?);
+                        }
+                        Field::ResponseFormat => {
+                            if response_format.is_some() {
+                                return Err(de::Error::duplicate_field("response_format"));
+                            }
+                            response_format = Some(map.next_value()?);
+                        }
+                        Field::Size => {
+                            if size.is_some() {
+                                return Err(de::Error::duplicate_field("size"));
+                            }
+                            size = Some(map.next_value()?);
+                        }
+                        Field::User => {
+                            if user.is_some() {
+                                return Err(de::Error::duplicate_field("user"));
+                            }
+                            user = Some(map.next_value()?);
+                        }
+                    }
+                }
+                Ok(ImageVariationRequest {
+                    image: image.ok_or_else(|| de::Error::missing_field("image"))?,
+                    model: model.ok_or_else(|| de::Error::missing_field("model"))?,
+                    n: n.unwrap_or(Some(1)),
+                    response_format: response_format.unwrap_or(Some(ResponseFormat::B64Json)),
+                    size,
+                    user,
+                })
+            }
+        }
+
+        const FIELDS: &[&str] = &["image", "model", "n", "response_format", "size", "user"];
+        deserializer.deserialize_struct(
+            "ImageVariationRequest",
+            FIELDS,
+            ImageVariationRequestVisitor,
+        )
+    }
+}
+
 /// The format in which the generated images are returned.
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 pub enum ResponseFormat {

--- a/api-server/endpoints/src/images.rs
+++ b/api-server/endpoints/src/images.rs
@@ -666,3 +666,12 @@ pub struct ImageObject {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prompt: Option<String>,
 }
+
+/// Represent the response from the `images` endpoint.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ListImagesResponse {
+    /// The Unix timestamp (in seconds) for when the response was created.
+    pub created: u64,
+    /// The list of file objects.
+    pub data: Vec<ImageObject>,
+}

--- a/api-server/endpoints/src/images.rs
+++ b/api-server/endpoints/src/images.rs
@@ -19,7 +19,7 @@ impl ImageCreateRequestBuilder {
                 model: model.into(),
                 prompt: prompt.into(),
                 n: Some(1),
-                response_format: Some(ResponseFormat::B64Json),
+                response_format: Some(ResponseFormat::Url),
                 ..Default::default()
             },
         }
@@ -166,7 +166,7 @@ impl<'de> Deserialize<'de> for ImageCreateRequest {
                     .ok_or_else(|| de::Error::invalid_length(1, &self))?;
                 let n = seq.next_element()?.unwrap_or(Some(1));
                 let quality = seq.next_element()?;
-                let response_format = seq.next_element()?.unwrap_or(Some(ResponseFormat::B64Json));
+                let response_format = seq.next_element()?.unwrap_or(Some(ResponseFormat::Url));
                 let size = seq.next_element()?;
                 let style = seq.next_element()?;
                 let user = seq.next_element()?;
@@ -252,7 +252,7 @@ impl<'de> Deserialize<'de> for ImageCreateRequest {
                     model: model.ok_or_else(|| de::Error::missing_field("model"))?,
                     n: n.unwrap_or(Some(1)),
                     quality,
-                    response_format: response_format.unwrap_or(Some(ResponseFormat::B64Json)),
+                    response_format: response_format.unwrap_or(Some(ResponseFormat::Url)),
                     size,
                     style,
                     user,
@@ -281,14 +281,14 @@ fn test_serialize_image_create_request() {
         let json = serde_json::to_string(&req).unwrap();
         assert_eq!(
             json,
-            r#"{"prompt":"This is a prompt","model":"test-model-name","n":1,"response_format":"b64_json"}"#
+            r#"{"prompt":"This is a prompt","model":"test-model-name","n":1,"response_format":"url"}"#
         );
     }
 
     {
         let req = ImageCreateRequestBuilder::new("test-model-name", "This is a prompt")
             .with_number_of_images(2)
-            .with_response_format(ResponseFormat::Url)
+            .with_response_format(ResponseFormat::B64Json)
             .with_size("1024x1024")
             .with_style("vivid")
             .with_user("user")
@@ -296,7 +296,7 @@ fn test_serialize_image_create_request() {
         let json = serde_json::to_string(&req).unwrap();
         assert_eq!(
             json,
-            r#"{"prompt":"This is a prompt","model":"test-model-name","n":2,"response_format":"url","size":"1024x1024","style":"vivid","user":"user"}"#
+            r#"{"prompt":"This is a prompt","model":"test-model-name","n":2,"response_format":"b64_json","size":"1024x1024","style":"vivid","user":"user"}"#
         );
     }
 }
@@ -309,7 +309,7 @@ fn test_deserialize_image_create_request() {
         assert_eq!(req.prompt, "This is a prompt");
         assert_eq!(req.model, "test-model-name");
         assert_eq!(req.n, Some(1));
-        assert_eq!(req.response_format, Some(ResponseFormat::B64Json));
+        assert_eq!(req.response_format, Some(ResponseFormat::Url));
     }
 
     {
@@ -399,7 +399,7 @@ pub struct ImageEditRequest {
     /// The size of the generated images. Defaults to 1024x1024.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<String>,
-    /// The format in which the generated images are returned. Must be one of `url` or `b64_json`. Defaults to `b64_json`.
+    /// The format in which the generated images are returned. Must be one of `url` or `b64_json`. Defaults to `url`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response_format: Option<ResponseFormat>,
     /// A unique identifier representing your end-user, which can help monitor and detect abuse.

--- a/api-server/llama-api-server/Cargo.toml
+++ b/api-server/llama-api-server/Cargo.toml
@@ -11,8 +11,8 @@ serde_json.workspace = true
 endpoints.workspace = true
 chat-prompts.workspace = true
 serde_yaml = "0.9"
-hyper_wasi = { version = "0.15", features = ["full"] }
-tokio_wasi = { version = "1", features = ["full"] }
+hyper = { version = "0.14", features = ["full"] }
+tokio = { version = "^1.36", features = ["io-util", "fs", "net", "time", "rt", "macros"] }
 thiserror.workspace = true
 uuid.workspace = true
 clap.workspace = true
@@ -28,5 +28,3 @@ walkdir = "2.5.0"
 
 [features]
 default = []
-full = ["https"]
-https = ["llama-core/https"]

--- a/api-server/llama-api-server/Cargo.toml
+++ b/api-server/llama-api-server/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "llama-api-server"
-version = "0.13.2"
+version = "0.14.0"
 edition = "2021"
 
 [dependencies]
 llama-core = { path = "../llama-core", features = ["logging"] }
+endpoints.workspace = true
+chat-prompts.workspace = true
 futures = { version = "0.3.6", default-features = false, features = ["async-await", "std"] }
 serde.workspace = true
 serde_json.workspace = true
-endpoints.workspace = true
-chat-prompts.workspace = true
 serde_yaml = "0.9"
 hyper = { version = "0.14", features = ["full"] }
 tokio = { version = "^1.36", features = ["io-util", "fs", "net", "time", "rt", "macros"] }

--- a/api-server/llama-api-server/src/backend/ggml.rs
+++ b/api-server/llama-api-server/src/backend/ggml.rs
@@ -21,7 +21,7 @@ use walkdir::{DirEntry, WalkDir};
 /// List all models available.
 pub(crate) async fn models_handler() -> Response<Body> {
     // log
-    info!(target: "models_handler", "Handling the coming model list request.");
+    info!(target: "stdout", "Handling the coming model list request.");
 
     let list_models_response = match llama_core::models::models().await {
         Ok(list_models_response) => list_models_response,
@@ -29,7 +29,7 @@ pub(crate) async fn models_handler() -> Response<Body> {
             let err_msg = format!("Failed to get model list. Reason: {}", e);
 
             // log
-            error!(target: "models_handler", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             return error::internal_server_error(err_msg);
         }
@@ -42,7 +42,7 @@ pub(crate) async fn models_handler() -> Response<Body> {
             let err_msg = format!("Failed to serialize the model list result. Reason: {}", e);
 
             // log
-            error!(target: "models_handler", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             return error::internal_server_error(err_msg);
         }
@@ -61,14 +61,14 @@ pub(crate) async fn models_handler() -> Response<Body> {
             let err_msg = format!("Failed to get model list. Reason: {}", e);
 
             // log
-            error!(target: "models_handler", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             error::internal_server_error(err_msg)
         }
     };
 
     // log
-    info!(target: "models_handler", "Send the model list response.");
+    info!(target: "stdout", "Send the model list response.");
 
     res
 }
@@ -76,7 +76,7 @@ pub(crate) async fn models_handler() -> Response<Body> {
 /// Compute embeddings for the input text and return the embeddings object.
 pub(crate) async fn embeddings_handler(mut req: Request<Body>) -> Response<Body> {
     // log
-    info!(target: "embeddings_handler", "Handling the coming embeddings request");
+    info!(target: "stdout", "Handling the coming embeddings request");
 
     if req.method().eq(&hyper::http::Method::OPTIONS) {
         let result = Response::builder()
@@ -106,7 +106,7 @@ pub(crate) async fn embeddings_handler(mut req: Request<Body>) -> Response<Body>
             let err_msg = format!("Fail to read buffer from request body. {}", e);
 
             // log
-            error!(target: "embeddings_handler", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             return error::internal_server_error(err_msg);
         }
@@ -117,7 +117,7 @@ pub(crate) async fn embeddings_handler(mut req: Request<Body>) -> Response<Body>
             let err_msg = format!("Fail to deserialize embedding request: {msg}", msg = e);
 
             // log
-            error!(target: "embeddings_handler", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             return error::bad_request(err_msg);
         }
@@ -129,7 +129,7 @@ pub(crate) async fn embeddings_handler(mut req: Request<Body>) -> Response<Body>
     let id = embedding_request.user.clone().unwrap();
 
     // log user id
-    info!(target: "embeddings_handler", "user: {}", &id);
+    info!(target: "stdout", "user: {}", &id);
 
     let res = match llama_core::embeddings::embeddings(&embedding_request).await {
         Ok(embedding_response) => {
@@ -150,7 +150,7 @@ pub(crate) async fn embeddings_handler(mut req: Request<Body>) -> Response<Body>
                             let err_msg = e.to_string();
 
                             // log
-                            error!(target: "embeddings_handler", "{}", &err_msg);
+                            error!(target: "stdout", "{}", &err_msg);
 
                             error::internal_server_error(err_msg)
                         }
@@ -160,7 +160,7 @@ pub(crate) async fn embeddings_handler(mut req: Request<Body>) -> Response<Body>
                     let err_msg = format!("Fail to serialize embedding object. {}", e);
 
                     // log
-                    error!(target: "embeddings_handler", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     error::internal_server_error(err_msg)
                 }
@@ -170,13 +170,13 @@ pub(crate) async fn embeddings_handler(mut req: Request<Body>) -> Response<Body>
             let err_msg = e.to_string();
 
             // log
-            error!(target: "embeddings_handler", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             error::internal_server_error(err_msg)
         }
     };
 
-    info!(target: "embeddings_handler", "Send the embeddings response");
+    info!(target: "stdout", "Send the embeddings response");
 
     res
 }
@@ -184,7 +184,7 @@ pub(crate) async fn embeddings_handler(mut req: Request<Body>) -> Response<Body>
 /// Process a completion request and returns a completion response with the answer from the model.
 pub(crate) async fn completions_handler(mut req: Request<Body>) -> Response<Body> {
     // log
-    info!(target: "completions_handler", "Handling the coming completions request.");
+    info!(target: "stdout", "Handling the coming completions request.");
 
     if req.method().eq(&hyper::http::Method::OPTIONS) {
         let result = Response::builder()
@@ -214,7 +214,7 @@ pub(crate) async fn completions_handler(mut req: Request<Body>) -> Response<Body
             let err_msg = format!("Fail to read buffer from request body. {}", e);
 
             // log
-            error!(target: "completions_handler", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             return error::internal_server_error(err_msg);
         }
@@ -225,7 +225,7 @@ pub(crate) async fn completions_handler(mut req: Request<Body>) -> Response<Body
             let err_msg = format!("Fail to deserialize completions request: {msg}", msg = e);
 
             // log
-            error!(target: "completions_handler", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             return error::bad_request(err_msg);
         }
@@ -237,7 +237,7 @@ pub(crate) async fn completions_handler(mut req: Request<Body>) -> Response<Body
     let id = completion_request.user.clone().unwrap();
 
     // log user id
-    info!(target: "completions_handler", "user: {}", &id);
+    info!(target: "stdout", "user: {}", &id);
 
     let res = match llama_core::completions::completions(&completion_request).await {
         Ok(completion_object) => {
@@ -248,7 +248,7 @@ pub(crate) async fn completions_handler(mut req: Request<Body>) -> Response<Body
                     let err_msg = format!("Fail to serialize completion object. {}", e);
 
                     // log
-                    error!(target: "completions_handler", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     return error::internal_server_error(err_msg);
                 }
@@ -268,7 +268,7 @@ pub(crate) async fn completions_handler(mut req: Request<Body>) -> Response<Body
                     let err_msg = e.to_string();
 
                     // log
-                    error!(target: "completions_handler", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     error::internal_server_error(err_msg)
                 }
@@ -278,20 +278,20 @@ pub(crate) async fn completions_handler(mut req: Request<Body>) -> Response<Body
             let err_msg = e.to_string();
 
             // log
-            error!(target: "completions_handler", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             error::internal_server_error(err_msg)
         }
     };
 
-    info!(target: "completions_handler", "Send the completions response.");
+    info!(target: "stdout", "Send the completions response.");
 
     res
 }
 
 /// Process a chat-completion request and returns a chat-completion response with the answer from the model.
 pub(crate) async fn chat_completions_handler(mut req: Request<Body>) -> Response<Body> {
-    info!(target: "chat_completions_handler", "Handling the coming chat completion request.");
+    info!(target: "stdout", "Handling the coming chat completion request.");
 
     if req.method().eq(&hyper::http::Method::OPTIONS) {
         let result = Response::builder()
@@ -307,14 +307,14 @@ pub(crate) async fn chat_completions_handler(mut req: Request<Body>) -> Response
                 let err_msg = e.to_string();
 
                 // log
-                error!(target: "chat_completions_handler", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 return error::internal_server_error(err_msg);
             }
         }
     }
 
-    info!(target: "chat_completions_handler", "Prepare the chat completion request.");
+    info!(target: "stdout", "Prepare the chat completion request.");
 
     // parse request
     let body_bytes = match to_bytes(req.body_mut()).await {
@@ -323,7 +323,7 @@ pub(crate) async fn chat_completions_handler(mut req: Request<Body>) -> Response
             let err_msg = format!("Fail to read buffer from request body. {}", e);
 
             // log
-            error!(target: "chat_completions_handler", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             return error::internal_server_error(err_msg);
         }
@@ -337,7 +337,7 @@ pub(crate) async fn chat_completions_handler(mut req: Request<Body>) -> Response
             );
 
             // log
-            error!(target: "chat_completions_handler", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             return error::bad_request(err_msg);
         }
@@ -350,7 +350,7 @@ pub(crate) async fn chat_completions_handler(mut req: Request<Body>) -> Response
     let id = chat_request.user.clone().unwrap();
 
     // log user id
-    info!(target: "chat_completions_handler", "user: {}", chat_request.user.clone().unwrap());
+    info!(target: "stdout", "user: {}", chat_request.user.clone().unwrap());
 
     let res = match llama_core::chat::chat(&mut chat_request).await {
         Ok(result) => match result {
@@ -370,7 +370,7 @@ pub(crate) async fn chat_completions_handler(mut req: Request<Body>) -> Response
                 match result {
                     Ok(response) => {
                         // log
-                        info!(target: "chat_completions_stream", "finish chat completions in stream mode");
+                        info!(target: "stdout", "finish chat completions in stream mode");
 
                         response
                     }
@@ -379,7 +379,7 @@ pub(crate) async fn chat_completions_handler(mut req: Request<Body>) -> Response
                             format!("Failed chat completions in stream mode. Reason: {}", e);
 
                         // log
-                        error!(target: "chat_completions_stream", "{}", &err_msg);
+                        error!(target: "stdout", "{}", &err_msg);
 
                         error::internal_server_error(err_msg)
                     }
@@ -393,7 +393,7 @@ pub(crate) async fn chat_completions_handler(mut req: Request<Body>) -> Response
                         let err_msg = format!("Failed to serialize chat completion object. {}", e);
 
                         // log
-                        error!(target: "chat_completions", "{}", &err_msg);
+                        error!(target: "stdout", "{}", &err_msg);
 
                         return error::internal_server_error(err_msg);
                     }
@@ -411,7 +411,7 @@ pub(crate) async fn chat_completions_handler(mut req: Request<Body>) -> Response
                 match result {
                     Ok(response) => {
                         // log
-                        info!(target: "chat_completions", "Finish chat completions in non-stream mode");
+                        info!(target: "stdout", "Finish chat completions in non-stream mode");
 
                         response
                     }
@@ -420,7 +420,7 @@ pub(crate) async fn chat_completions_handler(mut req: Request<Body>) -> Response
                             format!("Failed chat completions in non-stream mode. Reason: {}", e);
 
                         // log
-                        error!(target: "chat_completions", "{}", &err_msg);
+                        error!(target: "stdout", "{}", &err_msg);
 
                         error::internal_server_error(err_msg)
                     }
@@ -431,14 +431,14 @@ pub(crate) async fn chat_completions_handler(mut req: Request<Body>) -> Response
             let err_msg = format!("Failed to get chat completions. Reason: {}", e);
 
             // log
-            error!(target: "chat_completions_handler", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             error::internal_server_error(err_msg)
         }
     };
 
     // log
-    info!(target: "chat_completions_handler", "Send the chat completion response.");
+    info!(target: "stdout", "Send the chat completion response.");
 
     res
 }
@@ -446,7 +446,7 @@ pub(crate) async fn chat_completions_handler(mut req: Request<Body>) -> Response
 /// Upload files and return the file object.
 pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
     // log
-    info!(target: "files_handler", "Handling the coming files request");
+    info!(target: "stdout", "Handling the coming files request");
 
     let res = if req.method() == Method::POST {
         let boundary = "boundary=";
@@ -464,7 +464,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
                 let err_msg = format!("Fail to read buffer from request body. {}", e);
 
                 // log
-                error!(target: "files_handler", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 return error::internal_server_error(err_msg);
             }
@@ -484,7 +484,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
                             "Failed to upload the target file. The filename is not provided.";
 
                         // log
-                        error!(target: "files_handler", "{}", &err_msg);
+                        error!(target: "stdout", "{}", &err_msg);
 
                         return error::internal_server_error(err_msg);
                     }
@@ -500,7 +500,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
                     );
 
                     // log
-                    error!(target: "files_handler", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     return error::internal_server_error(err_msg);
                 }
@@ -512,7 +512,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
                         let err_msg = format!("Failed to read the target file. {}", e);
 
                         // log
-                        error!(target: "files_handler", "{}", &err_msg);
+                        error!(target: "stdout", "{}", &err_msg);
 
                         return error::internal_server_error(err_msg);
                     }
@@ -537,7 +537,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
                             format!("Failed to create archive document {}. {}", &filename, e);
 
                         // log
-                        error!(target: "files_handler", "{}", &err_msg);
+                        error!(target: "stdout", "{}", &err_msg);
 
                         return error::internal_server_error(err_msg);
                     }
@@ -545,7 +545,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
                 file.write_all(&buffer[..]).unwrap();
 
                 // log
-                info!(target: "files_handler", "file_id: {}, file_name: {}", &id, &filename);
+                info!(target: "stdout", "file_id: {}, file_name: {}", &id, &filename);
 
                 let created_at = match SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
                     Ok(n) => n.as_secs(),
@@ -553,7 +553,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
                         let err_msg = "Failed to get the current time.";
 
                         // log
-                        error!(target: "files_handler", "{}", &err_msg);
+                        error!(target: "stdout", "{}", &err_msg);
 
                         return error::internal_server_error(err_msg);
                     }
@@ -582,7 +582,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
                         let err_msg = format!("Failed to serialize file object. {}", e);
 
                         // log
-                        error!(target: "files_handler", "{}", &err_msg);
+                        error!(target: "stdout", "{}", &err_msg);
 
                         return error::internal_server_error(err_msg);
                     }
@@ -602,7 +602,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
                         let err_msg = e.to_string();
 
                         // log
-                        error!(target: "files_handler", "{}", &err_msg);
+                        error!(target: "stdout", "{}", &err_msg);
 
                         error::internal_server_error(err_msg)
                     }
@@ -612,7 +612,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
                 let err_msg = "Failed to upload the target file. Not found the target file.";
 
                 // log
-                error!(target: "files_handler", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 error::internal_server_error(err_msg)
             }
@@ -624,7 +624,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
             let mut file_objects: Vec<FileObject> = Vec::new();
             for entry in WalkDir::new("archives").into_iter().filter_map(|e| e.ok()) {
                 if !is_hidden(&entry) && entry.path().is_file() {
-                    info!(target: "files_handler", "archive file: {}", entry.path().display());
+                    info!(target: "stdout", "archive file: {}", entry.path().display());
 
                     let id = entry
                         .path()
@@ -666,7 +666,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
                 }
             }
 
-            info!(target: "files_handler", "Found {} archive files", file_objects.len());
+            info!(target: "stdout", "Found {} archive files", file_objects.len());
 
             let file_objects = ListFilesResponse {
                 object: "list".to_string(),
@@ -680,7 +680,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
                     let err_msg = format!("Failed to serialize file object. {}", e);
 
                     // log
-                    error!(target: "files_handler", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     return error::internal_server_error(err_msg);
                 }
@@ -700,7 +700,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
                     let err_msg = e.to_string();
 
                     // log
-                    error!(target: "files_handler", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     error::internal_server_error(err_msg)
                 }
@@ -711,7 +711,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
             let mut file_object: Option<FileObject> = None;
             for entry in WalkDir::new(root).into_iter().filter_map(|e| e.ok()) {
                 if !is_hidden(&entry) && entry.path().is_file() {
-                    info!(target: "files_handler", "archive file: {}", entry.path().display());
+                    info!(target: "stdout", "archive file: {}", entry.path().display());
 
                     let filename = entry
                         .path()
@@ -753,7 +753,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
                             let err_msg = format!("Failed to serialize file object. {}", e);
 
                             // log
-                            error!(target: "files_handler", "{}", &err_msg);
+                            error!(target: "stdout", "{}", &err_msg);
 
                             return error::internal_server_error(err_msg);
                         }
@@ -773,7 +773,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
                             let err_msg = e.to_string();
 
                             // log
-                            error!(target: "files_handler", "{}", &err_msg);
+                            error!(target: "stdout", "{}", &err_msg);
 
                             error::internal_server_error(err_msg)
                         }
@@ -786,7 +786,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
                     );
 
                     // log
-                    error!(target: "files_handler", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     error::internal_server_error(err_msg)
                 }
@@ -797,7 +797,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
         let root = format!("archives/{}", id);
         let status = match fs::remove_dir_all(root) {
             Ok(_) => {
-                info!(target: "files_handler", "Successfully deleted the target file with id {}.", id);
+                info!(target: "stdout", "Successfully deleted the target file with id {}.", id);
 
                 DeleteFileStatus {
                     id: id.into(),
@@ -809,7 +809,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
                 let err_msg = format!("Failed to delete the target file with id {}. {}", id, e);
 
                 // log
-                error!(target: "files_handler", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 DeleteFileStatus {
                     id: id.into(),
@@ -829,7 +829,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
                 );
 
                 // log
-                error!(target: "files_handler", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 return error::internal_server_error(err_msg);
             }
@@ -849,7 +849,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
                 let err_msg = e.to_string();
 
                 // log
-                error!(target: "files_handler", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 error::internal_server_error(err_msg)
             }
@@ -877,12 +877,12 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
         let err_msg = "Invalid HTTP Method.";
 
         // log
-        error!(target: "files_handler", "{}", &err_msg);
+        error!(target: "stdout", "{}", &err_msg);
 
         error::internal_server_error(err_msg)
     };
 
-    info!(target: "files_handler", "Send the files response");
+    info!(target: "stdout", "Send the files response");
 
     res
 }
@@ -890,7 +890,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
 /// Segment the text into chunks and return the chunks response.
 pub(crate) async fn chunks_handler(mut req: Request<Body>) -> Response<Body> {
     // log
-    info!(target: "chunks_handler", "Handling the coming chunks request");
+    info!(target: "stdout", "Handling the coming chunks request");
 
     if req.method().eq(&hyper::http::Method::OPTIONS) {
         let result = Response::builder()
@@ -920,7 +920,7 @@ pub(crate) async fn chunks_handler(mut req: Request<Body>) -> Response<Body> {
             let err_msg = format!("Fail to read buffer from request body. {}", e);
 
             // log
-            error!(target: "chunks_handler", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             return error::internal_server_error(err_msg);
         }
@@ -932,7 +932,7 @@ pub(crate) async fn chunks_handler(mut req: Request<Body>) -> Response<Body> {
             let err_msg = format!("Fail to deserialize chunks request: {msg}", msg = e);
 
             // log
-            error!(target: "chunks_handler", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             return error::bad_request(err_msg);
         }
@@ -944,7 +944,7 @@ pub(crate) async fn chunks_handler(mut req: Request<Body>) -> Response<Body> {
         let err_msg = "The `archives` directory does not exist.";
 
         // log
-        error!(target: "chunks_handler", "{}", &err_msg);
+        error!(target: "stdout", "{}", &err_msg);
 
         return error::internal_server_error(err_msg);
     }
@@ -955,7 +955,7 @@ pub(crate) async fn chunks_handler(mut req: Request<Body>) -> Response<Body> {
         let err_msg = format!("Not found archive id: {}", &chunks_request.id);
 
         // log
-        error!(target: "chunks_handler", "{}", &err_msg);
+        error!(target: "stdout", "{}", &err_msg);
 
         return error::internal_server_error(err_msg);
     }
@@ -969,13 +969,13 @@ pub(crate) async fn chunks_handler(mut req: Request<Body>) -> Response<Body> {
         );
 
         // log
-        error!(target: "chunks_handler", "{}", &err_msg);
+        error!(target: "stdout", "{}", &err_msg);
 
         return error::internal_server_error(err_msg);
     }
 
     // log
-    info!(target: "chunks_handler", "file_id: {}, file_name: {}", &chunks_request.id, &chunks_request.filename);
+    info!(target: "stdout", "file_id: {}, file_name: {}", &chunks_request.id, &chunks_request.filename);
 
     // get the extension of the archived file
     let extension = match file_path.extension().and_then(std::ffi::OsStr::to_str) {
@@ -987,7 +987,7 @@ pub(crate) async fn chunks_handler(mut req: Request<Body>) -> Response<Body> {
             );
 
             // log
-            error!(target: "chunks_handler", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             return error::internal_server_error(err_msg);
         }
@@ -1000,7 +1000,7 @@ pub(crate) async fn chunks_handler(mut req: Request<Body>) -> Response<Body> {
             let err_msg = format!("Failed to open `{}`. {}", &chunks_request.filename, e);
 
             // log
-            error!(target: "chunks_handler", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             return error::internal_server_error(err_msg);
         }
@@ -1012,7 +1012,7 @@ pub(crate) async fn chunks_handler(mut req: Request<Body>) -> Response<Body> {
         let err_msg = format!("Failed to read `{}`. {}", &chunks_request.filename, e);
 
         // log
-        error!(target: "chunks_handler", "{}", &err_msg);
+        error!(target: "stdout", "{}", &err_msg);
 
         return error::internal_server_error(err_msg);
     }
@@ -1042,7 +1042,7 @@ pub(crate) async fn chunks_handler(mut req: Request<Body>) -> Response<Body> {
                             let err_msg = e.to_string();
 
                             // log
-                            error!(target: "chunks_handler", "{}", &err_msg);
+                            error!(target: "stdout", "{}", &err_msg);
 
                             error::internal_server_error(err_msg)
                         }
@@ -1052,7 +1052,7 @@ pub(crate) async fn chunks_handler(mut req: Request<Body>) -> Response<Body> {
                     let err_msg = format!("Fail to serialize chunks response. {}", e);
 
                     // log
-                    error!(target: "chunks_handler", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     error::internal_server_error(err_msg)
                 }
@@ -1062,13 +1062,13 @@ pub(crate) async fn chunks_handler(mut req: Request<Body>) -> Response<Body> {
             let err_msg = e.to_string();
 
             // log
-            error!(target: "chunks_handler", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             error::internal_server_error(err_msg)
         }
     };
 
-    info!(target: "chunks_handler", "Send the chunks response.");
+    info!(target: "stdout", "Send the chunks response.");
 
     res
 }
@@ -1076,7 +1076,7 @@ pub(crate) async fn chunks_handler(mut req: Request<Body>) -> Response<Body> {
 /// Return the server info.
 pub(crate) async fn server_info_handler() -> Response<Body> {
     // log
-    info!(target: "server_info", "Handling the coming server info request.");
+    info!(target: "stdout", "Handling the coming server info request.");
 
     // get the server info
     let server_info = match SERVER_INFO.get() {
@@ -1085,7 +1085,7 @@ pub(crate) async fn server_info_handler() -> Response<Body> {
             let err_msg = "The server info is not set.";
 
             // log
-            error!(target: "server_info_handler", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             return error::internal_server_error("The server info is not set.");
         }
@@ -1098,7 +1098,7 @@ pub(crate) async fn server_info_handler() -> Response<Body> {
             let err_msg = format!("Fail to serialize server info. {}", e);
 
             // log
-            error!(target: "server_info_handler", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             return error::internal_server_error(err_msg);
         }
@@ -1117,13 +1117,13 @@ pub(crate) async fn server_info_handler() -> Response<Body> {
             let err_msg = e.to_string();
 
             // log
-            error!(target: "server_info_handler", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             error::internal_server_error(err_msg)
         }
     };
 
-    info!(target: "server_info", "Send the server info response.");
+    info!(target: "stdout", "Send the server info response.");
 
     res
 }

--- a/api-server/llama-api-server/src/error.rs
+++ b/api-server/llama-api-server/src/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 #[allow(dead_code)]
 pub(crate) fn not_implemented() -> Response<Body> {
     // log error
-    error!(target: "response", "501 Not Implemented");
+    error!(target: "stdout", "501 Not Implemented");
 
     Response::builder()
         .header("Access-Control-Allow-Origin", "*")
@@ -22,7 +22,7 @@ pub(crate) fn internal_server_error(msg: impl AsRef<str>) -> Response<Body> {
     };
 
     // log error
-    error!(target: "response", "{}", &err_msg);
+    error!(target: "stdout", "{}", &err_msg);
 
     Response::builder()
         .header("Access-Control-Allow-Origin", "*")
@@ -40,7 +40,7 @@ pub(crate) fn bad_request(msg: impl AsRef<str>) -> Response<Body> {
     };
 
     // log error
-    error!(target: "response", "{}", &err_msg);
+    error!(target: "stdout", "{}", &err_msg);
 
     Response::builder()
         .header("Access-Control-Allow-Origin", "*")
@@ -61,7 +61,7 @@ pub(crate) fn invalid_endpoint(msg: impl AsRef<str>) -> Response<Body> {
     };
 
     // log error
-    error!(target: "response", "{}", &err_msg);
+    error!(target: "stdout", "{}", &err_msg);
 
     Response::builder()
         .header("Access-Control-Allow-Origin", "*")

--- a/api-server/llama-api-server/src/main.rs
+++ b/api-server/llama-api-server/src/main.rs
@@ -95,6 +95,12 @@ struct Cli {
     /// Repeat alpha frequency penalty. 0.0 = disabled
     #[arg(long, default_value = "0.0")]
     frequency_penalty: f64,
+    /// BNF-like grammar to constrain generations (see samples in grammars/ dir).
+    #[arg(long, default_value = "")]
+    pub grammar: String,
+    /// JSON schema to constrain generations (https://json-schema.org/), e.g. `{}` for any JSON object. For schemas w/ external $refs, use --grammar + example/json_schema_to_grammar.py instead.
+    #[arg(long)]
+    pub json_schema: Option<String>,
     /// Path to the multimodal projector file
     #[arg(long)]
     llava_mmproj: Option<String>,
@@ -260,6 +266,16 @@ async fn main() -> Result<(), ServerError> {
     // log frequency penalty
     info!(target: "server_config", "frequency_penalty: {}", cli.frequency_penalty);
 
+    // log grammar
+    if !cli.grammar.is_empty() {
+        info!(target: "stdout", "grammar: {}", &cli.grammar);
+    }
+
+    // log json schema
+    if let Some(json_schema) = &cli.json_schema {
+        info!(target: "stdout", "json_schema: {}", json_schema);
+    }
+
     // log multimodal projector
     if let Some(llava_mmproj) = &cli.llava_mmproj {
         info!(target: "server_config", "llava_mmproj: {}", llava_mmproj);
@@ -319,6 +335,8 @@ async fn main() -> Result<(), ServerError> {
                 .with_repeat_penalty(cli.repeat_penalty)
                 .with_presence_penalty(cli.presence_penalty)
                 .with_frequency_penalty(cli.frequency_penalty)
+                .with_grammar(cli.grammar)
+                .with_json_schema(cli.json_schema)
                 .with_reverse_prompt(cli.reverse_prompt)
                 .with_mmproj(cli.llava_mmproj.clone())
                 .enable_plugin_log(true)
@@ -368,6 +386,8 @@ async fn main() -> Result<(), ServerError> {
         .with_repeat_penalty(cli.repeat_penalty)
         .with_presence_penalty(cli.presence_penalty)
         .with_frequency_penalty(cli.frequency_penalty)
+        .with_grammar(cli.grammar)
+        .with_json_schema(cli.json_schema)
         .with_reverse_prompt(cli.reverse_prompt)
         .with_mmproj(cli.llava_mmproj.clone())
         .enable_plugin_log(true)

--- a/api-server/llama-api-server/src/main.rs
+++ b/api-server/llama-api-server/src/main.rs
@@ -531,9 +531,11 @@ async fn handle_request(
                 None => 0,
             };
 
-            info!(target: "stdout", "method: {}, endpoint: {}, http_version: {}, content-length: {}", method, path, version, size);
+            info!(target: "stdout", "method: {}, http_version: {}, content-length: {}", method, version, size);
+            info!(target: "stdout", "endpoint: {}", path);
         } else {
-            info!(target: "stdout", "method: {}, endpoint: {}, http_version: {}", method, path, version);
+            info!(target: "stdout", "method: {}, http_version: {}", method, version);
+            info!(target: "stdout", "endpoint: {}", path);
         }
     }
 
@@ -549,26 +551,26 @@ async fn handle_request(
         if status_code.as_u16() < 400 {
             // log response
             let response_version = format!("{:?}", response.version());
+            info!(target: "stdout", "response_version: {}", response_version);
             let response_body_size: u64 = response.body().size_hint().lower();
+            info!(target: "stdout", "response_body_size: {}", response_body_size);
             let response_status = status_code.as_u16();
-            let response_is_informational = status_code.is_informational();
+            info!(target: "stdout", "response_status: {}", response_status);
             let response_is_success = status_code.is_success();
-            let response_is_redirection = status_code.is_redirection();
-            let response_is_client_error = status_code.is_client_error();
-            let response_is_server_error = status_code.is_server_error();
-
-            info!(target: "stdout", "version: {}, body_size: {}, status: {}, is_informational: {}, is_success: {}, is_redirection: {}, is_client_error: {}, is_server_error: {}", response_version, response_body_size, response_status, response_is_informational, response_is_success, response_is_redirection, response_is_client_error, response_is_server_error);
+            info!(target: "stdout", "response_is_success: {}", response_is_success);
         } else {
             let response_version = format!("{:?}", response.version());
+            error!(target: "stdout", "response_version: {}", response_version);
             let response_body_size: u64 = response.body().size_hint().lower();
+            error!(target: "stdout", "response_body_size: {}", response_body_size);
             let response_status = status_code.as_u16();
-            let response_is_informational = status_code.is_informational();
+            error!(target: "stdout", "response_status: {}", response_status);
             let response_is_success = status_code.is_success();
-            let response_is_redirection = status_code.is_redirection();
+            error!(target: "stdout", "response_is_success: {}", response_is_success);
             let response_is_client_error = status_code.is_client_error();
+            error!(target: "stdout", "response_is_client_error: {}", response_is_client_error);
             let response_is_server_error = status_code.is_server_error();
-
-            error!(target: "stdout", "version: {}, body_size: {}, status: {}, is_informational: {}, is_success: {}, is_redirection: {}, is_client_error: {}, is_server_error: {}", response_version, response_body_size, response_status, response_is_informational, response_is_success, response_is_redirection, response_is_client_error, response_is_server_error);
+            error!(target: "stdout", "response_is_server_error: {}", response_is_server_error);
         }
     }
 

--- a/api-server/llama-api-server/src/main.rs
+++ b/api-server/llama-api-server/src/main.rs
@@ -74,6 +74,9 @@ struct Cli {
     /// How split tensors should be distributed accross GPUs. If None the model is not split; otherwise, a comma-separated list of non-negative values, e.g., "3,2" presents 60% of the data to GPU 0 and 40% to GPU 1.
     #[arg(long)]
     tensor_split: Option<String>,
+    /// Number of threads to use during computation
+    #[arg(long, default_value = "2")]
+    threads: u64,
     /// Disable memory mapping for file access of chat models
     #[arg(long)]
     no_mmap: Option<bool>,
@@ -231,6 +234,9 @@ async fn main() -> Result<(), ServerError> {
         info!(target: "server_config", "tensor_split: {}", tensor_split);
     }
 
+    // log threads
+    info!(target: "stdout", "threads: {}", cli.threads);
+
     // log no_mmap
     if let Some(no_mmap) = &cli.no_mmap {
         info!(
@@ -273,6 +279,9 @@ async fn main() -> Result<(), ServerError> {
                 )
                 .with_ctx_size(cli.ctx_size[0])
                 .with_batch_size(cli.batch_size[0])
+                .with_main_gpu(cli.main_gpu)
+                .with_tensor_split(cli.tensor_split)
+                .with_threads(cli.threads)
                 .enable_plugin_log(true)
                 .enable_debug_log(plugin_debug)
                 .build();
@@ -303,6 +312,7 @@ async fn main() -> Result<(), ServerError> {
                 .with_n_gpu_layers(cli.n_gpu_layers)
                 .with_main_gpu(cli.main_gpu)
                 .with_tensor_split(cli.tensor_split)
+                .with_threads(cli.threads)
                 .disable_mmap(cli.no_mmap)
                 .with_temperature(cli.temp)
                 .with_top_p(cli.top_p)
@@ -349,6 +359,9 @@ async fn main() -> Result<(), ServerError> {
         .with_batch_size(cli.batch_size[0])
         .with_n_predict(cli.n_predict)
         .with_n_gpu_layers(cli.n_gpu_layers)
+        .with_main_gpu(cli.main_gpu)
+        .with_tensor_split(cli.tensor_split.clone())
+        .with_threads(cli.threads)
         .disable_mmap(cli.no_mmap)
         .with_temperature(cli.temp)
         .with_top_p(cli.top_p)
@@ -387,6 +400,9 @@ async fn main() -> Result<(), ServerError> {
         )
         .with_ctx_size(cli.ctx_size[1])
         .with_batch_size(cli.batch_size[1])
+        .with_main_gpu(cli.main_gpu)
+        .with_tensor_split(cli.tensor_split)
+        .with_threads(cli.threads)
         .enable_plugin_log(true)
         .enable_debug_log(plugin_debug)
         .build();

--- a/api-server/llama-api-server/src/main.rs
+++ b/api-server/llama-api-server/src/main.rs
@@ -20,6 +20,7 @@ use llama_core::MetadataBuilder;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, net::SocketAddr, path::PathBuf};
+use tokio::net::TcpListener;
 use utils::LogLevel;
 
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -496,7 +497,10 @@ async fn main() -> Result<(), ServerError> {
         async move { Ok::<_, Error>(service_fn(move |req| handle_request(req, web_ui.clone()))) }
     });
 
-    let server = Server::bind(&addr).serve(new_service);
+    let tcp_listener = TcpListener::bind(addr).await.unwrap();
+    let server = Server::from_tcp(tcp_listener.into_std().unwrap())
+        .unwrap()
+        .serve(new_service);
 
     match server.await {
         Ok(_) => Ok(()),

--- a/api-server/llama-api-server/src/main.rs
+++ b/api-server/llama-api-server/src/main.rs
@@ -498,12 +498,6 @@ async fn main() -> Result<(), ServerError> {
 
     let server = Server::bind(&addr).serve(new_service);
 
-    // println!(
-    //     "LlamaEdge API server listening on http://{}:{}",
-    //     addr.ip(),
-    //     addr.port()
-    // );
-
     match server.await {
         Ok(_) => Ok(()),
         Err(e) => Err(ServerError::Operation(e.to_string())),

--- a/api-server/llama-core/Cargo.toml
+++ b/api-server/llama-core/Cargo.toml
@@ -20,8 +20,8 @@ uuid.workspace = true
 once_cell = "1.18"
 futures = { version = "0.3.6", default-features = false, features = ["async-await", "std"] }
 futures-util = "0.3"
-reqwest = { package = "reqwest_wasi", version = "0.11", features = ["json", "stream"] }
-qdrant_rest_client = { version = "0.0.4", default-features = false }
+reqwest = { version = "0.11", default-features = false, features = ["json", "stream", "rustls-tls"] }
+qdrant_rest_client = "0.1.1"
 text-splitter = { version = "^0.7", features = ["tiktoken-rs", "markdown"] }
 tiktoken-rs = "^0.5"
 wasi-logger = { workspace = true, optional = true }
@@ -33,6 +33,5 @@ base64.workspace = true
 
 [features]
 default = []
-full = ["https", "logging"]
-https = ["reqwest/wasmedge-tls", "qdrant_rest_client/wasmedge-tls"]
+full = ["logging"]
 logging = ["wasi-logger", "log"]

--- a/api-server/llama-core/Cargo.toml
+++ b/api-server/llama-core/Cargo.toml
@@ -28,6 +28,8 @@ wasi-logger = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
 regex = "1"
 either.workspace = true
+wasmedge_stable_diffusion = { version = "0.1.0", git = "https://github.com/WasmEdge/wasmedge-stable-diffusion.git" }
+base64.workspace = true
 
 [features]
 default = []

--- a/api-server/llama-core/Cargo.toml
+++ b/api-server/llama-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-core"
-version = "0.14.1"
+version = "0.15.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/api-server/llama-core/src/chat.rs
+++ b/api-server/llama-core/src/chat.rs
@@ -2082,7 +2082,7 @@ async fn download_image(image_url: impl AsRef<str>) -> Result<String, LlamaCoreE
     })?;
 
     let mut content = response.bytes_stream();
-    while let Ok(item) = content.next().await.unwrap() {
+    while let Some(Ok(item)) = content.next().await {
         std::io::copy(&mut item.as_ref(), &mut dest).map_err(|e| {
             let err_msg = format!(
                 "Fail to write the image content to the file: {}. Reason: {}",

--- a/api-server/llama-core/src/chat.rs
+++ b/api-server/llama-core/src/chat.rs
@@ -42,9 +42,9 @@ pub async fn chat(
 > {
     #[cfg(feature = "logging")]
     {
-        info!(target: "llama-core", "tool choice: {:?}", chat_request.tool_choice.as_ref());
-        info!(target: "llama-core", "tools: {:?}", chat_request.tools.as_ref());
-        info!(target: "llama-core", "stream mode: {:?}", chat_request.stream);
+        info!(target: "stdout", "tool choice: {:?}", chat_request.tool_choice.as_ref());
+        info!(target: "stdout", "tools: {:?}", chat_request.tools.as_ref());
+        info!(target: "stdout", "stream mode: {:?}", chat_request.stream);
     }
 
     match chat_request.stream {
@@ -79,7 +79,7 @@ async fn chat_stream(
     chat_request: &mut ChatCompletionRequest,
 ) -> Result<impl futures::TryStream<Ok = String, Error = LlamaCoreError>, LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama_core", "Process chat completion request in the stream mode.");
+    info!(target: "stdout", "Process chat completion request in the stream mode.");
 
     let running_mode = running_mode()?;
     if running_mode == RunningMode::Embeddings {
@@ -89,7 +89,7 @@ async fn chat_stream(
         );
 
         #[cfg(feature = "logging")]
-        error!(target: "llama_core", "{}", &err_msg);
+        error!(target: "stdout", "{}", &err_msg);
 
         return Err(LlamaCoreError::Operation(err_msg));
     }
@@ -101,7 +101,7 @@ async fn chat_stream(
     };
 
     #[cfg(feature = "logging")]
-    info!(target: "llama_core", "user: {}", &id);
+    info!(target: "stdout", "user: {}", &id);
 
     // parse the `include_usage` option
     let include_usage = match chat_request.stream_options {
@@ -110,7 +110,7 @@ async fn chat_stream(
     };
 
     #[cfg(feature = "logging")]
-    info!(target: "llama_core", "include_usage: {}", include_usage);
+    info!(target: "stdout", "include_usage: {}", include_usage);
 
     // update metadata
     let mut metadata = check_model_metadata(chat_request).await?;
@@ -121,9 +121,9 @@ async fn chat_stream(
 
     #[cfg(feature = "logging")]
     {
-        info!(target: "llama_core", "prompt:\n{}", &prompt);
-        info!(target: "llama_core", "available_completion_tokens: {}", avaible_completion_tokens);
-        info!(target: "llama_core", "tool_use: {}", tool_use);
+        info!(target: "stdout", "prompt:\n{}", &prompt);
+        info!(target: "stdout", "available_completion_tokens: {}", avaible_completion_tokens);
+        info!(target: "stdout", "tool_use: {}", tool_use);
     }
 
     // update metadata n_predict
@@ -142,7 +142,7 @@ async fn chat_stream(
                         let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
                         #[cfg(feature = "logging")]
-                        error!(target: "llama_core", "{}", &err_msg);
+                        error!(target: "stdout", "{}", &err_msg);
 
                         return Err(LlamaCoreError::Operation(err_msg.into()));
                     }
@@ -152,7 +152,7 @@ async fn chat_stream(
                     let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     LlamaCoreError::Operation(err_msg)
                 })?;
@@ -166,7 +166,7 @@ async fn chat_stream(
                         );
 
                         #[cfg(feature = "logging")]
-                        error!(target: "llama_core", "{}", &err_msg);
+                        error!(target: "stdout", "{}", &err_msg);
 
                         return Err(LlamaCoreError::Operation(err_msg));
                     }
@@ -179,7 +179,7 @@ async fn chat_stream(
                         let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
                         #[cfg(feature = "logging")]
-                        error!(target: "llama_core", "{}", &err_msg);
+                        error!(target: "stdout", "{}", &err_msg);
 
                         return Err(LlamaCoreError::Operation(err_msg.into()));
                     }
@@ -189,7 +189,7 @@ async fn chat_stream(
                     let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     LlamaCoreError::Operation(err_msg)
                 })?;
@@ -200,7 +200,7 @@ async fn chat_stream(
                         let err_msg = "There is no model available in the chat graphs.";
 
                         #[cfg(feature = "logging")]
-                        error!(target: "llama_core", "{}", &err_msg);
+                        error!(target: "stdout", "{}", &err_msg);
 
                         return Err(LlamaCoreError::Operation(err_msg.into()));
                     }
@@ -210,7 +210,7 @@ async fn chat_stream(
     };
 
     #[cfg(feature = "logging")]
-    info!(target: "llama_core", "End of the chat completion stream.");
+    info!(target: "stdout", "End of the chat completion stream.");
 
     Ok(stream)
 }
@@ -221,7 +221,7 @@ fn chat_stream_by_graph(
     include_usage: bool,
 ) -> Result<ChatStream, LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama_core", "Handle chat request with available tools by the model named {}.", graph.name());
+    info!(target: "stdout", "Handle chat request with available tools by the model named {}.", graph.name());
 
     let id = id.into();
 
@@ -236,13 +236,13 @@ fn chat_stream_by_graph(
                 );
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama_core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
 
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "raw generation:\n{}", output);
+            info!(target: "stdout", "raw generation:\n{}", output);
 
             // post-process
             let message = post_process(output, &graph.metadata.prompt_template).map_err(|e| {
@@ -250,13 +250,13 @@ fn chat_stream_by_graph(
             })?;
 
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "post-processed generation:\n{}", &message);
+            info!(target: "stdout", "post-processed generation:\n{}", &message);
 
             // retrieve the number of prompt and completion tokens
             let token_info = get_token_info_by_graph(graph)?;
 
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "prompt tokens: {}, completion tokens: {}", token_info.prompt_tokens, token_info.completion_tokens);
+            info!(target: "stdout", "prompt tokens: {}, completion tokens: {}", token_info.prompt_tokens, token_info.completion_tokens);
 
             let usage = Some(Usage {
                 prompt_tokens: token_info.prompt_tokens,
@@ -270,7 +270,7 @@ fn chat_stream_by_graph(
                     let err_msg = format!("Failed to get the current time. Reason: {}", e);
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     LlamaCoreError::Operation(err_msg)
                 })?;
@@ -284,7 +284,7 @@ fn chat_stream_by_graph(
                 let err_msg = "The tool use is only supported for 'mistral-chat' and 'chatml' prompt templates.";
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama_core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 return Err(LlamaCoreError::Operation(err_msg.into()));
             }
@@ -333,7 +333,7 @@ fn chat_stream_by_graph(
                         format!("Failed to serialize chat completion chunk. Reason: {}", e);
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     LlamaCoreError::Operation(err_msg)
                 })?;
@@ -357,7 +357,7 @@ fn chat_stream_by_graph(
                         format!("Failed to serialize chat completion chunk. Reason: {}", e);
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     LlamaCoreError::Operation(err_msg)
                 })?;
@@ -387,7 +387,7 @@ fn chat_stream_by_graph(
                 );
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama_core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -397,7 +397,7 @@ fn chat_stream_by_graph(
                 let err_msg = format!("Failed to post-process the output. {}", e);
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama_core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -406,7 +406,7 @@ fn chat_stream_by_graph(
             let token_info = get_token_info_by_graph(graph)?;
 
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "prompt tokens: {}, completion tokens: {}", token_info.prompt_tokens, token_info.completion_tokens);
+            info!(target: "stdout", "prompt tokens: {}, completion tokens: {}", token_info.prompt_tokens, token_info.completion_tokens);
 
             let usage = Some(Usage {
                 prompt_tokens: token_info.prompt_tokens,
@@ -420,7 +420,7 @@ fn chat_stream_by_graph(
                     let err_msg = format!("Failed to get the current time. Reason: {}", e);
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     LlamaCoreError::Operation(err_msg)
                 })?;
@@ -452,7 +452,7 @@ fn chat_stream_by_graph(
                         format!("Failed to serialize chat completion chunk. Reason: {}", e);
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     LlamaCoreError::Operation(err_msg)
                 })?;
@@ -478,7 +478,7 @@ fn chat_stream_by_graph(
                         format!("Failed to serialize chat completion chunk. Reason: {}", e);
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     LlamaCoreError::Operation(err_msg)
                 })?;
@@ -502,7 +502,7 @@ fn chat_stream_by_graph(
             wasmedge_wasi_nn::BackendError::PromptTooLong,
         )) => {
             #[cfg(feature = "logging")]
-            warn!(target: "llama_core", "The prompt is too long. Please reduce the length of your input and try again.");
+            warn!(target: "stdout", "The prompt is too long. Please reduce the length of your input and try again.");
 
             // Retrieve the output.
             let output_buffer = get_output_buffer(graph, OUTPUT_TENSOR)?;
@@ -513,7 +513,7 @@ fn chat_stream_by_graph(
                 );
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama_core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -523,7 +523,7 @@ fn chat_stream_by_graph(
                 let err_msg = format!("Failed to post-process the output. {}", e);
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama_core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -532,7 +532,7 @@ fn chat_stream_by_graph(
             let token_info = get_token_info_by_graph(graph)?;
 
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "prompt tokens: {}, completion tokens: {}", token_info.prompt_tokens, token_info.completion_tokens);
+            info!(target: "stdout", "prompt tokens: {}, completion tokens: {}", token_info.prompt_tokens, token_info.completion_tokens);
 
             let usage = Some(Usage {
                 prompt_tokens: token_info.prompt_tokens,
@@ -546,7 +546,7 @@ fn chat_stream_by_graph(
                     let err_msg = format!("Failed to get the current time. Reason: {}", e);
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     LlamaCoreError::Operation(err_msg)
                 })?;
@@ -578,7 +578,7 @@ fn chat_stream_by_graph(
                         format!("Failed to serialize chat completion chunk. Reason: {}", e);
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     LlamaCoreError::Operation(err_msg)
                 })?;
@@ -604,7 +604,7 @@ fn chat_stream_by_graph(
                         format!("Failed to serialize chat completion chunk. Reason: {}", e);
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     LlamaCoreError::Operation(err_msg)
                 })?;
@@ -628,7 +628,7 @@ fn chat_stream_by_graph(
             let err_msg = format!("Failed to compute the chat completion. Reason: {}", e);
 
             #[cfg(feature = "logging")]
-            error!(target: "llama_core", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             Err(LlamaCoreError::Backend(BackendError::Compute(err_msg)))
         }
@@ -639,7 +639,7 @@ async fn chat_once(
     chat_request: &mut ChatCompletionRequest,
 ) -> Result<ChatCompletionObject, LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama_core", "Processing chat completion request in non-stream mode.");
+    info!(target: "stdout", "Processing chat completion request in non-stream mode.");
 
     let running_mode = running_mode()?;
     if running_mode == RunningMode::Embeddings {
@@ -649,7 +649,7 @@ async fn chat_once(
         );
 
         #[cfg(feature = "logging")]
-        error!(target: "llama_core", "{}", &err_msg);
+        error!(target: "stdout", "{}", &err_msg);
 
         return Err(LlamaCoreError::Operation(err_msg));
     }
@@ -661,7 +661,7 @@ async fn chat_once(
     };
 
     #[cfg(feature = "logging")]
-    info!(target: "llama_core", "user: {}", &id);
+    info!(target: "stdout", "user: {}", &id);
 
     // update metadata
     let mut metadata = check_model_metadata(chat_request).await?;
@@ -672,9 +672,9 @@ async fn chat_once(
 
     #[cfg(feature = "logging")]
     {
-        info!(target: "llama_core", "prompt:\n{}", &prompt);
-        info!(target: "llama_core", "available_completion_tokens: {}", avaible_completion_tokens);
-        info!(target: "llama_core", "tool_use: {}", tool_use);
+        info!(target: "stdout", "prompt:\n{}", &prompt);
+        info!(target: "stdout", "available_completion_tokens: {}", avaible_completion_tokens);
+        info!(target: "stdout", "tool_use: {}", tool_use);
     }
 
     // update metadata n_predict
@@ -687,7 +687,7 @@ async fn chat_once(
     let res = compute(model_name.as_ref(), id, tool_use);
 
     #[cfg(feature = "logging")]
-    info!(target: "llama_core", "End of the chat completion.");
+    info!(target: "stdout", "End of the chat completion.");
 
     res
 }
@@ -698,7 +698,7 @@ fn compute(
     tool_use: bool,
 ) -> Result<ChatCompletionObject, LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama_core", "Compute chat completion.");
+    info!(target: "stdout", "Compute chat completion.");
 
     match model_name {
         Some(model_name) => {
@@ -708,7 +708,7 @@ fn compute(
                     let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     return Err(LlamaCoreError::Operation(err_msg.into()));
                 }
@@ -718,7 +718,7 @@ fn compute(
                 let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama_core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -732,7 +732,7 @@ fn compute(
                     );
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     Err(LlamaCoreError::Operation(err_msg))
                 }
@@ -745,7 +745,7 @@ fn compute(
                     let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     return Err(LlamaCoreError::Operation(err_msg.into()));
                 }
@@ -755,7 +755,7 @@ fn compute(
                 let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama_core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -766,7 +766,7 @@ fn compute(
                     let err_msg = "There is no model available in the chat graphs.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     Err(LlamaCoreError::Operation(err_msg.into()))
                 }
@@ -781,7 +781,7 @@ fn compute_by_graph(
     tool_use: bool,
 ) -> Result<ChatCompletionObject, LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama_core", "Compute chat completion by the model named {}.", graph.name());
+    info!(target: "stdout", "Compute chat completion by the model named {}.", graph.name());
 
     match graph.compute() {
         Ok(_) => {
@@ -794,13 +794,13 @@ fn compute_by_graph(
                 );
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama_core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
 
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "raw generation: {}", output);
+            info!(target: "stdout", "raw generation: {}", output);
 
             // post-process
             let message = post_process(output, &graph.metadata.prompt_template).map_err(|e| {
@@ -808,13 +808,13 @@ fn compute_by_graph(
             })?;
 
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "post-processed generation:\n{}", &message);
+            info!(target: "stdout", "post-processed generation:\n{}", &message);
 
             // retrieve the number of prompt and completion tokens
             let token_info = get_token_info_by_graph(graph)?;
 
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "prompt tokens: {}, completion tokens: {}", token_info.prompt_tokens, token_info.completion_tokens);
+            info!(target: "stdout", "prompt tokens: {}, completion tokens: {}", token_info.prompt_tokens, token_info.completion_tokens);
 
             let created = SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
@@ -822,7 +822,7 @@ fn compute_by_graph(
                     let err_msg = format!("Failed to get the current time. Reason: {}", e);
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     LlamaCoreError::Operation(err_msg)
                 })?;
@@ -838,7 +838,7 @@ fn compute_by_graph(
                         let err_msg = "The tool use is only supported for 'mistral-chat' and 'chatml' prompt templates.";
 
                         #[cfg(feature = "logging")]
-                        error!(target: "llama_core", "{}", &err_msg);
+                        error!(target: "stdout", "{}", &err_msg);
 
                         return Err(LlamaCoreError::Operation(err_msg.into()));
                     }
@@ -917,7 +917,7 @@ fn compute_by_graph(
                 );
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama_core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -927,7 +927,7 @@ fn compute_by_graph(
                 let err_msg = format!("Failed to post-process the output. {}", e);
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama_core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -936,7 +936,7 @@ fn compute_by_graph(
             let token_info = get_token_info_by_graph(graph)?;
 
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "prompt tokens: {}, completion tokens: {}", token_info.prompt_tokens, token_info.completion_tokens);
+            info!(target: "stdout", "prompt tokens: {}, completion tokens: {}", token_info.prompt_tokens, token_info.completion_tokens);
 
             let created = SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
@@ -944,7 +944,7 @@ fn compute_by_graph(
                     let err_msg = format!("Failed to get the current time. Reason: {}", e);
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     LlamaCoreError::Operation(err_msg)
                 })?;
@@ -977,7 +977,7 @@ fn compute_by_graph(
             wasmedge_wasi_nn::BackendError::PromptTooLong,
         )) => {
             #[cfg(feature = "logging")]
-            warn!(target: "llama_core", "The prompt is too long. Please reduce the length of your input and try again.");
+            warn!(target: "stdout", "The prompt is too long. Please reduce the length of your input and try again.");
 
             // Retrieve the output.
             let output_buffer = get_output_buffer(graph, OUTPUT_TENSOR)?;
@@ -988,7 +988,7 @@ fn compute_by_graph(
                 );
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama_core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -998,7 +998,7 @@ fn compute_by_graph(
                 let err_msg = format!("Failed to post-process the output. {}", e);
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama_core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -1007,7 +1007,7 @@ fn compute_by_graph(
             let token_info = get_token_info_by_graph(graph)?;
 
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "prompt tokens: {}, completion tokens: {}", token_info.prompt_tokens, token_info.completion_tokens);
+            info!(target: "stdout", "prompt tokens: {}, completion tokens: {}", token_info.prompt_tokens, token_info.completion_tokens);
 
             let created = SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
@@ -1015,7 +1015,7 @@ fn compute_by_graph(
                     let err_msg = format!("Failed to get the current time. Reason: {}", e);
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     LlamaCoreError::Operation(err_msg)
                 })?;
@@ -1048,7 +1048,7 @@ fn compute_by_graph(
             let err_msg = format!("Failed to compute the chat completion. Reason: {}", e);
 
             #[cfg(feature = "logging")]
-            error!(target: "llama_core", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             Err(LlamaCoreError::Backend(BackendError::Compute(err_msg)))
         }
@@ -1067,7 +1067,7 @@ fn parse_tool_calls(
                     let matched = &cap[0];
 
                     #[cfg(feature = "logging")]
-                    info!(target: "llama_core", "captured: {}", matched);
+                    info!(target: "stdout", "captured: {}", matched);
 
                     match serde_json::from_str::<Vec<serde_json::Value>>(matched) {
                         Ok(group) => values.extend(group),
@@ -1078,7 +1078,7 @@ fn parse_tool_calls(
                             );
 
                             #[cfg(feature = "logging")]
-                            error!(target: "llama_core", "{}", &err_msg);
+                            error!(target: "stdout", "{}", &err_msg);
 
                             return Err(LlamaCoreError::Operation(err_msg));
                         }
@@ -1096,7 +1096,7 @@ fn parse_tool_calls(
                             );
 
                             #[cfg(feature = "logging")]
-                            error!(target: "llama_core", "{}", &err_msg);
+                            error!(target: "stdout", "{}", &err_msg);
 
                             return Err(LlamaCoreError::Operation(err_msg));
                         }
@@ -1111,7 +1111,7 @@ fn parse_tool_calls(
                             );
 
                             #[cfg(feature = "logging")]
-                            error!(target: "llama_core", "{}", &err_msg);
+                            error!(target: "stdout", "{}", &err_msg);
 
                             return Err(LlamaCoreError::Operation(err_msg));
                         }
@@ -1135,7 +1135,7 @@ fn parse_tool_calls(
                 };
 
                 #[cfg(feature = "logging")]
-                info!(target: "llama_core", "parsed result: {:?}", parsed);
+                info!(target: "stdout", "parsed result: {:?}", parsed);
 
                 Ok(parsed)
             }
@@ -1143,7 +1143,7 @@ fn parse_tool_calls(
                 let err_msg = format!("Failed to create a regex pattern. Reason: {}", e);
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama_core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 Err(LlamaCoreError::Operation(err_msg))
             }
@@ -1156,7 +1156,7 @@ fn parse_tool_calls(
                         let matched = cap[1].replace("\\n", ""); // Remove "\\n" from the captured group
 
                         #[cfg(feature = "logging")]
-                        info!(target: "llama_core", "captured: {}", &matched);
+                        info!(target: "stdout", "captured: {}", &matched);
 
                         match serde_json::from_str::<serde_json::Value>(&matched) {
                             Ok(value) => values.push(value),
@@ -1167,7 +1167,7 @@ fn parse_tool_calls(
                                 );
 
                                 #[cfg(feature = "logging")]
-                                error!(target: "llama_core", "{}", &err_msg);
+                                error!(target: "stdout", "{}", &err_msg);
 
                                 return Err(LlamaCoreError::Operation(err_msg));
                             }
@@ -1185,7 +1185,7 @@ fn parse_tool_calls(
                                 );
 
                                 #[cfg(feature = "logging")]
-                                error!(target: "llama_core", "{}", &err_msg);
+                                error!(target: "stdout", "{}", &err_msg);
 
                                 return Err(LlamaCoreError::Operation(err_msg));
                             }
@@ -1200,7 +1200,7 @@ fn parse_tool_calls(
                                 );
 
                                 #[cfg(feature = "logging")]
-                                error!(target: "llama_core", "{}", &err_msg);
+                                error!(target: "stdout", "{}", &err_msg);
 
                                 return Err(LlamaCoreError::Operation(err_msg));
                             }
@@ -1224,7 +1224,7 @@ fn parse_tool_calls(
                     };
 
                     #[cfg(feature = "logging")]
-                    info!(target: "llama_core", "parsed result: {:?}", parsed);
+                    info!(target: "stdout", "parsed result: {:?}", parsed);
 
                     Ok(parsed)
                 }
@@ -1232,7 +1232,7 @@ fn parse_tool_calls(
                     let err_msg = format!("Failed to create a regex pattern. Reason: {}", e);
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     Err(LlamaCoreError::Operation(err_msg))
                 }
@@ -1247,7 +1247,7 @@ fn parse_tool_calls(
                         let matched = cleaned.trim();
 
                         #[cfg(feature = "logging")]
-                        info!(target: "llama_core", "captured: {}", matched);
+                        info!(target: "stdout", "captured: {}", matched);
 
                         match serde_json::from_str::<serde_json::Value>(matched) {
                             Ok(value) => values.push(value),
@@ -1258,7 +1258,7 @@ fn parse_tool_calls(
                                 );
 
                                 #[cfg(feature = "logging")]
-                                error!(target: "llama_core", "{}", &err_msg);
+                                error!(target: "stdout", "{}", &err_msg);
 
                                 return Err(LlamaCoreError::Operation(err_msg));
                             }
@@ -1276,7 +1276,7 @@ fn parse_tool_calls(
                                 );
 
                                 #[cfg(feature = "logging")]
-                                error!(target: "llama_core", "{}", &err_msg);
+                                error!(target: "stdout", "{}", &err_msg);
 
                                 return Err(LlamaCoreError::Operation(err_msg));
                             }
@@ -1291,7 +1291,7 @@ fn parse_tool_calls(
                                 );
 
                                 #[cfg(feature = "logging")]
-                                error!(target: "llama_core", "{}", &err_msg);
+                                error!(target: "stdout", "{}", &err_msg);
 
                                 return Err(LlamaCoreError::Operation(err_msg));
                             }
@@ -1315,7 +1315,7 @@ fn parse_tool_calls(
                     };
 
                     #[cfg(feature = "logging")]
-                    info!(target: "llama_core", "parsed result: {:?}", parsed);
+                    info!(target: "stdout", "parsed result: {:?}", parsed);
 
                     Ok(parsed)
                 }
@@ -1323,7 +1323,7 @@ fn parse_tool_calls(
                     let err_msg = format!("Failed to create a regex pattern. Reason: {}", e);
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     Err(LlamaCoreError::Operation(err_msg))
                 }
@@ -1331,7 +1331,7 @@ fn parse_tool_calls(
         }
         PromptTemplateType::Llama3Tool => {
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "raw input: {}", input);
+            info!(target: "stdout", "raw input: {}", input);
 
             let re = match regex::Regex::new(r"^\{.*\}$") {
                 Ok(re) => re,
@@ -1339,7 +1339,7 @@ fn parse_tool_calls(
                     let err_msg = format!("Failed to create a regex pattern. Reason: {}", e);
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     return Err(LlamaCoreError::Operation(err_msg));
                 }
@@ -1361,7 +1361,7 @@ fn parse_tool_calls(
                                     );
 
                                     #[cfg(feature = "logging")]
-                                    error!(target: "llama_core", "{}", &err_msg);
+                                    error!(target: "stdout", "{}", &err_msg);
 
                                     return Err(LlamaCoreError::Operation(err_msg));
                                 }
@@ -1376,7 +1376,7 @@ fn parse_tool_calls(
                                     );
 
                                     #[cfg(feature = "logging")]
-                                    error!(target: "llama_core", "{}", &err_msg);
+                                    error!(target: "stdout", "{}", &err_msg);
 
                                     return Err(LlamaCoreError::Operation(err_msg));
                                 }
@@ -1400,7 +1400,7 @@ fn parse_tool_calls(
                         };
 
                         #[cfg(feature = "logging")]
-                        info!(target: "llama_core", "parsed result: {:?}", parsed);
+                        info!(target: "stdout", "parsed result: {:?}", parsed);
 
                         Ok(parsed)
                     }
@@ -1409,7 +1409,7 @@ fn parse_tool_calls(
                             format!("Failed to deserialize generated tool calls. Reason: {}", e);
 
                         #[cfg(feature = "logging")]
-                        error!(target: "llama_core", "{}", &err_msg);
+                        error!(target: "stdout", "{}", &err_msg);
 
                         Err(LlamaCoreError::Operation(err_msg))
                     }
@@ -1422,19 +1422,19 @@ fn parse_tool_calls(
                 };
 
                 #[cfg(feature = "logging")]
-                info!(target: "llama_core", "parsed result: {:?}", parsed);
+                info!(target: "stdout", "parsed result: {:?}", parsed);
 
                 Ok(parsed)
             }
         }
         PromptTemplateType::InternLM2Tool => {
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "raw input: {}", input);
+            info!(target: "stdout", "raw input: {}", input);
 
             let blocks: Vec<&str> = input.trim().split("<|action_start|><|plugin|>").collect();
 
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "blocks: {:?}", blocks);
+            info!(target: "stdout", "blocks: {:?}", blocks);
 
             let mut tool_calls: Vec<ToolCall> = vec![];
             let mut content = String::new();
@@ -1445,7 +1445,7 @@ fn parse_tool_calls(
                         let value = block.trim().trim_end_matches("<|action_end|>");
 
                         #[cfg(feature = "logging")]
-                        info!(target: "llama_core", "tool call: {}", value);
+                        info!(target: "stdout", "tool call: {}", value);
 
                         match serde_json::from_str::<serde_json::Value>(value) {
                             Ok(value) => {
@@ -1458,7 +1458,7 @@ fn parse_tool_calls(
                                         );
 
                                         #[cfg(feature = "logging")]
-                                        error!(target: "llama_core", "{}", &err_msg);
+                                        error!(target: "stdout", "{}", &err_msg);
 
                                         return Err(LlamaCoreError::Operation(err_msg));
                                     }
@@ -1473,7 +1473,7 @@ fn parse_tool_calls(
                                         );
 
                                         #[cfg(feature = "logging")]
-                                        error!(target: "llama_core", "{}", &err_msg);
+                                        error!(target: "stdout", "{}", &err_msg);
 
                                         return Err(LlamaCoreError::Operation(err_msg));
                                     }
@@ -1496,7 +1496,7 @@ fn parse_tool_calls(
                                 );
 
                                 #[cfg(feature = "logging")]
-                                error!(target: "llama_core", "{}", &err_msg);
+                                error!(target: "stdout", "{}", &err_msg);
 
                                 return Err(LlamaCoreError::Operation(err_msg));
                             }
@@ -1522,7 +1522,7 @@ fn parse_tool_calls(
             };
 
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "parsed result: {:?}", parsed);
+            info!(target: "stdout", "parsed result: {:?}", parsed);
 
             Ok(parsed)
         }
@@ -1541,7 +1541,7 @@ async fn check_model_metadata(
     chat_request: &ChatCompletionRequest,
 ) -> Result<Metadata, LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama_core", "Check model metadata.");
+    info!(target: "stdout", "Check model metadata.");
 
     let mut should_update = false;
     let mut metadata = get_model_metadata(chat_request.model.as_ref())?;
@@ -1646,7 +1646,7 @@ async fn update_n_predict(
     // check if necessary to update n_predict with max_tokens
     if let Some(max_tokens) = chat_request.max_tokens {
         #[cfg(feature = "logging")]
-        info!(target: "llama_core", "available_completion_tokens: {}, max_tokens from request: {}, n_predict: {}", available_completion_tokens, max_tokens, metadata.n_predict);
+        info!(target: "stdout", "available_completion_tokens: {}, max_tokens from request: {}, n_predict: {}", available_completion_tokens, max_tokens, metadata.n_predict);
 
         let max_completion_tokens = match available_completion_tokens < max_tokens {
             true => available_completion_tokens,
@@ -1656,7 +1656,7 @@ async fn update_n_predict(
         // update n_predict
         if metadata.n_predict != max_completion_tokens {
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "update n_predict from {} to {}", metadata.n_predict, max_completion_tokens);
+            info!(target: "stdout", "update n_predict from {} to {}", metadata.n_predict, max_completion_tokens);
 
             metadata.n_predict = max_completion_tokens;
 
@@ -1666,7 +1666,7 @@ async fn update_n_predict(
         }
     } else if metadata.n_predict < available_completion_tokens {
         #[cfg(feature = "logging")]
-        info!(target: "llama_core", "Update n_predict from {} to {}", metadata.n_predict, available_completion_tokens);
+        info!(target: "stdout", "Update n_predict from {} to {}", metadata.n_predict, available_completion_tokens);
 
         // update n_predict
         metadata.n_predict = available_completion_tokens;
@@ -1689,7 +1689,7 @@ fn post_process(
     template_ty: &PromptTemplateType,
 ) -> Result<String, String> {
     #[cfg(feature = "logging")]
-    info!(target: "llama_core", "Post-process the generated output.");
+    info!(target: "stdout", "Post-process the generated output.");
 
     let output = if *template_ty == PromptTemplateType::Baichuan2 {
         if output.as_ref().contains("用户:") {
@@ -1829,7 +1829,7 @@ fn build_prompt(
     chat_request: &mut ChatCompletionRequest,
 ) -> Result<(String, u64, bool), LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama_core", "Build the chat prompt from the chat messages.");
+    info!(target: "stdout", "Build the chat prompt from the chat messages.");
 
     let metadata = get_model_metadata(model_name)?;
     let ctx_size = metadata.ctx_size as u64;
@@ -1847,7 +1847,7 @@ fn build_prompt(
         //         let err_msg = format!("Fail to build chat prompts. Reason: {}", e);
 
         //         #[cfg(feature = "logging")]
-        //         error!(target: "llama_core", "{}", &err_msg);
+        //         error!(target: "stdout", "{}", &err_msg);
 
         //         return Err(LlamaCoreError::Operation(err_msg));
         //     }
@@ -1857,7 +1857,7 @@ fn build_prompt(
             let err_msg = "The messages in the chat request are empty.";
 
             #[cfg(feature = "logging")]
-            error!(target: "llama_core", "{}", err_msg);
+            error!(target: "stdout", "{}", err_msg);
 
             return Err(LlamaCoreError::Operation(err_msg.to_owned()));
         }
@@ -1871,7 +1871,7 @@ fn build_prompt(
                             let err_msg = format!("Fail to build chat prompts. Reason: {}", e);
 
                             #[cfg(feature = "logging")]
-                            error!(target: "llama_core", "{}", &err_msg);
+                            error!(target: "stdout", "{}", &err_msg);
 
                             return Err(LlamaCoreError::Operation(err_msg));
                         }
@@ -1886,14 +1886,14 @@ fn build_prompt(
                             let err_msg = format!("Fail to build chat prompts. Reason: {}", e);
 
                             #[cfg(feature = "logging")]
-                            error!(target: "llama_core", "{}", &err_msg);
+                            error!(target: "stdout", "{}", &err_msg);
 
                             return Err(LlamaCoreError::Operation(err_msg));
                         }
                     },
                     None => {
                         #[cfg(feature = "logging")]
-                        warn!(target: "llama_core", "The tool choice without tools is not supported.");
+                        warn!(target: "stdout", "The tool choice without tools is not supported.");
 
                         match chat_prompt.build_with_tools(&mut chat_request.messages, None) {
                             Ok(prompt) => (prompt, false),
@@ -1901,7 +1901,7 @@ fn build_prompt(
                                 let err_msg = format!("Fail to build chat prompts. Reason: {}", e);
 
                                 #[cfg(feature = "logging")]
-                                error!(target: "llama_core", "{}", &err_msg);
+                                error!(target: "stdout", "{}", &err_msg);
 
                                 return Err(LlamaCoreError::Operation(err_msg));
                             }
@@ -1915,7 +1915,7 @@ fn build_prompt(
                     let err_msg = format!("Fail to build chat prompts. Reason: {}", e);
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     return Err(LlamaCoreError::Operation(err_msg));
                 }
@@ -1968,7 +1968,7 @@ fn build_prompt(
                                 );
 
                             #[cfg(feature = "logging")]
-                            error!(target: "llama_core", "{}", &err_msg);
+                            error!(target: "stdout", "{}", &err_msg);
 
                             return Err(LlamaCoreError::Operation(err_msg));
                         } else {
@@ -2009,7 +2009,7 @@ fn build_prompt(
                                 );
 
                             #[cfg(feature = "logging")]
-                            error!(target: "llama_core", "{}", &err_msg);
+                            error!(target: "stdout", "{}", &err_msg);
 
                             return Err(LlamaCoreError::Operation(err_msg));
                         } else {
@@ -2018,7 +2018,7 @@ fn build_prompt(
                     }
                     _ => {
                         #[cfg(feature = "logging")]
-                        info!(target: "llama_core", "remove a {} message from the message queue", chat_request.messages[0].role());
+                        info!(target: "stdout", "remove a {} message from the message queue", chat_request.messages[0].role());
 
                         chat_request.messages.remove(0);
                     }
@@ -2034,14 +2034,14 @@ fn build_prompt(
 /// Downloads an image from the given URL and returns the file name.
 async fn download_image(image_url: impl AsRef<str>) -> Result<String, LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama_core", "Download image from the URL.");
+    info!(target: "stdout", "Download image from the URL.");
 
     let image_url = image_url.as_ref();
     let url = reqwest::Url::parse(image_url).map_err(|e| {
         let err_msg = format!("Fail to parse the image URL: {}. Reason: {}", image_url, e);
 
         #[cfg(feature = "logging")]
-        error!(target: "llama_core", "{}", &err_msg);
+        error!(target: "stdout", "{}", &err_msg);
 
         LlamaCoreError::Operation(err_msg)
     })?;
@@ -2053,7 +2053,7 @@ async fn download_image(image_url: impl AsRef<str>) -> Result<String, LlamaCoreE
         );
 
         #[cfg(feature = "logging")]
-        error!(target: "llama_core", "{}", &err_msg);
+        error!(target: "stdout", "{}", &err_msg);
 
         LlamaCoreError::Operation(err_msg)
     })?;
@@ -2076,7 +2076,7 @@ async fn download_image(image_url: impl AsRef<str>) -> Result<String, LlamaCoreE
         );
 
         #[cfg(feature = "logging")]
-        error!(target: "llama_core", "{}", &err_msg);
+        error!(target: "stdout", "{}", &err_msg);
 
         LlamaCoreError::Operation(err_msg)
     })?;
@@ -2090,14 +2090,14 @@ async fn download_image(image_url: impl AsRef<str>) -> Result<String, LlamaCoreE
             );
 
             #[cfg(feature = "logging")]
-            error!(target: "llama_core", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             LlamaCoreError::Operation(err_msg)
         })?;
     }
 
     #[cfg(feature = "logging")]
-    info!(target: "llama_core", "The image is downloaded successfully.");
+    info!(target: "stdout", "The image is downloaded successfully.");
 
     Ok(fname)
 }
@@ -2106,7 +2106,7 @@ fn set_prompt(model_name: Option<&String>, prompt: impl AsRef<str>) -> Result<()
     match model_name {
         Some(model_name) => {
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "Set prompt to the chat model named {}.", model_name);
+            info!(target: "stdout", "Set prompt to the chat model named {}.", model_name);
 
             let chat_graphs = match CHAT_GRAPHS.get() {
                 Some(chat_graphs) => chat_graphs,
@@ -2114,7 +2114,7 @@ fn set_prompt(model_name: Option<&String>, prompt: impl AsRef<str>) -> Result<()
                     let err_msg = format!("Fail to get the underlying value of `CHAT_GRAPHS` while trying to set prompt to the model named {}.", model_name);
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", err_msg);
+                    error!(target: "stdout", "{}", err_msg);
 
                     return Err(LlamaCoreError::Operation(err_msg));
                 }
@@ -2124,7 +2124,7 @@ fn set_prompt(model_name: Option<&String>, prompt: impl AsRef<str>) -> Result<()
                 let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS` while trying to set prompt to the model named {}. Reason: {}", model_name, e);
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama_core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -2141,7 +2141,7 @@ fn set_prompt(model_name: Option<&String>, prompt: impl AsRef<str>) -> Result<()
                     );
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     Err(LlamaCoreError::Operation(err_msg))
                 }
@@ -2149,7 +2149,7 @@ fn set_prompt(model_name: Option<&String>, prompt: impl AsRef<str>) -> Result<()
         }
         None => {
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "Set prompt to the default chat model.");
+            info!(target: "stdout", "Set prompt to the default chat model.");
 
             let chat_graphs = match CHAT_GRAPHS.get() {
                 Some(chat_graphs) => chat_graphs,
@@ -2157,7 +2157,7 @@ fn set_prompt(model_name: Option<&String>, prompt: impl AsRef<str>) -> Result<()
                     let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS` while trying to set prompt to the default model.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", err_msg);
+                    error!(target: "stdout", "{}", err_msg);
 
                     return Err(LlamaCoreError::Operation(err_msg.into()));
                 }
@@ -2167,7 +2167,7 @@ fn set_prompt(model_name: Option<&String>, prompt: impl AsRef<str>) -> Result<()
                 let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`while trying to set prompt to the default model. Reason: {}", e);
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama_core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -2181,7 +2181,7 @@ fn set_prompt(model_name: Option<&String>, prompt: impl AsRef<str>) -> Result<()
                     let err_msg = "There is no model available in the chat graphs while trying to set prompt to the default model.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", err_msg);
+                    error!(target: "stdout", "{}", err_msg);
 
                     Err(LlamaCoreError::Operation(err_msg.into()))
                 }
@@ -2210,7 +2210,7 @@ fn set_prompt(model_name: Option<&String>, prompt: impl AsRef<str>) -> Result<()
 /// Get a copy of the metadata of the model.
 fn get_model_metadata(model_name: Option<&String>) -> Result<Metadata, LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama_core", "Get the model metadata.");
+    info!(target: "stdout", "Get the model metadata.");
 
     match model_name {
         Some(model_name) => {
@@ -2220,7 +2220,7 @@ fn get_model_metadata(model_name: Option<&String>) -> Result<Metadata, LlamaCore
                     let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", err_msg);
+                    error!(target: "stdout", "{}", err_msg);
 
                     return Err(LlamaCoreError::Operation(err_msg.into()));
                 }
@@ -2230,7 +2230,7 @@ fn get_model_metadata(model_name: Option<&String>) -> Result<Metadata, LlamaCore
                 let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama_core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -2243,7 +2243,7 @@ fn get_model_metadata(model_name: Option<&String>) -> Result<Metadata, LlamaCore
                     );
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     Err(LlamaCoreError::Operation(err_msg))
                 }
@@ -2256,7 +2256,7 @@ fn get_model_metadata(model_name: Option<&String>) -> Result<Metadata, LlamaCore
                     let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", err_msg);
+                    error!(target: "stdout", "{}", err_msg);
 
                     return Err(LlamaCoreError::Operation(err_msg.into()));
                 }
@@ -2266,7 +2266,7 @@ fn get_model_metadata(model_name: Option<&String>) -> Result<Metadata, LlamaCore
                 let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama_core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -2277,7 +2277,7 @@ fn get_model_metadata(model_name: Option<&String>) -> Result<Metadata, LlamaCore
                     let err_msg = "There is no model available in the chat graphs.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", err_msg);
+                    error!(target: "stdout", "{}", err_msg);
 
                     Err(LlamaCoreError::Operation(err_msg.into()))
                 }
@@ -2291,7 +2291,7 @@ fn update_model_metadata(
     metadata: &Metadata,
 ) -> Result<(), LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama_core", "Update the model metadata.");
+    info!(target: "stdout", "Update the model metadata.");
 
     let config = match serde_json::to_string(metadata) {
         Ok(config) => config,
@@ -2299,7 +2299,7 @@ fn update_model_metadata(
             let err_msg = format!("Fail to serialize metadata to a JSON string. {}", e);
 
             #[cfg(feature = "logging")]
-            error!(target: "llama_core", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             return Err(LlamaCoreError::Operation(err_msg));
         }
@@ -2313,7 +2313,7 @@ fn update_model_metadata(
                     let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", err_msg);
+                    error!(target: "stdout", "{}", err_msg);
 
                     return Err(LlamaCoreError::Operation(err_msg.into()));
                 }
@@ -2323,7 +2323,7 @@ fn update_model_metadata(
                 let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. Reason: {}", e);
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama_core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -2340,7 +2340,7 @@ fn update_model_metadata(
                     );
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     Err(LlamaCoreError::Operation(err_msg))
                 }
@@ -2353,7 +2353,7 @@ fn update_model_metadata(
                     let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", err_msg);
+                    error!(target: "stdout", "{}", err_msg);
 
                     return Err(LlamaCoreError::Operation(err_msg.into()));
                 }
@@ -2363,7 +2363,7 @@ fn update_model_metadata(
                 let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. Reason: {}", e);
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama_core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -2377,7 +2377,7 @@ fn update_model_metadata(
                     let err_msg = "There is no model available in the chat graphs.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", err_msg);
+                    error!(target: "stdout", "{}", err_msg);
 
                     Err(LlamaCoreError::Operation(err_msg.into()))
                 }
@@ -2446,7 +2446,7 @@ impl Drop for ChatStream {
     fn drop(&mut self) {
         if self.cache.is_none() {
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "Clean up the context of the stream work environment.");
+            info!(target: "stdout", "Clean up the context of the stream work environment.");
 
             match &self.model {
                 Some(model_name) => {
@@ -2461,7 +2461,7 @@ impl Drop for ChatStream {
                                         );
 
                                         #[cfg(feature = "logging")]
-                                        error!(target: "llama_core", "{}", &err_msg);
+                                        error!(target: "stdout", "{}", &err_msg);
 
                                         #[cfg(not(feature = "logging"))]
                                         println!(
@@ -2477,7 +2477,7 @@ impl Drop for ChatStream {
                                     );
 
                                     #[cfg(feature = "logging")]
-                                    error!(target: "llama_core", "{}", &err_msg);
+                                    error!(target: "stdout", "{}", &err_msg);
 
                                     #[cfg(not(feature = "logging"))]
                                     println!(
@@ -2491,7 +2491,7 @@ impl Drop for ChatStream {
                                     format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
 
                                 #[cfg(feature = "logging")]
-                                error!(target: "llama_core", "{}", &err_msg);
+                                error!(target: "stdout", "{}", &err_msg);
 
                                 #[cfg(not(feature = "logging"))]
                                 println!(
@@ -2504,7 +2504,7 @@ impl Drop for ChatStream {
                             let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
                             #[cfg(feature = "logging")]
-                            error!(target: "llama_core", "{}", &err_msg);
+                            error!(target: "stdout", "{}", &err_msg);
 
                             #[cfg(not(feature = "logging"))]
                             println!(
@@ -2526,7 +2526,7 @@ impl Drop for ChatStream {
                                         );
 
                                         #[cfg(feature = "logging")]
-                                        error!(target: "llama_core", "{}", &err_msg);
+                                        error!(target: "stdout", "{}", &err_msg);
 
                                         #[cfg(not(feature = "logging"))]
                                         println!(
@@ -2539,7 +2539,7 @@ impl Drop for ChatStream {
                                     let err_msg = "There is no model available in the chat graphs.";
 
                                     #[cfg(feature = "logging")]
-                                    error!(target: "llama_core", "{}", err_msg);
+                                    error!(target: "stdout", "{}", err_msg);
 
                                     #[cfg(not(feature = "logging"))]
                                     println!(
@@ -2553,7 +2553,7 @@ impl Drop for ChatStream {
                                     format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
 
                                 #[cfg(feature = "logging")]
-                                error!(target: "llama_core", "{}", &err_msg);
+                                error!(target: "stdout", "{}", &err_msg);
 
                                 #[cfg(not(feature = "logging"))]
                                 println!(
@@ -2566,7 +2566,7 @@ impl Drop for ChatStream {
                             let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
                             #[cfg(feature = "logging")]
-                            error!(target: "llama_core", "{}", &err_msg);
+                            error!(target: "stdout", "{}", &err_msg);
 
                             #[cfg(not(feature = "logging"))]
                             println!(
@@ -2579,7 +2579,7 @@ impl Drop for ChatStream {
             }
 
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "Cleanup done!");
+            info!(target: "stdout", "Cleanup done!");
         }
     }
 }
@@ -2599,7 +2599,7 @@ impl futures::Stream for ChatStream {
             );
 
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "Get the next item: {:?}", &x);
+            info!(target: "stdout", "Get the next item: {:?}", &x);
 
             match x {
                 Ok(x) => {
@@ -2618,7 +2618,7 @@ impl futures::Stream for ChatStream {
             let x = this.cache.as_mut().unwrap().pop_front();
 
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "Get the next item from the cache: {:?}", &x);
+            info!(target: "stdout", "Get the next item from the cache: {:?}", &x);
 
             match x {
                 Some(x) => Poll::Ready(Some(Ok(x))),
@@ -2637,7 +2637,7 @@ fn compute_stream(
     stream_state: &mut StreamState,
 ) -> Result<String, LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama_core", "Compute the chat stream chunk.");
+    info!(target: "stdout", "Compute the chat stream chunk.");
 
     if *prompt_too_long_state == PromptTooLongState::EndOfSequence
         || *context_full_state == ContextFullState::EndOfSequence
@@ -2655,7 +2655,7 @@ fn compute_stream(
                     let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     return Err(LlamaCoreError::Operation(err_msg.into()));
                 }
@@ -2665,7 +2665,7 @@ fn compute_stream(
                 let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama_core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -2691,7 +2691,7 @@ fn compute_stream(
                                             );
 
                                             #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
+                                            error!(target: "stdout", "{}", &err_msg);
 
 
                                             LlamaCoreError::Operation(err_msg)
@@ -2713,7 +2713,7 @@ fn compute_stream(
                                                 let err_msg = "The length of the invalid utf8 bytes exceed 4.";
 
                                                 #[cfg(feature = "logging")]
-                                                error!(target: "llama_core", "{}", &err_msg);
+                                                error!(target: "stdout", "{}", &err_msg);
 
                                                 return Err(LlamaCoreError::Operation(
                                                     err_msg.into(),
@@ -2733,7 +2733,7 @@ fn compute_stream(
                                     format!("Failed to get the current time. Reason: {}", e);
 
                                 #[cfg(feature = "logging")]
-                                error!(target: "llama_core", "{}", &err_msg);
+                                error!(target: "stdout", "{}", &err_msg);
 
                                 LlamaCoreError::Operation(err_msg)
                             })?;
@@ -2766,7 +2766,7 @@ fn compute_stream(
                                     );
 
                                     #[cfg(feature = "logging")]
-                                    error!(target: "llama_core", "{}", &err_msg);
+                                    error!(target: "stdout", "{}", &err_msg);
 
                                     LlamaCoreError::Operation(err_msg)
                                 })?;
@@ -2791,7 +2791,7 @@ fn compute_stream(
                                     });
 
                                     #[cfg(feature = "logging")]
-                                    info!(target: "llama_core", "token_info: {} prompt tokens, {} completion tokens", token_info.prompt_tokens, token_info.completion_tokens);
+                                    info!(target: "stdout", "token_info: {} prompt tokens, {} completion tokens", token_info.prompt_tokens, token_info.completion_tokens);
 
                                     let created = SystemTime::now()
                                         .duration_since(std::time::UNIX_EPOCH)
@@ -2802,7 +2802,7 @@ fn compute_stream(
                                             );
 
                                             #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
+                                            error!(target: "stdout", "{}", &err_msg);
 
                                             LlamaCoreError::Operation(err_msg)
                                         })?;
@@ -2826,7 +2826,7 @@ fn compute_stream(
                                         );
 
                                         #[cfg(feature = "logging")]
-                                        error!(target: "llama_core", "{}", &err_msg);
+                                        error!(target: "stdout", "{}", &err_msg);
 
                                         LlamaCoreError::Operation(err_msg)
                                     })?;
@@ -2847,7 +2847,7 @@ fn compute_stream(
                                         );
 
                                         #[cfg(feature = "logging")]
-                                        error!(target: "llama_core", "{}", &err_msg);
+                                        error!(target: "stdout", "{}", &err_msg);
 
                                         return Err(LlamaCoreError::Backend(
                                             BackendError::FinishSingle(err_msg),
@@ -2877,7 +2877,7 @@ fn compute_stream(
                                             );
 
                                             #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
+                                            error!(target: "stdout", "{}", &err_msg);
 
                                             LlamaCoreError::Operation(err_msg)
                                         })?;
@@ -2912,7 +2912,7 @@ fn compute_stream(
                                         );
 
                                         #[cfg(feature = "logging")]
-                                        error!(target: "llama_core", "{}", &err_msg);
+                                        error!(target: "stdout", "{}", &err_msg);
 
                                         LlamaCoreError::Operation(err_msg)
                                     })?;
@@ -2941,7 +2941,7 @@ fn compute_stream(
                                             );
 
                                             #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
+                                            error!(target: "stdout", "{}", &err_msg);
 
                                             LlamaCoreError::Operation(err_msg)
                                         })?;
@@ -2965,7 +2965,7 @@ fn compute_stream(
                                         );
 
                                         #[cfg(feature = "logging")]
-                                        error!(target: "llama_core", "{}", &err_msg);
+                                        error!(target: "stdout", "{}", &err_msg);
 
                                         LlamaCoreError::Operation(err_msg)
                                     })?;
@@ -2986,7 +2986,7 @@ fn compute_stream(
                                         );
 
                                         #[cfg(feature = "logging")]
-                                        error!(target: "llama_core", "{}", &err_msg);
+                                        error!(target: "stdout", "{}", &err_msg);
 
                                         return Err(LlamaCoreError::Backend(
                                             BackendError::FinishSingle(err_msg),
@@ -3016,7 +3016,7 @@ fn compute_stream(
                                             );
 
                                             #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
+                                            error!(target: "stdout", "{}", &err_msg);
 
                                             LlamaCoreError::Operation(err_msg)
                                         })?;
@@ -3049,7 +3049,7 @@ fn compute_stream(
                                         );
 
                                         #[cfg(feature = "logging")]
-                                        error!(target: "llama_core", "{}", &err_msg);
+                                        error!(target: "stdout", "{}", &err_msg);
 
                                         LlamaCoreError::Operation(err_msg)
                                     })?;
@@ -3078,7 +3078,7 @@ fn compute_stream(
                                             );
 
                                             #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
+                                            error!(target: "stdout", "{}", &err_msg);
 
                                             LlamaCoreError::Operation(err_msg)
                                         })?;
@@ -3102,7 +3102,7 @@ fn compute_stream(
                                         );
 
                                         #[cfg(feature = "logging")]
-                                        error!(target: "llama_core", "{}", &err_msg);
+                                        error!(target: "stdout", "{}", &err_msg);
 
                                         LlamaCoreError::Operation(err_msg)
                                     })?;
@@ -3123,7 +3123,7 @@ fn compute_stream(
                                         );
 
                                         #[cfg(feature = "logging")]
-                                        error!(target: "llama_core", "{}", &err_msg);
+                                        error!(target: "stdout", "{}", &err_msg);
 
                                         return Err(LlamaCoreError::Backend(
                                             BackendError::FinishSingle(err_msg),
@@ -3141,7 +3141,7 @@ fn compute_stream(
                                     format!("Failed to clean up the context. Reason: {}", e);
 
                                 #[cfg(feature = "logging")]
-                                error!(target: "llama_core", "{}", &err_msg);
+                                error!(target: "stdout", "{}", &err_msg);
 
                                 return Err(LlamaCoreError::Backend(BackendError::FinishSingle(
                                     err_msg,
@@ -3152,7 +3152,7 @@ fn compute_stream(
                                 format!("Failed to compute the chat completion. Reason: {}", e);
 
                             #[cfg(feature = "logging")]
-                            error!(target: "llama_core", "{}", &err_msg);
+                            error!(target: "stdout", "{}", &err_msg);
 
                             Err(LlamaCoreError::Backend(BackendError::ComputeSingle(
                                 err_msg,
@@ -3167,7 +3167,7 @@ fn compute_stream(
                     );
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     Err(LlamaCoreError::Operation(err_msg))
                 }
@@ -3180,7 +3180,7 @@ fn compute_stream(
                     let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     return Err(LlamaCoreError::Operation(err_msg.into()));
                 }
@@ -3190,7 +3190,7 @@ fn compute_stream(
                 let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama_core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -3215,7 +3215,7 @@ fn compute_stream(
                                             );
 
                                             #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
+                                            error!(target: "stdout", "{}", &err_msg);
 
                                             LlamaCoreError::Operation(err_msg)
                                         })?;
@@ -3235,7 +3235,7 @@ fn compute_stream(
                                                 let err_msg = "The length of the invalid utf8 bytes exceed 4.";
 
                                                 #[cfg(feature = "logging")]
-                                                error!(target: "llama_core", "{}", &err_msg);
+                                                error!(target: "stdout", "{}", &err_msg);
 
                                                 return Err(LlamaCoreError::Operation(
                                                     err_msg.into(),
@@ -3255,7 +3255,7 @@ fn compute_stream(
                                     format!("Failed to get the current time. Reason: {}", e);
 
                                 #[cfg(feature = "logging")]
-                                error!(target: "llama_core", "{}", &err_msg);
+                                error!(target: "stdout", "{}", &err_msg);
 
                                 LlamaCoreError::Operation(err_msg)
                             })?;
@@ -3288,7 +3288,7 @@ fn compute_stream(
                                     );
 
                                     #[cfg(feature = "logging")]
-                                    error!(target: "llama_core", "{}", &err_msg);
+                                    error!(target: "stdout", "{}", &err_msg);
 
                                     LlamaCoreError::Operation(err_msg)
                                 })?;
@@ -3313,7 +3313,7 @@ fn compute_stream(
                                     });
 
                                     #[cfg(feature = "logging")]
-                                    info!(target: "llama_core", "token_info: {} prompt tokens, {} completion tokens", token_info.prompt_tokens, token_info.completion_tokens);
+                                    info!(target: "stdout", "token_info: {} prompt tokens, {} completion tokens", token_info.prompt_tokens, token_info.completion_tokens);
 
                                     let created = SystemTime::now()
                                         .duration_since(std::time::UNIX_EPOCH)
@@ -3324,7 +3324,7 @@ fn compute_stream(
                                             );
 
                                             #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
+                                            error!(target: "stdout", "{}", &err_msg);
 
                                             LlamaCoreError::Operation(err_msg)
                                         })?;
@@ -3348,7 +3348,7 @@ fn compute_stream(
                                         );
 
                                         #[cfg(feature = "logging")]
-                                        error!(target: "llama_core", "{}", &err_msg);
+                                        error!(target: "stdout", "{}", &err_msg);
 
                                         LlamaCoreError::Operation(err_msg)
                                     })?;
@@ -3369,7 +3369,7 @@ fn compute_stream(
                                         );
 
                                         #[cfg(feature = "logging")]
-                                        error!(target: "llama_core", "{}", &err_msg);
+                                        error!(target: "stdout", "{}", &err_msg);
 
                                         return Err(LlamaCoreError::Backend(
                                             BackendError::FinishSingle(err_msg),
@@ -3399,7 +3399,7 @@ fn compute_stream(
                                             );
 
                                             #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
+                                            error!(target: "stdout", "{}", &err_msg);
 
                                             LlamaCoreError::Operation(err_msg)
                                         })?;
@@ -3434,7 +3434,7 @@ fn compute_stream(
                                         );
 
                                         #[cfg(feature = "logging")]
-                                        error!(target: "llama_core", "{}", &err_msg);
+                                        error!(target: "stdout", "{}", &err_msg);
 
                                         LlamaCoreError::Operation(err_msg)
                                     })?;
@@ -3463,7 +3463,7 @@ fn compute_stream(
                                             );
 
                                             #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
+                                            error!(target: "stdout", "{}", &err_msg);
 
                                             LlamaCoreError::Operation(err_msg)
                                         })?;
@@ -3487,7 +3487,7 @@ fn compute_stream(
                                         );
 
                                         #[cfg(feature = "logging")]
-                                        error!(target: "llama_core", "{}", &err_msg);
+                                        error!(target: "stdout", "{}", &err_msg);
 
                                         LlamaCoreError::Operation(err_msg)
                                     })?;
@@ -3508,7 +3508,7 @@ fn compute_stream(
                                         );
 
                                         #[cfg(feature = "logging")]
-                                        error!(target: "llama_core", "{}", &err_msg);
+                                        error!(target: "stdout", "{}", &err_msg);
 
                                         return Err(LlamaCoreError::Backend(
                                             BackendError::FinishSingle(err_msg),
@@ -3538,7 +3538,7 @@ fn compute_stream(
                                             );
 
                                             #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
+                                            error!(target: "stdout", "{}", &err_msg);
 
                                             LlamaCoreError::Operation(err_msg)
                                         })?;
@@ -3571,7 +3571,7 @@ fn compute_stream(
                                         );
 
                                         #[cfg(feature = "logging")]
-                                        error!(target: "llama_core", "{}", &err_msg);
+                                        error!(target: "stdout", "{}", &err_msg);
 
                                         LlamaCoreError::Operation(err_msg)
                                     })?;
@@ -3600,7 +3600,7 @@ fn compute_stream(
                                             );
 
                                             #[cfg(feature = "logging")]
-                                            error!(target: "llama_core", "{}", &err_msg);
+                                            error!(target: "stdout", "{}", &err_msg);
 
                                             LlamaCoreError::Operation(err_msg)
                                         })?;
@@ -3624,7 +3624,7 @@ fn compute_stream(
                                         );
 
                                         #[cfg(feature = "logging")]
-                                        error!(target: "llama_core", "{}", &err_msg);
+                                        error!(target: "stdout", "{}", &err_msg);
 
                                         LlamaCoreError::Operation(err_msg)
                                     })?;
@@ -3645,7 +3645,7 @@ fn compute_stream(
                                         );
 
                                         #[cfg(feature = "logging")]
-                                        error!(target: "llama_core", "{}", &err_msg);
+                                        error!(target: "stdout", "{}", &err_msg);
 
                                         return Err(LlamaCoreError::Backend(
                                             BackendError::FinishSingle(err_msg),
@@ -3663,7 +3663,7 @@ fn compute_stream(
                                     format!("Failed to clean up the context. Reason: {}", e);
 
                                 #[cfg(feature = "logging")]
-                                error!(target: "llama_core", "{}", &err_msg);
+                                error!(target: "stdout", "{}", &err_msg);
 
                                 return Err(LlamaCoreError::Backend(BackendError::FinishSingle(
                                     err_msg,
@@ -3674,7 +3674,7 @@ fn compute_stream(
                                 format!("Failed to compute the chat completion. Reason: {}", e);
 
                             #[cfg(feature = "logging")]
-                            error!(target: "llama_core", "{}", &err_msg);
+                            error!(target: "stdout", "{}", &err_msg);
 
                             Err(LlamaCoreError::Backend(BackendError::ComputeSingle(
                                 err_msg,
@@ -3686,7 +3686,7 @@ fn compute_stream(
                     let err_msg = "There is no model available in the chat graphs.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama_core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     Err(LlamaCoreError::Operation(err_msg.into()))
                 }
@@ -3695,7 +3695,7 @@ fn compute_stream(
     };
 
     #[cfg(feature = "logging")]
-    info!(target: "llama_core", "Return the chat stream chunk!");
+    info!(target: "stdout", "Return the chat stream chunk!");
 
     res
 }

--- a/api-server/llama-core/src/chat.rs
+++ b/api-server/llama-core/src/chat.rs
@@ -2239,8 +2239,7 @@ fn get_model_metadata(model_name: Option<&String>) -> Result<Metadata, LlamaCore
                 Some(graph) => Ok(graph.metadata.clone()),
                 None => {
                     let err_msg = format!(
-                        "The model `{}` does not exist in the chat graphs.",
-                        &model_name
+                        "The model `{}` does not exist in the chat graphs. The available models are: {:?}", model_name, chat_graphs.keys()
                     );
 
                     #[cfg(feature = "logging")]

--- a/api-server/llama-core/src/chat.rs
+++ b/api-server/llama-core/src/chat.rs
@@ -13,21 +13,17 @@ use chat_prompts::{
     PromptTemplateType,
 };
 use either::{Either, Left, Right};
-#[cfg(feature = "https")]
-use endpoints::chat::{
-    ChatCompletionRequestMessage, ChatCompletionUserMessageContent, ContentPart,
-};
 use endpoints::{
     chat::{
         ChatCompletionChunk, ChatCompletionChunkChoice, ChatCompletionChunkChoiceDelta,
         ChatCompletionObject, ChatCompletionObjectChoice, ChatCompletionObjectMessage,
-        ChatCompletionRequest, ChatCompletionRole, Function, ToolCall, ToolCallForChunk,
+        ChatCompletionRequest, ChatCompletionRequestMessage, ChatCompletionRole,
+        ChatCompletionUserMessageContent, ContentPart, Function, ToolCall, ToolCallForChunk,
         ToolChoice,
     },
     common::{FinishReason, Usage},
 };
 use error::{BackendError, LlamaCoreError};
-#[cfg(feature = "https")]
 use futures::StreamExt;
 use std::{
     collections::VecDeque,
@@ -1551,7 +1547,6 @@ async fn check_model_metadata(
     let mut metadata = get_model_metadata(chat_request.model.as_ref())?;
 
     // check if necessary to update `image`
-    #[cfg(feature = "https")]
     if let Some(ChatCompletionRequestMessage::User(user_message)) = chat_request.messages.last() {
         if let ChatCompletionUserMessageContent::Parts(parts) = user_message.content() {
             for part in parts {
@@ -2037,7 +2032,6 @@ fn build_prompt(
 }
 
 /// Downloads an image from the given URL and returns the file name.
-#[cfg(feature = "https")]
 async fn download_image(image_url: impl AsRef<str>) -> Result<String, LlamaCoreError> {
     #[cfg(feature = "logging")]
     info!(target: "llama_core", "Download image from the URL.");

--- a/api-server/llama-core/src/completions.rs
+++ b/api-server/llama-core/src/completions.rs
@@ -15,7 +15,7 @@ use std::time::SystemTime;
 /// Given a prompt, the model will return one or more predicted completions along with the probabilities of alternative tokens at each position.
 pub async fn completions(request: &CompletionRequest) -> Result<CompletionObject, LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Generate completions");
+    info!(target: "stdout", "Generate completions");
 
     let running_mode = running_mode()?;
     if running_mode == RunningMode::Embeddings || running_mode == RunningMode::Rag {
@@ -25,7 +25,7 @@ pub async fn completions(request: &CompletionRequest) -> Result<CompletionObject
         );
 
         #[cfg(feature = "logging")]
-        error!(target: "llama-core", "{}", &err_msg);
+        error!(target: "stdout", "{}", &err_msg);
 
         return Err(LlamaCoreError::Operation(err_msg));
     }
@@ -43,12 +43,12 @@ fn compute(
     model_name: Option<&String>,
 ) -> std::result::Result<CompletionObject, LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Compute completions");
+    info!(target: "stdout", "Compute completions");
 
     match model_name {
         Some(model_name) => {
             #[cfg(feature = "logging")]
-            info!(target: "llama-core", "Model: {}", model_name);
+            info!(target: "stdout", "Model: {}", model_name);
 
             let chat_graphs = match CHAT_GRAPHS.get() {
                 Some(chat_graphs) => chat_graphs,
@@ -56,7 +56,7 @@ fn compute(
                     let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama-core", "{}", err_msg);
+                    error!(target: "stdout", "{}", err_msg);
 
                     return Err(LlamaCoreError::Operation(err_msg.into()));
                 }
@@ -66,7 +66,7 @@ fn compute(
                 let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama-core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -80,7 +80,7 @@ fn compute(
                     );
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama-core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     Err(LlamaCoreError::Operation(err_msg))
                 }
@@ -93,7 +93,7 @@ fn compute(
                     let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama-core", "{}", err_msg);
+                    error!(target: "stdout", "{}", err_msg);
 
                     return Err(LlamaCoreError::Operation(err_msg.into()));
                 }
@@ -103,7 +103,7 @@ fn compute(
                 let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama-core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -114,7 +114,7 @@ fn compute(
                     let err_msg = "There is no model available in the chat graphs.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama-core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     Err(LlamaCoreError::Operation(err_msg.into()))
                 }
@@ -129,14 +129,14 @@ fn compute_by_graph(
     prompt: impl AsRef<str>,
 ) -> std::result::Result<CompletionObject, LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Compute completions by graph");
+    info!(target: "stdout", "Compute completions by graph");
 
     // check if the `embedding` model is disabled or not
     if graph.metadata.embeddings {
         graph.metadata.embeddings = false;
 
         #[cfg(feature = "logging")]
-        info!(target: "llama-core", "The `embedding` field of metadata sets to false.");
+        info!(target: "stdout", "The `embedding` field of metadata sets to false.");
 
         graph.update_metadata()?;
     }
@@ -149,7 +149,7 @@ fn compute_by_graph(
             let err_msg = format!("Failed to set the input tensor. {}", e);
 
             #[cfg(feature = "logging")]
-            error!(target: "llama-core", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             LlamaCoreError::Backend(BackendError::SetInput(err_msg))
         })?;
@@ -159,7 +159,7 @@ fn compute_by_graph(
         let err_msg = format!("Failed to execute the inference. {}", e);
 
         #[cfg(feature = "logging")]
-        error!(target: "llama-core", "{}", &err_msg);
+        error!(target: "stdout", "{}", &err_msg);
 
         LlamaCoreError::Backend(BackendError::Compute(err_msg))
     })?;
@@ -175,7 +175,7 @@ fn compute_by_graph(
         );
 
         #[cfg(feature = "logging")]
-        error!(target: "llama-core", "{}", &err_msg);
+        error!(target: "stdout", "{}", &err_msg);
 
         LlamaCoreError::Operation(err_msg)
     })?;
@@ -185,7 +185,7 @@ fn compute_by_graph(
     let token_info = get_token_info_by_graph(graph)?;
 
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Prompt tokens: {}, Completion tokens: {}", token_info.prompt_tokens, token_info.completion_tokens);
+    info!(target: "stdout", "Prompt tokens: {}, Completion tokens: {}", token_info.prompt_tokens, token_info.completion_tokens);
 
     let created = SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -193,13 +193,13 @@ fn compute_by_graph(
             let err_msg = format!("Failed to get the current time. {}", e);
 
             #[cfg(feature = "logging")]
-            error!(target: "llama-core", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             LlamaCoreError::Operation(err_msg)
         })?;
 
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Completions generated successfully.");
+    info!(target: "stdout", "Completions generated successfully.");
 
     Ok(CompletionObject {
         id: uuid::Uuid::new_v4().to_string(),

--- a/api-server/llama-core/src/embeddings.rs
+++ b/api-server/llama-core/src/embeddings.rs
@@ -25,7 +25,7 @@ pub async fn embeddings(
     embedding_request: &EmbeddingRequest,
 ) -> Result<EmbeddingsResponse, LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Computing embeddings");
+    info!(target: "stdout", "Computing embeddings");
 
     let running_mode = running_mode()?;
     if running_mode == RunningMode::Chat {
@@ -35,7 +35,7 @@ pub async fn embeddings(
         );
 
         #[cfg(feature = "logging")]
-        error!(target: "llama-core", "{}", &err_msg);
+        error!(target: "stdout", "{}", &err_msg);
 
         return Err(LlamaCoreError::Operation(err_msg));
     }
@@ -52,7 +52,7 @@ pub async fn embeddings(
                 let err_msg = "No embedding model is available.";
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama-core", "{}", err_msg);
+                error!(target: "stdout", "{}", err_msg);
 
                 return Err(LlamaCoreError::Operation(err_msg.into()));
             }
@@ -63,7 +63,7 @@ pub async fn embeddings(
         let err_msg = format!("Fail to acquire the lock of `EMBEDDING_GRAPHS`. {}", e);
 
         #[cfg(feature = "logging")]
-        error!(target: "llama-core", "{}", &err_msg);
+        error!(target: "stdout", "{}", &err_msg);
 
         LlamaCoreError::Operation(err_msg)
     })?;
@@ -77,7 +77,7 @@ pub async fn embeddings(
             );
 
             #[cfg(feature = "logging")]
-            error!(target: "llama-core", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             return Err(LlamaCoreError::Operation(err_msg));
         }
@@ -120,7 +120,7 @@ pub async fn embeddings(
     };
 
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Embeddings computed successfully.");
+    info!(target: "stdout", "Embeddings computed successfully.");
 
     Ok(embedding_reponse)
 }
@@ -130,7 +130,7 @@ fn compute_embeddings(
     input: &[String],
 ) -> Result<(Vec<EmbeddingObject>, Usage), LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Compute embeddings for {} chunks", input.len());
+    info!(target: "stdout", "Compute embeddings for {} chunks", input.len());
 
     // compute embeddings
     let mut embeddings: Vec<EmbeddingObject> = Vec::new();
@@ -144,13 +144,13 @@ fn compute_embeddings(
                 let err_msg = e.to_string();
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama-core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Backend(BackendError::SetInput(err_msg))
             })?;
 
         #[cfg(feature = "logging")]
-        info!(target: "llama-core", "compute embeddings for chunk {}", idx + 1);
+        info!(target: "stdout", "compute embeddings for chunk {}", idx + 1);
 
         match graph.compute() {
             Ok(_) => {
@@ -165,7 +165,7 @@ fn compute_embeddings(
                     );
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama-core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     LlamaCoreError::Operation(err_msg)
                 })?;
@@ -176,7 +176,7 @@ fn compute_embeddings(
                         format!("Failed to deserialize the embedding data. Reason: {}", e);
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama-core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     LlamaCoreError::Operation(err_msg)
                 })?;
@@ -200,7 +200,7 @@ fn compute_embeddings(
                 let err_msg = format!("Failed to compute embeddings. Reason: {}", e);
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama-core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 return Err(LlamaCoreError::Backend(BackendError::Compute(err_msg)));
             }
@@ -208,7 +208,7 @@ fn compute_embeddings(
     }
 
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "token usage of embeddings: {} prompt tokens, {} comletion tokens", usage.prompt_tokens, usage.completion_tokens);
+    info!(target: "stdout", "token usage of embeddings: {} prompt tokens, {} comletion tokens", usage.prompt_tokens, usage.completion_tokens);
 
     Ok((embeddings, usage))
 }
@@ -234,7 +234,7 @@ pub fn dimension(name: Option<&str>) -> Result<u64, LlamaCoreError> {
             let err_msg = "Fail to get the underlying value of `EMBEDDING_GRAPHS`.";
 
             #[cfg(feature = "logging")]
-            error!(target: "llama-core", "{}", err_msg);
+            error!(target: "stdout", "{}", err_msg);
 
             return Err(LlamaCoreError::Operation(err_msg.into()));
         }
@@ -244,7 +244,7 @@ pub fn dimension(name: Option<&str>) -> Result<u64, LlamaCoreError> {
         let err_msg = format!("Fail to acquire the lock of `EMBEDDING_GRAPHS`. {}", e);
 
         #[cfg(feature = "logging")]
-        error!(target: "llama-core", "{}", &err_msg);
+        error!(target: "stdout", "{}", &err_msg);
 
         LlamaCoreError::Operation(err_msg)
     })?;
@@ -259,7 +259,7 @@ pub fn dimension(name: Option<&str>) -> Result<u64, LlamaCoreError> {
                 );
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama-core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 Err(LlamaCoreError::Operation(err_msg))
             }
@@ -272,7 +272,7 @@ pub fn dimension(name: Option<&str>) -> Result<u64, LlamaCoreError> {
                         let err_msg = "Fail to get the underlying value of `EMBEDDING_GRAPHS`.";
 
                         #[cfg(feature = "logging")]
-                        error!(target: "llama-core", "{}", err_msg);
+                        error!(target: "stdout", "{}", err_msg);
 
                         return Err(LlamaCoreError::Operation(err_msg.into()));
                     }
@@ -283,7 +283,7 @@ pub fn dimension(name: Option<&str>) -> Result<u64, LlamaCoreError> {
                 let err_msg = "There is no model available in the embedding graphs.";
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama-core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 Err(LlamaCoreError::Operation(err_msg.into()))
             }

--- a/api-server/llama-core/src/images.rs
+++ b/api-server/llama-core/src/images.rs
@@ -1,6 +1,8 @@
 use crate::{error::LlamaCoreError, SD_IMAGE_TO_IMAGE, SD_TEXT_TO_IMAGE};
 use base64::{engine::general_purpose, Engine as _};
-use endpoints::images::{ImageCreateRequest, ImageEditRequest, ImageObject, ListImagesResponse};
+use endpoints::images::{
+    ImageCreateRequest, ImageEditRequest, ImageObject, ImageVariationRequest, ListImagesResponse,
+};
 use std::{
     fs::{self, File},
     io::{self, Read},
@@ -261,7 +263,7 @@ pub async fn image_edit(req: &mut ImageEditRequest) -> Result<ListImagesResponse
 
 /// Create a variation of a given image.
 pub async fn image_variation(
-    _req: &mut ImageEditRequest,
+    _req: &mut ImageVariationRequest,
 ) -> Result<ListImagesResponse, LlamaCoreError> {
     unimplemented!("image_variation")
 }

--- a/api-server/llama-core/src/images.rs
+++ b/api-server/llama-core/src/images.rs
@@ -1,4 +1,4 @@
-use crate::{error::LlamaCoreError, SD_TEXT_TO_IMAGE};
+use crate::{error::LlamaCoreError, SD_IMAGE_TO_IMAGE, SD_TEXT_TO_IMAGE};
 use base64::{engine::general_purpose, Engine as _};
 use endpoints::images::{ImageCreateRequest, ImageEditRequest, ImageObject, ListImagesResponse};
 use std::{
@@ -6,7 +6,7 @@ use std::{
     io::{self, Read},
     path::Path,
 };
-use wasmedge_stable_diffusion::{BaseFunction, Context};
+use wasmedge_stable_diffusion::{stable_diffusion_interface::ImageType, BaseFunction, Context};
 
 /// Create an image given a prompt.
 pub async fn image_generation(
@@ -55,13 +55,13 @@ pub async fn image_generation(
                 fs::create_dir(&file_path).unwrap();
             }
             let filename = "output.png";
-            let image_file = file_path.join(filename);
-            let image_file = image_file.to_str().unwrap();
+            let output_image_file = file_path.join(filename);
+            let output_image_file = output_image_file.to_str().unwrap();
 
             // create and dump the generated image
             text_to_image
                 .set_prompt(&req.prompt)
-                .set_output_path(image_file)
+                .set_output_path(output_image_file)
                 .generate()
                 .map_err(|e| {
                     let err_msg = format!("Fail to dump the image. {}", e);
@@ -77,7 +77,7 @@ pub async fn image_generation(
             info!(target: "llama_core", "file_id: {}, file_name: {}", &id, &filename);
 
             // convert the image to base64 string
-            let base64_string = match image_to_base64(image_file) {
+            let base64_string = match image_to_base64(output_image_file) {
                 Ok(base64_string) => base64_string,
                 Err(e) => {
                     let err_msg = format!("Fail to convert the image to base64 string. {}", e);
@@ -131,8 +131,139 @@ pub async fn image_generation(
 }
 
 /// Create an edited or extended image given an original image and a prompt.
-pub async fn image_edit(_req: &mut ImageEditRequest) -> Result<ListImagesResponse, LlamaCoreError> {
-    unimplemented!("image_edit")
+pub async fn image_edit(req: &mut ImageEditRequest) -> Result<ListImagesResponse, LlamaCoreError> {
+    let sd = match SD_IMAGE_TO_IMAGE.get() {
+        Some(sd) => sd,
+        None => {
+            let err_msg = "Fail to get the underlying value of `SD_IMAGE_TO_IMAGE`.";
+
+            #[cfg(feature = "logging")]
+            error!(target: "llama_core", "{}", &err_msg);
+
+            return Err(LlamaCoreError::Operation(err_msg.into()));
+        }
+    };
+
+    let sd_locked = sd.lock().map_err(|e| {
+        let err_msg = format!("Fail to acquire the lock of `SD_IMAGE_TO_IMAGE`. {}", e);
+
+        #[cfg(feature = "logging")]
+        error!(target: "llama_core", "{}", &err_msg);
+
+        LlamaCoreError::Operation(err_msg)
+    })?;
+
+    match sd_locked.create_context().map_err(|e| {
+        let err_msg = format!("Fail to create the context. {}", e);
+
+        #[cfg(feature = "logging")]
+        error!(target: "llama_core", "{}", &err_msg);
+
+        LlamaCoreError::InitContext(err_msg)
+    })? {
+        Context::ImageToImage(mut image_to_image) => {
+            // create a unique file id
+            let id = format!("file_{}", uuid::Uuid::new_v4());
+
+            // save the file
+            let path = Path::new("archives");
+            if !path.exists() {
+                fs::create_dir(path).unwrap();
+            }
+            let file_path = path.join(&id);
+            if !file_path.exists() {
+                fs::create_dir(&file_path).unwrap();
+            }
+            let filename = "output.png";
+            let output_image_file = file_path.join(filename);
+            let output_image_file = output_image_file.to_str().unwrap();
+
+            // get the path of the original image
+            let origin_image_file = Path::new("archives")
+                .join(&req.image.id)
+                .join(&req.image.filename);
+            let path_origin_image = origin_image_file.to_str().ok_or(LlamaCoreError::Operation(
+                "Fail to get the path of the original image.".into(),
+            ))?;
+
+            // create and dump the generated image
+            image_to_image
+                .set_prompt(&req.prompt)
+                .set_image(ImageType::Path(path_origin_image))
+                .set_output_path(output_image_file)
+                .generate()
+                .map_err(|e| {
+                    let err_msg = format!("Fail to dump the image. {}", e);
+
+                    #[cfg(feature = "logging")]
+                    error!(target: "llama_core", "{}", &err_msg);
+
+                    LlamaCoreError::Operation(err_msg)
+                })?;
+
+            // log
+            #[cfg(feature = "logging")]
+            info!(target: "llama_core", "file_id: {}, file_name: {}", &id, &filename);
+
+            // convert the image to base64 string
+            let base64_string = match image_to_base64(output_image_file) {
+                Ok(base64_string) => base64_string,
+                Err(e) => {
+                    let err_msg = format!("Fail to convert the image to base64 string. {}", e);
+
+                    #[cfg(feature = "logging")]
+                    error!(target: "llama_core", "{}", &err_msg);
+
+                    return Err(LlamaCoreError::Operation(err_msg));
+                }
+            };
+
+            // log
+            #[cfg(feature = "logging")]
+            info!(target: "llama_core", "base64 string: {}", &base64_string.chars().take(10).collect::<String>());
+
+            let created: u64 =
+                match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+                    Ok(n) => n.as_secs(),
+                    Err(_) => {
+                        let err_msg = "Failed to get the current time.";
+
+                        // log
+                        #[cfg(feature = "logging")]
+                        error!(target: "llama_core", "{}", &err_msg);
+
+                        return Err(LlamaCoreError::Operation(err_msg.into()));
+                    }
+                };
+
+            // create an image object
+            let image = ImageObject {
+                b64_json: Some(base64_string),
+                url: None,
+                prompt: Some(req.prompt.clone()),
+            };
+
+            Ok(ListImagesResponse {
+                created,
+                data: vec![image],
+            })
+        }
+        _ => {
+            let err_msg = "Fail to get the `ImageToImage` context.";
+
+            #[cfg(feature = "logging")]
+            error!(target: "llama_core", "{}", &err_msg);
+
+            Err(LlamaCoreError::Operation(err_msg.into()))
+        }
+    }
+}
+
+/// Create a variation of a given image.
+pub async fn image_variation(
+    _req: &mut ImageEditRequest,
+) -> Result<ListImagesResponse, LlamaCoreError> {
+    unimplemented!("image_variation")
 }
 
 // convert an image file to a base64 string

--- a/api-server/llama-core/src/images.rs
+++ b/api-server/llama-core/src/images.rs
@@ -76,7 +76,7 @@ pub async fn image_generation(
 
             // log
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "file_id: {}, file_name: {}", &id, &filename);
+            info!(target: "stdout", "file_id: {}, file_name: {}", &id, &filename);
 
             // convert the image to base64 string
             let base64_string = match image_to_base64(output_image_file) {
@@ -93,7 +93,7 @@ pub async fn image_generation(
 
             // log
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "base64 string: {}", &base64_string.chars().take(10).collect::<String>());
+            info!(target: "stdout", "base64 string: {}", &base64_string.chars().take(10).collect::<String>());
 
             let created: u64 =
                 match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
@@ -205,7 +205,7 @@ pub async fn image_edit(req: &mut ImageEditRequest) -> Result<ListImagesResponse
 
             // log
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "file_id: {}, file_name: {}", &id, &filename);
+            info!(target: "stdout", "file_id: {}, file_name: {}", &id, &filename);
 
             // convert the image to base64 string
             let base64_string = match image_to_base64(output_image_file) {
@@ -222,7 +222,7 @@ pub async fn image_edit(req: &mut ImageEditRequest) -> Result<ListImagesResponse
 
             // log
             #[cfg(feature = "logging")]
-            info!(target: "llama_core", "base64 string: {}", &base64_string.chars().take(10).collect::<String>());
+            info!(target: "stdout", "base64 string: {}", &base64_string.chars().take(10).collect::<String>());
 
             let created: u64 =
                 match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {

--- a/api-server/llama-core/src/images.rs
+++ b/api-server/llama-core/src/images.rs
@@ -1,0 +1,146 @@
+use crate::{error::LlamaCoreError, SD_TEXT_TO_IMAGE};
+use base64::{engine::general_purpose, Engine as _};
+use endpoints::images::{ImageCreateRequest, ImageEditRequest, ImageObject, ListImagesResponse};
+use std::{
+    fs::{self, File},
+    io::{self, Read},
+    path::Path,
+};
+use wasmedge_stable_diffusion::{BaseFunction, Context};
+
+pub async fn image_generation(
+    req: &mut ImageCreateRequest,
+) -> Result<ListImagesResponse, LlamaCoreError> {
+    let sd = match SD_TEXT_TO_IMAGE.get() {
+        Some(sd) => sd,
+        None => {
+            let err_msg = "Fail to get the underlying value of `SD_TEXT_TO_IMAGE`.";
+
+            #[cfg(feature = "logging")]
+            error!(target: "llama_core", "{}", &err_msg);
+
+            return Err(LlamaCoreError::Operation(err_msg.into()));
+        }
+    };
+
+    let sd_locked = sd.lock().map_err(|e| {
+        let err_msg = format!("Fail to acquire the lock of `SD_TEXT_TO_IMAGE`. {}", e);
+
+        #[cfg(feature = "logging")]
+        error!(target: "llama_core", "{}", &err_msg);
+
+        LlamaCoreError::Operation(err_msg)
+    })?;
+
+    match sd_locked.create_context().map_err(|e| {
+        let err_msg = format!("Fail to create the context. {}", e);
+
+        #[cfg(feature = "logging")]
+        error!(target: "llama_core", "{}", &err_msg);
+
+        LlamaCoreError::InitContext(err_msg)
+    })? {
+        Context::TextToImage(mut text_to_image) => {
+            // create a unique file id
+            let id = format!("file_{}", uuid::Uuid::new_v4());
+
+            // save the file
+            let path = Path::new("archives");
+            if !path.exists() {
+                fs::create_dir(path).unwrap();
+            }
+            let file_path = path.join(&id);
+            if !file_path.exists() {
+                fs::create_dir(&file_path).unwrap();
+            }
+            let filename = "output.png";
+            let image_file = file_path.join(filename);
+            let image_file = image_file.to_str().unwrap();
+
+            // create and dump the generated image
+            text_to_image
+                .set_prompt(&req.prompt)
+                .set_output_path(image_file)
+                .generate()
+                .map_err(|e| {
+                    let err_msg = format!("Fail to dump the image. {}", e);
+
+                    #[cfg(feature = "logging")]
+                    error!(target: "llama_core", "{}", &err_msg);
+
+                    LlamaCoreError::Operation(err_msg)
+                })?;
+
+            // log
+            #[cfg(feature = "logging")]
+            info!(target: "llama_core", "file_id: {}, file_name: {}", &id, &filename);
+
+            // convert the image to base64 string
+            let base64_string = match image_to_base64(image_file) {
+                Ok(base64_string) => base64_string,
+                Err(e) => {
+                    let err_msg = format!("Fail to convert the image to base64 string. {}", e);
+
+                    #[cfg(feature = "logging")]
+                    error!(target: "llama_core", "{}", &err_msg);
+
+                    return Err(LlamaCoreError::Operation(err_msg));
+                }
+            };
+
+            // log
+            #[cfg(feature = "logging")]
+            info!(target: "llama_core", "base64 string: {}", &base64_string.chars().take(10).collect::<String>());
+
+            let created: u64 =
+                match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+                    Ok(n) => n.as_secs(),
+                    Err(_) => {
+                        let err_msg = "Failed to get the current time.";
+
+                        // log
+                        #[cfg(feature = "logging")]
+                        error!(target: "llama_core", "{}", &err_msg);
+
+                        return Err(LlamaCoreError::Operation(err_msg.into()));
+                    }
+                };
+
+            // create an image object
+            let image = ImageObject {
+                b64_json: Some(base64_string),
+                url: None,
+                prompt: Some(req.prompt.clone()),
+            };
+
+            Ok(ListImagesResponse {
+                created,
+                data: vec![image],
+            })
+        }
+        _ => {
+            let err_msg = "Fail to get the `TextToImage` context.";
+
+            #[cfg(feature = "logging")]
+            error!(target: "llama_core", "{}", &err_msg);
+
+            Err(LlamaCoreError::Operation(err_msg.into()))
+        }
+    }
+}
+
+pub async fn image_edit(_req: &mut ImageEditRequest) -> Result<ListImagesResponse, LlamaCoreError> {
+    unimplemented!("image_edit")
+}
+
+// convert an image file to a base64 string
+fn image_to_base64(image_path: &str) -> io::Result<String> {
+    // Open the file
+    let mut image_file = File::open(image_path)?;
+
+    // Read the file into a byte array
+    let mut buffer = Vec::new();
+    image_file.read_to_end(&mut buffer)?;
+
+    Ok(general_purpose::STANDARD.encode(&buffer))
+}

--- a/api-server/llama-core/src/images.rs
+++ b/api-server/llama-core/src/images.rs
@@ -8,6 +8,7 @@ use std::{
 };
 use wasmedge_stable_diffusion::{BaseFunction, Context};
 
+/// Create an image given a prompt.
 pub async fn image_generation(
     req: &mut ImageCreateRequest,
 ) -> Result<ListImagesResponse, LlamaCoreError> {
@@ -129,6 +130,7 @@ pub async fn image_generation(
     }
 }
 
+/// Create an edited or extended image given an original image and a prompt.
 pub async fn image_edit(_req: &mut ImageEditRequest) -> Result<ListImagesResponse, LlamaCoreError> {
     unimplemented!("image_edit")
 }

--- a/api-server/llama-core/src/lib.rs
+++ b/api-server/llama-core/src/lib.rs
@@ -315,7 +315,7 @@ impl Graph {
             let err_msg = e.to_string();
 
             #[cfg(feature = "logging")]
-            error!(target: "llama-core", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             LlamaCoreError::Operation(err_msg)
         })?;
@@ -331,7 +331,7 @@ impl Graph {
             let err_msg = e.to_string();
 
             #[cfg(feature = "logging")]
-            error!(target: "llama-core", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             LlamaCoreError::Operation(err_msg)
         })?;
@@ -341,7 +341,7 @@ impl Graph {
             let err_msg = e.to_string();
 
             #[cfg(feature = "logging")]
-            error!(target: "llama-core", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             LlamaCoreError::Operation(err_msg)
         })?;
@@ -352,7 +352,7 @@ impl Graph {
                 let err_msg = e.to_string();
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama-core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -383,7 +383,7 @@ impl Graph {
     /// Update metadata
     pub fn update_metadata(&mut self) -> Result<(), LlamaCoreError> {
         #[cfg(feature = "logging")]
-        info!(target: "llama-core", "Update metadata for the model named {}", self.name());
+        info!(target: "stdout", "Update metadata for the model named {}", self.name());
 
         // update metadata
         let config = match serde_json::to_string(&self.metadata) {
@@ -392,7 +392,7 @@ impl Graph {
                 let err_msg = format!("Failed to update metadta. Reason: Fail to serialize metadata to a JSON string. {}", e);
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama-core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 return Err(LlamaCoreError::Operation(err_msg));
             }
@@ -401,7 +401,7 @@ impl Graph {
         let res = set_tensor_data_u8(self, 1, config.as_bytes());
 
         #[cfg(feature = "logging")]
-        info!(target: "llama-core", "Metadata updated successfully.");
+        info!(target: "stdout", "Metadata updated successfully.");
 
         res
     }
@@ -463,13 +463,13 @@ pub fn init_core_context(
     metadata_for_embeddings: Option<&[Metadata]>,
 ) -> Result<(), LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Initializing the core context");
+    info!(target: "stdout", "Initializing the core context");
 
     if metadata_for_chats.is_none() && metadata_for_embeddings.is_none() {
         let err_msg = "Failed to initialize the core context. Please set metadata for chat completions and/or embeddings.";
 
         #[cfg(feature = "logging")]
-        error!(target: "llama-core", "{}", err_msg);
+        error!(target: "stdout", "{}", err_msg);
 
         return Err(LlamaCoreError::InitContext(err_msg.into()));
     }
@@ -487,7 +487,7 @@ pub fn init_core_context(
             let err_msg = "Failed to initialize the core context. Reason: The `CHAT_GRAPHS` has already been initialized";
 
             #[cfg(feature = "logging")]
-            error!(target: "llama-core", "{}", err_msg);
+            error!(target: "stdout", "{}", err_msg);
 
             LlamaCoreError::InitContext(err_msg.into())
         })?;
@@ -508,7 +508,7 @@ pub fn init_core_context(
                 let err_msg = "Failed to initialize the core context. Reason: The `EMBEDDING_GRAPHS` has already been initialized";
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama-core", "{}", err_msg);
+                error!(target: "stdout", "{}", err_msg);
 
                 LlamaCoreError::InitContext(err_msg.into())
             })?;
@@ -519,19 +519,19 @@ pub fn init_core_context(
     }
 
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "running mode: {}", mode);
+    info!(target: "stdout", "running mode: {}", mode);
 
     RUNNING_MODE.set(RwLock::new(mode)).map_err(|_| {
         let err_msg = "Failed to initialize the core context. Reason: The `RUNNING_MODE` has already been initialized";
 
         #[cfg(feature = "logging")]
-        error!(target: "llama-core", "{}", err_msg);
+        error!(target: "stdout", "{}", err_msg);
 
         LlamaCoreError::InitContext(err_msg.into())
     })?;
 
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "The core context has been initialized");
+    info!(target: "stdout", "The core context has been initialized");
 
     Ok(())
 }
@@ -542,14 +542,14 @@ pub fn init_rag_core_context(
     metadata_for_embeddings: &[Metadata],
 ) -> Result<(), LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Initializing the core context for RAG scenarios");
+    info!(target: "stdout", "Initializing the core context for RAG scenarios");
 
     // chat models
     if metadata_for_chats.is_empty() {
         let err_msg = "The metadata for chat models is empty";
 
         #[cfg(feature = "logging")]
-        error!(target: "llama-core", "{}", err_msg);
+        error!(target: "stdout", "{}", err_msg);
 
         return Err(LlamaCoreError::InitContext(err_msg.into()));
     }
@@ -563,7 +563,7 @@ pub fn init_rag_core_context(
         let err_msg = "Failed to initialize the core context. Reason: The `CHAT_GRAPHS` has already been initialized";
 
         #[cfg(feature = "logging")]
-        error!(target: "llama-core", "{}", err_msg);
+        error!(target: "stdout", "{}", err_msg);
 
         LlamaCoreError::InitContext(err_msg.into())
     })?;
@@ -573,7 +573,7 @@ pub fn init_rag_core_context(
         let err_msg = "The metadata for embeddings is empty";
 
         #[cfg(feature = "logging")]
-        error!(target: "llama-core", "{}", err_msg);
+        error!(target: "stdout", "{}", err_msg);
 
         return Err(LlamaCoreError::InitContext(err_msg.into()));
     }
@@ -589,7 +589,7 @@ pub fn init_rag_core_context(
             let err_msg = "Failed to initialize the core context. Reason: The `EMBEDDING_GRAPHS` has already been initialized";
 
             #[cfg(feature = "logging")]
-            error!(target: "llama-core", "{}", err_msg);
+            error!(target: "stdout", "{}", err_msg);
 
             LlamaCoreError::InitContext(err_msg.into())
         })?;
@@ -597,20 +597,20 @@ pub fn init_rag_core_context(
     let running_mode = RunningMode::Rag;
 
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "running mode: {}", running_mode);
+    info!(target: "stdout", "running mode: {}", running_mode);
 
     // set running mode
     RUNNING_MODE.set(RwLock::new(running_mode)).map_err(|_| {
             let err_msg = "Failed to initialize the core context. Reason: The `RUNNING_MODE` has already been initialized";
 
             #[cfg(feature = "logging")]
-            error!(target: "llama-core", "{}", err_msg);
+            error!(target: "stdout", "{}", err_msg);
 
             LlamaCoreError::InitContext(err_msg.into())
         })?;
 
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "The core context for RAG scenarios has been initialized");
+    info!(target: "stdout", "The core context for RAG scenarios has been initialized");
 
     Ok(())
 }
@@ -620,7 +620,7 @@ pub fn init_rag_core_context(
 /// Note that it is required to call `init_core_context` before calling this function.
 pub fn get_plugin_info() -> Result<PluginInfo, LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Getting the plugin info");
+    info!(target: "stdout", "Getting the plugin info");
 
     match running_mode()? {
         RunningMode::Embeddings => {
@@ -630,7 +630,7 @@ pub fn get_plugin_info() -> Result<PluginInfo, LlamaCoreError> {
                     let err_msg = "Fail to get the underlying value of `EMBEDDING_GRAPHS`.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama-core", "{}", err_msg);
+                    error!(target: "stdout", "{}", err_msg);
 
                     return Err(LlamaCoreError::Operation(err_msg.into()));
                 }
@@ -640,7 +640,7 @@ pub fn get_plugin_info() -> Result<PluginInfo, LlamaCoreError> {
                 let err_msg = format!("Fail to acquire the lock of `EMBEDDING_GRAPHS`. {}", e);
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama-core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -651,7 +651,7 @@ pub fn get_plugin_info() -> Result<PluginInfo, LlamaCoreError> {
                     let err_msg = "Fail to get the underlying value of `EMBEDDING_GRAPHS`.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama-core", "{}", err_msg);
+                    error!(target: "stdout", "{}", err_msg);
 
                     return Err(LlamaCoreError::Operation(err_msg.into()));
                 }
@@ -666,7 +666,7 @@ pub fn get_plugin_info() -> Result<PluginInfo, LlamaCoreError> {
                     let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama-core", "{}", err_msg);
+                    error!(target: "stdout", "{}", err_msg);
 
                     return Err(LlamaCoreError::Operation(err_msg.into()));
                 }
@@ -676,7 +676,7 @@ pub fn get_plugin_info() -> Result<PluginInfo, LlamaCoreError> {
                 let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama-core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -687,7 +687,7 @@ pub fn get_plugin_info() -> Result<PluginInfo, LlamaCoreError> {
                     let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama-core", "{}", err_msg);
+                    error!(target: "stdout", "{}", err_msg);
 
                     return Err(LlamaCoreError::Operation(err_msg.into()));
                 }
@@ -700,7 +700,7 @@ pub fn get_plugin_info() -> Result<PluginInfo, LlamaCoreError> {
 
 fn get_plugin_info_by_graph(graph: &Graph) -> Result<PluginInfo, LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Getting the plugin info by the graph named {}", graph.name());
+    info!(target: "stdout", "Getting the plugin info by the graph named {}", graph.name());
 
     // get the plugin metadata
     let output_buffer = get_output_buffer(graph, PLUGIN_VERSION)?;
@@ -708,7 +708,7 @@ fn get_plugin_info_by_graph(graph: &Graph) -> Result<PluginInfo, LlamaCoreError>
         let err_msg = format!("Fail to deserialize the plugin metadata. {}", e);
 
         #[cfg(feature = "logging")]
-        error!(target: "llama-core", "{}", &err_msg);
+        error!(target: "stdout", "{}", &err_msg);
 
         LlamaCoreError::Operation(err_msg)
     })?;
@@ -721,7 +721,7 @@ fn get_plugin_info_by_graph(graph: &Graph) -> Result<PluginInfo, LlamaCoreError>
                 let err_msg = "Failed to convert the build number of the plugin to u64";
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama-core", "{}", err_msg);
+                error!(target: "stdout", "{}", err_msg);
 
                 return Err(LlamaCoreError::Operation(err_msg.into()));
             }
@@ -730,7 +730,7 @@ fn get_plugin_info_by_graph(graph: &Graph) -> Result<PluginInfo, LlamaCoreError>
             let err_msg = "Metadata does not have the field `llama_build_number`.";
 
             #[cfg(feature = "logging")]
-            error!(target: "llama-core", "{}", err_msg);
+            error!(target: "stdout", "{}", err_msg);
 
             return Err(LlamaCoreError::Operation(err_msg.into()));
         }
@@ -744,7 +744,7 @@ fn get_plugin_info_by_graph(graph: &Graph) -> Result<PluginInfo, LlamaCoreError>
                 let err_msg = "Failed to convert the commit id of the plugin to string";
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama-core", "{}", err_msg);
+                error!(target: "stdout", "{}", err_msg);
 
                 return Err(LlamaCoreError::Operation(err_msg.into()));
             }
@@ -753,14 +753,14 @@ fn get_plugin_info_by_graph(graph: &Graph) -> Result<PluginInfo, LlamaCoreError>
             let err_msg = "Metadata does not have the field `llama_commit`.";
 
             #[cfg(feature = "logging")]
-            error!(target: "llama-core", "{}", err_msg);
+            error!(target: "stdout", "{}", err_msg);
 
             return Err(LlamaCoreError::Operation(err_msg.into()));
         }
     };
 
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Plugin info: b{}(commit {})", plugin_build_number, plugin_commit);
+    info!(target: "stdout", "Plugin info: b{}(commit {})", plugin_build_number, plugin_commit);
 
     Ok(PluginInfo {
         build_number: plugin_build_number,
@@ -806,7 +806,7 @@ impl std::fmt::Display for RunningMode {
 /// Return the current running mode.
 pub fn running_mode() -> Result<RunningMode, LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Get the running mode.");
+    info!(target: "stdout", "Get the running mode.");
 
     let mode = match RUNNING_MODE.get() {
         Some(mode) => match mode.read() {
@@ -815,7 +815,7 @@ pub fn running_mode() -> Result<RunningMode, LlamaCoreError> {
                 let err_msg = format!("Fail to get the underlying value of `RUNNING_MODE`. {}", e);
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama-core", "{}", err_msg);
+                error!(target: "stdout", "{}", err_msg);
 
                 return Err(LlamaCoreError::Operation(err_msg));
             }
@@ -824,14 +824,14 @@ pub fn running_mode() -> Result<RunningMode, LlamaCoreError> {
             let err_msg = "Fail to get the underlying value of `RUNNING_MODE`.";
 
             #[cfg(feature = "logging")]
-            error!(target: "llama-core", "{}", err_msg);
+            error!(target: "stdout", "{}", err_msg);
 
             return Err(LlamaCoreError::Operation(err_msg.into()));
         }
     };
 
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "running mode: {}", &mode);
+    info!(target: "stdout", "running mode: {}", &mode);
 
     Ok(mode.to_owned())
 }

--- a/api-server/llama-core/src/lib.rs
+++ b/api-server/llama-core/src/lib.rs
@@ -93,6 +93,8 @@ pub struct Metadata {
     pub ctx_size: u64,
     #[serde(rename = "batch-size")]
     pub batch_size: u64,
+    #[serde(rename = "threads")]
+    pub threads: u64,
 
     // * Sampling parameters (used by the llama sampling context).
     #[serde(rename = "temp")]
@@ -126,6 +128,7 @@ impl Default for Metadata {
             use_mmap: Some(true),
             ctx_size: 512,
             batch_size: 512,
+            threads: 2,
             temperature: 1.0,
             top_p: 1.0,
             repeat_penalty: 1.1,
@@ -199,6 +202,11 @@ impl MetadataBuilder {
 
     pub fn with_tensor_split(mut self, split: Option<String>) -> Self {
         self.metadata.tensor_split = split;
+        self
+    }
+
+    pub fn with_threads(mut self, threads: u64) -> Self {
+        self.metadata.threads = threads;
         self
     }
 

--- a/api-server/llama-core/src/lib.rs
+++ b/api-server/llama-core/src/lib.rs
@@ -107,6 +107,13 @@ pub struct Metadata {
     pub presence_penalty: f64,
     #[serde(rename = "frequency-penalty")]
     pub frequency_penalty: f64,
+
+    // * grammar parameters
+    /// BNF-like grammar to constrain generations (see samples in grammars/ dir). Defaults to empty string.
+    pub grammar: String,
+    /// JSON schema to constrain generations (https://json-schema.org/), e.g. `{}` for any JSON object. For schemas w/ external $refs, use --grammar + example/json_schema_to_grammar.py instead.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub json_schema: Option<String>,
 }
 impl Default for Metadata {
     fn default() -> Self {
@@ -134,6 +141,8 @@ impl Default for Metadata {
             repeat_penalty: 1.1,
             presence_penalty: 0.0,
             frequency_penalty: 0.0,
+            grammar: String::new(),
+            json_schema: None,
         }
     }
 }
@@ -267,6 +276,16 @@ impl MetadataBuilder {
 
     pub fn with_frequency_penalty(mut self, penalty: f64) -> Self {
         self.metadata.frequency_penalty = penalty;
+        self
+    }
+
+    pub fn with_grammar(mut self, grammar: impl Into<String>) -> Self {
+        self.metadata.grammar = grammar.into();
+        self
+    }
+
+    pub fn with_json_schema(mut self, schema: Option<String>) -> Self {
+        self.metadata.json_schema = schema;
         self
     }
 

--- a/api-server/llama-core/src/models.rs
+++ b/api-server/llama-core/src/models.rs
@@ -6,7 +6,7 @@ use endpoints::models::{ListModelsResponse, Model};
 /// Lists models available
 pub async fn models() -> Result<ListModelsResponse, LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "List models");
+    info!(target: "stdout", "List models");
 
     let mut models = vec![];
 
@@ -16,7 +16,7 @@ pub async fn models() -> Result<ListModelsResponse, LlamaCoreError> {
                 let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama-core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;

--- a/api-server/llama-core/src/rag.rs
+++ b/api-server/llama-core/src/rag.rs
@@ -26,7 +26,7 @@ pub async fn rag_doc_chunks_to_embeddings(
     rag_embedding_request: &RagEmbeddingRequest,
 ) -> Result<EmbeddingsResponse, LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Convert document chunks to embeddings.");
+    info!(target: "stdout", "Convert document chunks to embeddings.");
 
     let running_mode = running_mode()?;
     if running_mode != RunningMode::Rag {
@@ -36,7 +36,7 @@ pub async fn rag_doc_chunks_to_embeddings(
         );
 
         #[cfg(feature = "logging")]
-        error!(target: "llama-core", "{}", &err_msg);
+        error!(target: "stdout", "{}", &err_msg);
 
         return Err(LlamaCoreError::Operation(err_msg));
     }
@@ -46,11 +46,11 @@ pub async fn rag_doc_chunks_to_embeddings(
     let qdrant_collection_name = rag_embedding_request.qdrant_collection_name.as_str();
 
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Compute embeddings for document chunks.");
+    info!(target: "stdout", "Compute embeddings for document chunks.");
 
     #[cfg(feature = "logging")]
     if let Ok(request_str) = serde_json::to_string(&embedding_request) {
-        info!(target: "llama-core", "Embedding request: {}", request_str);
+        info!(target: "stdout", "Embedding request: {}", request_str);
     }
 
     // compute embeddings for the document
@@ -95,14 +95,14 @@ pub async fn rag_query_to_embeddings(
     rag_embedding_request: &RagEmbeddingRequest,
 ) -> Result<EmbeddingsResponse, LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Compute embeddings for the user query.");
+    info!(target: "stdout", "Compute embeddings for the user query.");
 
     let running_mode = running_mode()?;
     if running_mode != RunningMode::Rag {
         let err_msg = format!("The RAG query is not supported in the {running_mode} mode.",);
 
         #[cfg(feature = "logging")]
-        error!(target: "llama-core", "{}", &err_msg);
+        error!(target: "stdout", "{}", &err_msg);
 
         return Err(LlamaCoreError::Operation(err_msg));
     }
@@ -130,9 +130,9 @@ pub async fn rag_retrieve_context(
 ) -> Result<RetrieveObject, LlamaCoreError> {
     #[cfg(feature = "logging")]
     {
-        info!(target: "llama-core", "Retrieve context.");
+        info!(target: "stdout", "Retrieve context.");
 
-        info!(target: "llama-core", "qdrant_url: {}, qdrant_collection_name: {}, limit: {}, score_threshold: {}", qdrant_url.as_ref(), qdrant_collection_name.as_ref(), limit, score_threshold.unwrap_or_default());
+        info!(target: "stdout", "qdrant_url: {}, qdrant_collection_name: {}, limit: {}, score_threshold: {}", qdrant_url.as_ref(), qdrant_collection_name.as_ref(), limit, score_threshold.unwrap_or_default());
     }
 
     let running_mode = running_mode()?;
@@ -143,7 +143,7 @@ pub async fn rag_retrieve_context(
         );
 
         #[cfg(feature = "logging")]
-        error!(target: "llama-core", "{}", &err_msg);
+        error!(target: "stdout", "{}", &err_msg);
 
         return Err(LlamaCoreError::Operation(err_msg));
     }
@@ -164,7 +164,7 @@ pub async fn rag_retrieve_context(
         Ok(points) => points,
         Err(e) => {
             #[cfg(feature = "logging")]
-            error!(target: "llama-core", "{}", e.to_string());
+            error!(target: "stdout", "{}", e.to_string());
 
             return Err(e);
         }
@@ -206,7 +206,7 @@ async fn qdrant_create_collection(
     dim: usize,
 ) -> Result<(), LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Create a Qdrant collection named {} of {} dimensions.", collection_name.as_ref(), dim);
+    info!(target: "stdout", "Create a Qdrant collection named {} of {} dimensions.", collection_name.as_ref(), dim);
 
     if let Err(e) = qdrant_client
         .create_collection(collection_name.as_ref(), dim as u32)
@@ -215,7 +215,7 @@ async fn qdrant_create_collection(
         let err_msg = e.to_string();
 
         #[cfg(feature = "logging")]
-        error!(target: "llama-core", "{}", &err_msg);
+        error!(target: "stdout", "{}", &err_msg);
 
         return Err(LlamaCoreError::Operation(err_msg));
     }
@@ -230,7 +230,7 @@ async fn qdrant_persist_embeddings(
     chunks: &[String],
 ) -> Result<(), LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Persist embeddings to the Qdrant instance.");
+    info!(target: "stdout", "Persist embeddings to the Qdrant instance.");
 
     let mut points = Vec::<Point>::new();
     for embedding in embeddings {
@@ -253,7 +253,7 @@ async fn qdrant_persist_embeddings(
     }
 
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Number of points to be upserted: {}", points.len());
+    info!(target: "stdout", "Number of points to be upserted: {}", points.len());
 
     if let Err(e) = qdrant_client
         .upsert_points(collection_name.as_ref(), points)
@@ -262,7 +262,7 @@ async fn qdrant_persist_embeddings(
         let err_msg = format!("Failed to upsert points. Reason: {}", e);
 
         #[cfg(feature = "logging")]
-        error!(target: "llama-core", "{}", &err_msg);
+        error!(target: "stdout", "{}", &err_msg);
 
         return Err(LlamaCoreError::Operation(err_msg));
     }
@@ -278,7 +278,7 @@ async fn qdrant_search_similar_points(
     score_threshold: Option<f32>,
 ) -> Result<Vec<ScoredPoint>, LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Search similar points from the qdrant instance.");
+    info!(target: "stdout", "Search similar points from the qdrant instance.");
 
     match qdrant_client
         .search_points(
@@ -291,7 +291,7 @@ async fn qdrant_search_similar_points(
     {
         Ok(search_result) => {
             #[cfg(feature = "logging")]
-            info!(target: "llama-core", "Number of similar points found: {}", search_result.len());
+            info!(target: "stdout", "Number of similar points found: {}", search_result.len());
 
             Ok(search_result)
         }
@@ -299,7 +299,7 @@ async fn qdrant_search_similar_points(
             let err_msg = e.to_string();
 
             #[cfg(feature = "logging")]
-            error!(target: "llama-core", "Fail to search similar points from the qdrant instance. Reason: {}", &err_msg);
+            error!(target: "stdout", "Fail to search similar points from the qdrant instance. Reason: {}", &err_msg);
 
             Err(LlamaCoreError::Operation(err_msg))
         }
@@ -332,7 +332,7 @@ pub fn chunk_text(
         let err_msg = "Failed to upload the target file. Only files with 'txt' and 'md' extensions are supported.";
 
         #[cfg(feature = "logging")]
-        error!(target: "llama-core", "{}", err_msg);
+        error!(target: "stdout", "{}", err_msg);
 
         return Err(LlamaCoreError::Operation(err_msg.into()));
     }
@@ -340,13 +340,13 @@ pub fn chunk_text(
     match ty.as_ref().to_lowercase().as_str() {
         "txt" => {
             #[cfg(feature = "logging")]
-            info!(target: "llama-core", "Chunk the plain text contents.");
+            info!(target: "stdout", "Chunk the plain text contents.");
 
             let tokenizer = cl100k_base().map_err(|e| {
                 let err_msg = e.to_string();
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama-core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -360,19 +360,19 @@ pub fn chunk_text(
                 .collect::<Vec<_>>();
 
             #[cfg(feature = "logging")]
-            info!(target: "llama-core", "Number of chunks: {}", chunks.len());
+            info!(target: "stdout", "Number of chunks: {}", chunks.len());
 
             Ok(chunks)
         }
         "md" => {
             #[cfg(feature = "logging")]
-            info!(target: "llama-core", "Chunk the markdown contents.");
+            info!(target: "stdout", "Chunk the markdown contents.");
 
             let tokenizer = cl100k_base().map_err(|e| {
                 let err_msg = e.to_string();
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama-core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -386,7 +386,7 @@ pub fn chunk_text(
                 .collect::<Vec<_>>();
 
             #[cfg(feature = "logging")]
-            info!(target: "llama-core", "Number of chunks: {}", chunks.len());
+            info!(target: "stdout", "Number of chunks: {}", chunks.len());
 
             Ok(chunks)
         }
@@ -395,7 +395,7 @@ pub fn chunk_text(
                 "Failed to upload the target file. Only text and markdown files are supported.";
 
             #[cfg(feature = "logging")]
-            error!(target: "llama-core", "{}", err_msg);
+            error!(target: "stdout", "{}", err_msg);
 
             Err(LlamaCoreError::Operation(err_msg.into()))
         }

--- a/api-server/llama-core/src/utils.rs
+++ b/api-server/llama-core/src/utils.rs
@@ -14,7 +14,7 @@ pub(crate) fn gen_chat_id() -> String {
 /// Return the names of the chat models.
 pub fn chat_model_names() -> Result<Vec<String>, LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Get the names of the chat models.");
+    info!(target: "stdout", "Get the names of the chat models.");
 
     let chat_graphs = match CHAT_GRAPHS.get() {
         Some(chat_graphs) => chat_graphs,
@@ -22,7 +22,7 @@ pub fn chat_model_names() -> Result<Vec<String>, LlamaCoreError> {
             let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
             #[cfg(feature = "logging")]
-            error!(target: "llama-core", "{}", err_msg);
+            error!(target: "stdout", "{}", err_msg);
 
             return Err(LlamaCoreError::Operation(err_msg.into()));
         }
@@ -32,7 +32,7 @@ pub fn chat_model_names() -> Result<Vec<String>, LlamaCoreError> {
         let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
 
         #[cfg(feature = "logging")]
-        error!(target: "llama-core", "{}", &err_msg);
+        error!(target: "stdout", "{}", &err_msg);
 
         LlamaCoreError::Operation(err_msg)
     })?;
@@ -48,7 +48,7 @@ pub fn chat_model_names() -> Result<Vec<String>, LlamaCoreError> {
 /// Return the names of the embedding models.
 pub fn embedding_model_names() -> Result<Vec<String>, LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Get the names of the embedding models.");
+    info!(target: "stdout", "Get the names of the embedding models.");
 
     let embedding_graphs = match EMBEDDING_GRAPHS.get() {
         Some(embedding_graphs) => embedding_graphs,
@@ -65,7 +65,7 @@ pub fn embedding_model_names() -> Result<Vec<String>, LlamaCoreError> {
             let err_msg = format!("Fail to acquire the lock of `EMBEDDING_GRAPHS`. {}", e);
 
             #[cfg(feature = "logging")]
-            error!(target: "llama-core", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             return Err(LlamaCoreError::Operation(err_msg));
         }
@@ -84,10 +84,10 @@ pub fn chat_prompt_template(name: Option<&str>) -> Result<PromptTemplateType, Ll
     #[cfg(feature = "logging")]
     match name {
         Some(name) => {
-            info!(target: "llama-core", "Get the chat prompt template type from the chat model named {}.", name)
+            info!(target: "stdout", "Get the chat prompt template type from the chat model named {}.", name)
         }
         None => {
-            info!(target: "llama-core", "Get the chat prompt template type from the default chat model.")
+            info!(target: "stdout", "Get the chat prompt template type from the default chat model.")
         }
     }
 
@@ -97,7 +97,7 @@ pub fn chat_prompt_template(name: Option<&str>) -> Result<PromptTemplateType, Ll
             let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
             #[cfg(feature = "logging")]
-            error!(target: "llama-core", "{}", err_msg);
+            error!(target: "stdout", "{}", err_msg);
 
             return Err(LlamaCoreError::Operation(err_msg.into()));
         }
@@ -107,7 +107,7 @@ pub fn chat_prompt_template(name: Option<&str>) -> Result<PromptTemplateType, Ll
         let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
 
         #[cfg(feature = "logging")]
-        error!(target: "llama-core", "{}", &err_msg);
+        error!(target: "stdout", "{}", &err_msg);
 
         LlamaCoreError::Operation(err_msg)
     })?;
@@ -118,7 +118,7 @@ pub fn chat_prompt_template(name: Option<&str>) -> Result<PromptTemplateType, Ll
                 let prompt_template = graph.prompt_template();
 
                 #[cfg(feature = "logging")]
-                info!(target: "llama-core", "prompt_template: {}", &prompt_template);
+                info!(target: "stdout", "prompt_template: {}", &prompt_template);
 
                 Ok(prompt_template)
             }
@@ -126,7 +126,7 @@ pub fn chat_prompt_template(name: Option<&str>) -> Result<PromptTemplateType, Ll
                 let err_msg = format!("Not found `{}` chat model.", name);
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama-core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 Err(LlamaCoreError::Operation(err_msg))
             }
@@ -136,7 +136,7 @@ pub fn chat_prompt_template(name: Option<&str>) -> Result<PromptTemplateType, Ll
                 let prompt_template = graph.prompt_template();
 
                 #[cfg(feature = "logging")]
-                info!(target: "llama-core", "prompt_template: {}", &prompt_template);
+                info!(target: "stdout", "prompt_template: {}", &prompt_template);
 
                 Ok(prompt_template)
             }
@@ -144,7 +144,7 @@ pub fn chat_prompt_template(name: Option<&str>) -> Result<PromptTemplateType, Ll
                 let err_msg = "There is no model available in the chat graphs.";
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama-core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 Err(LlamaCoreError::Operation(err_msg.into()))
             }
@@ -155,7 +155,7 @@ pub fn chat_prompt_template(name: Option<&str>) -> Result<PromptTemplateType, Ll
 /// Get output buffer generated by model.
 pub(crate) fn get_output_buffer(graph: &Graph, index: usize) -> Result<Vec<u8>, LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Get the output buffer generated by the model named {} in the non-stream mode.", graph.name());
+    info!(target: "stdout", "Get the output buffer generated by the model named {} in the non-stream mode.", graph.name());
 
     let mut output_buffer: Vec<u8> = Vec::with_capacity(MAX_BUFFER_SIZE);
 
@@ -163,7 +163,7 @@ pub(crate) fn get_output_buffer(graph: &Graph, index: usize) -> Result<Vec<u8>, 
         let err_msg = format!("Fail to get the generated output tensor. {msg}", msg = e);
 
         #[cfg(feature = "logging")]
-        error!(target: "llama-core", "{}", &err_msg);
+        error!(target: "stdout", "{}", &err_msg);
 
         LlamaCoreError::Backend(BackendError::GetOutput(err_msg))
     })?;
@@ -173,7 +173,7 @@ pub(crate) fn get_output_buffer(graph: &Graph, index: usize) -> Result<Vec<u8>, 
     }
 
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Output buffer size: {}", output_size);
+    info!(target: "stdout", "Output buffer size: {}", output_size);
 
     Ok(output_buffer)
 }
@@ -184,7 +184,7 @@ pub(crate) fn get_output_buffer_single(
     index: usize,
 ) -> Result<Vec<u8>, LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Get output buffer generated by the model named {} in the stream mode.", graph.name());
+    info!(target: "stdout", "Get output buffer generated by the model named {} in the stream mode.", graph.name());
 
     let mut output_buffer: Vec<u8> = Vec::with_capacity(MAX_BUFFER_SIZE);
 
@@ -194,7 +194,7 @@ pub(crate) fn get_output_buffer_single(
             let err_msg = format!("Fail to get plugin metadata. {msg}", msg = e);
 
             #[cfg(feature = "logging")]
-            error!(target: "llama-core", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             LlamaCoreError::Backend(BackendError::GetOutput(err_msg))
         })?;
@@ -218,7 +218,7 @@ pub(crate) fn set_tensor_data_u8(
         let err_msg = format!("Fail to set input tensor at index {}", idx);
 
         #[cfg(feature = "logging")]
-        error!(target: "llama-core", "{}", &err_msg);
+        error!(target: "stdout", "{}", &err_msg);
 
         return Err(LlamaCoreError::Operation(err_msg));
     };
@@ -229,7 +229,7 @@ pub(crate) fn set_tensor_data_u8(
 /// Get the token information from the graph.
 pub(crate) fn get_token_info_by_graph(graph: &Graph) -> Result<TokenInfo, LlamaCoreError> {
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "Get token info from the model named {}.", graph.name());
+    info!(target: "stdout", "Get token info from the model named {}.", graph.name());
 
     let output_buffer = get_output_buffer(graph, 1)?;
     let token_info: Value = match serde_json::from_slice(&output_buffer[..]) {
@@ -238,7 +238,7 @@ pub(crate) fn get_token_info_by_graph(graph: &Graph) -> Result<TokenInfo, LlamaC
             let err_msg = format!("Fail to deserialize token info: {msg}", msg = e);
 
             #[cfg(feature = "logging")]
-            error!(target: "llama-core", "{}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             return Err(LlamaCoreError::Operation(err_msg));
         }
@@ -250,7 +250,7 @@ pub(crate) fn get_token_info_by_graph(graph: &Graph) -> Result<TokenInfo, LlamaC
             let err_msg = "Fail to convert `input_tokens` to u64.";
 
             #[cfg(feature = "logging")]
-            error!(target: "llama-core", "{}", err_msg);
+            error!(target: "stdout", "{}", err_msg);
 
             return Err(LlamaCoreError::Operation(err_msg.into()));
         }
@@ -261,14 +261,14 @@ pub(crate) fn get_token_info_by_graph(graph: &Graph) -> Result<TokenInfo, LlamaC
             let err_msg = "Fail to convert `output_tokens` to u64.";
 
             #[cfg(feature = "logging")]
-            error!(target: "llama-core", "{}", err_msg);
+            error!(target: "stdout", "{}", err_msg);
 
             return Err(LlamaCoreError::Operation(err_msg.into()));
         }
     };
 
     #[cfg(feature = "logging")]
-    info!(target: "llama-core", "prompt tokens: {}, completion tokens: {}", prompt_tokens, completion_tokens);
+    info!(target: "stdout", "prompt tokens: {}, completion tokens: {}", prompt_tokens, completion_tokens);
 
     Ok(TokenInfo {
         prompt_tokens,
@@ -288,7 +288,7 @@ pub(crate) fn get_token_info_by_graph_name(
                     let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama-core", "{}", err_msg);
+                    error!(target: "stdout", "{}", err_msg);
 
                     return Err(LlamaCoreError::Operation(err_msg.into()));
                 }
@@ -298,7 +298,7 @@ pub(crate) fn get_token_info_by_graph_name(
                 let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama-core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -312,7 +312,7 @@ pub(crate) fn get_token_info_by_graph_name(
                     );
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama-core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     Err(LlamaCoreError::Operation(err_msg))
                 }
@@ -325,7 +325,7 @@ pub(crate) fn get_token_info_by_graph_name(
                     let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama-core", "{}", err_msg);
+                    error!(target: "stdout", "{}", err_msg);
 
                     return Err(LlamaCoreError::Operation(err_msg.into()));
                 }
@@ -335,7 +335,7 @@ pub(crate) fn get_token_info_by_graph_name(
                 let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
 
                 #[cfg(feature = "logging")]
-                error!(target: "llama-core", "{}", &err_msg);
+                error!(target: "stdout", "{}", &err_msg);
 
                 LlamaCoreError::Operation(err_msg)
             })?;
@@ -346,7 +346,7 @@ pub(crate) fn get_token_info_by_graph_name(
                     let err_msg = "There is no model available in the chat graphs.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "llama-core", "{}", &err_msg);
+                    error!(target: "stdout", "{}", &err_msg);
 
                     Err(LlamaCoreError::Operation(err_msg.into()))
                 }

--- a/chat/Cargo.toml
+++ b/chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-chat"
-version = "0.13.2"
+version = "0.14.0"
 edition = "2021"
 
 [dependencies]

--- a/chat/README.md
+++ b/chat/README.md
@@ -129,6 +129,8 @@ Options:
           The main GPU to use
       --tensor-split <TENSOR_SPLIT>
           How split tensors should be distributed accross GPUs. If None the model is not split; otherwise, a comma-separated list of non-negative values, e.g., "3,2" presents 60% of the data to GPU 0 and 40% to GPU 1
+      --threads <THREADS>
+          Number of threads to use during computation [default: 2]
       --no-mmap <NO_MMAP>
           Disable memory mapping for file access of chat models [possible values: true, false]
   -b, --batch-size <BATCH_SIZE>

--- a/chat/README.md
+++ b/chat/README.md
@@ -145,6 +145,10 @@ Options:
           Repeat alpha presence penalty. 0.0 = disabled [default: 0.0]
       --frequency-penalty <FREQUENCY_PENALTY>
           Repeat alpha frequency penalty. 0.0 = disabled [default: 0.0]
+      --grammar <GRAMMAR>
+          BNF-like grammar to constrain generations (see samples in grammars/ dir) [default: ]
+      --json-schema <JSON_SCHEMA>
+          JSON schema to constrain generations (https://json-schema.org/), e.g. `{}` for any JSON object. For schemas w/ external $refs, use --grammar + example/json_schema_to_grammar.py instead
   -p, --prompt-template <PROMPT_TEMPLATE>
           Sets the prompt template [possible values: llama-2-chat, llama-3-chat, llama-3-tool, mistral-instruct, mistral-tool, mistrallite, openchat, codellama-instruct, codellama-super-instruct, human-assistant, vicuna-1.0-chat, vicuna-1.1-chat, vicuna-llava, chatml, chatml-tool, internlm-2-tool, baichuan-2, wizard-coder, zephyr, stablelm-zephyr, intel-neural, deepseek-chat, deepseek-coder, deepseek-chat-2, solar-instruct, phi-2-chat, phi-2-instruct, phi-3-chat, phi-3-instruct, gemma-instruct, octopus, glm-4-chat, groq-llama3-tool, embedding]
   -r, --reverse-prompt <REVERSE_PROMPT>

--- a/chat/src/main.rs
+++ b/chat/src/main.rs
@@ -35,6 +35,9 @@ struct Cli {
     /// How split tensors should be distributed accross GPUs. If None the model is not split; otherwise, a comma-separated list of non-negative values, e.g., "3,2" presents 60% of the data to GPU 0 and 40% to GPU 1.
     #[arg(long)]
     tensor_split: Option<String>,
+    /// Number of threads to use during computation
+    #[arg(long, default_value = "2")]
+    threads: u64,
     /// Disable memory mapping for file access of chat models
     #[arg(long)]
     no_mmap: Option<bool>,
@@ -130,6 +133,7 @@ async fn main() -> anyhow::Result<()> {
     if let Some(tensor_split) = &cli.tensor_split {
         log(format!("[INFO] Tensor split: {}", tensor_split));
     }
+    log(format!("[INFO] Threads: {}", &cli.threads));
     // no_mmap
     if let Some(no_mmap) = &cli.no_mmap {
         log(format!(
@@ -178,6 +182,7 @@ async fn main() -> anyhow::Result<()> {
         .with_n_gpu_layers(cli.n_gpu_layers)
         .with_main_gpu(cli.main_gpu)
         .with_tensor_split(cli.tensor_split)
+        .with_threads(cli.threads)
         .disable_mmap(cli.no_mmap)
         .with_batch_size(cli.batch_size)
         .with_repeat_penalty(cli.repeat_penalty)

--- a/chat/src/main.rs
+++ b/chat/src/main.rs
@@ -59,6 +59,12 @@ struct Cli {
     /// Repeat alpha frequency penalty. 0.0 = disabled
     #[arg(long, default_value = "0.0")]
     frequency_penalty: f64,
+    /// BNF-like grammar to constrain generations (see samples in grammars/ dir).
+    #[arg(long, default_value = "")]
+    pub grammar: String,
+    /// JSON schema to constrain generations (https://json-schema.org/), e.g. `{}` for any JSON object. For schemas w/ external $refs, use --grammar + example/json_schema_to_grammar.py instead.
+    #[arg(long)]
+    pub json_schema: Option<String>,
     /// Sets the prompt template.
     #[arg(short, long, value_parser = clap::value_parser!(PromptTemplateType), required = true)]
     prompt_template: PromptTemplateType,
@@ -170,6 +176,12 @@ async fn main() -> anyhow::Result<()> {
         "[INFO] Frequency penalty (0.0 = disabled): {}",
         &cli.frequency_penalty
     ));
+    // grammar
+    log(format!("[INFO] BNF-like grammar: {}", &cli.grammar));
+    // json schema
+    if let Some(json_schema) = &cli.json_schema {
+        log(format!("[INFO] JSON schema: {}", json_schema));
+    }
     // log prompts
     log(format!("[INFO] Enable prompt log: {}", &cli.log_prompts));
     // log statistics
@@ -188,6 +200,8 @@ async fn main() -> anyhow::Result<()> {
         .with_repeat_penalty(cli.repeat_penalty)
         .with_presence_penalty(cli.presence_penalty)
         .with_frequency_penalty(cli.frequency_penalty)
+        .with_grammar(cli.grammar)
+        .with_json_schema(cli.json_schema)
         .with_reverse_prompt(cli.reverse_prompt)
         .enable_prompts_log(cli.log_prompts || cli.log_all)
         .enable_plugin_log(cli.log_stat || cli.log_all)

--- a/run-llm.sh
+++ b/run-llm.sh
@@ -265,7 +265,7 @@ if [ -n "$model" ]; then
     printf "[+] Install WasmEdge with wasi-nn_ggml plugin ...\n\n"
 
     if [ "$ggml_version" = "latest" ]; then
-        if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v 0.13.5; then
+        if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v 0.14.0; then
             source $HOME/.wasmedge/env
             wasmedge_path=$(which wasmedge)
             printf "\n    The WasmEdge Runtime is installed in %s.\n\n" "$wasmedge_path"
@@ -274,7 +274,7 @@ if [ -n "$model" ]; then
             exit 1
         fi
     else
-        if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v 0.13.5 --ggmlbn=$ggml_version; then
+        if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v 0.14.0 --ggmlbn=$ggml_version; then
             source $HOME/.wasmedge/env
             wasmedge_path=$(which wasmedge)
             printf "\n    The WasmEdge Runtime is installed in %s.\n\n" "$wasmedge_path"
@@ -327,7 +327,7 @@ elif [ "$interactive" -eq 0 ]; then
     printf "[+] Installing WasmEdge with wasi-nn_ggml plugin ...\n\n"
 
     if [ "$ggml_version" = "latest" ]; then
-        if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v 0.13.5; then
+        if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v 0.14.0; then
             source $HOME/.wasmedge/env
             wasmedge_path=$(which wasmedge)
             printf "\n    The WasmEdge Runtime is installed in %s.\n\n" "$wasmedge_path"
@@ -336,7 +336,7 @@ elif [ "$interactive" -eq 0 ]; then
             exit 1
         fi
     else
-        if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v 0.13.5 --ggmlbn=$ggml_version; then
+        if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v 0.14.0 --ggmlbn=$ggml_version; then
             source $HOME/.wasmedge/env
             wasmedge_path=$(which wasmedge)
             printf "\n    The WasmEdge Runtime is installed in %s.\n\n" "$wasmedge_path"
@@ -433,7 +433,7 @@ elif [ "$interactive" -eq 1 ]; then
     if [[ "$reinstall_wasmedge" == "1" ]]; then
         # install WasmEdge + wasi-nn_ggml plugin
         if [ "$ggml_version" = "latest" ]; then
-            if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v 0.13.5; then
+            if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v 0.14.0; then
                 source $HOME/.wasmedge/env
                 wasmedge_path=$(which wasmedge)
                 printf "\n    The WasmEdge Runtime is installed in %s.\n\n" "$wasmedge_path"
@@ -442,7 +442,7 @@ elif [ "$interactive" -eq 1 ]; then
                 exit 1
             fi
         else
-            if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v 0.13.5 --ggmlbn=$ggml_version; then
+            if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v 0.14.0 --ggmlbn=$ggml_version; then
                 source $HOME/.wasmedge/env
                 wasmedge_path=$(which wasmedge)
                 printf "\n    The WasmEdge Runtime is installed in %s.\n\n" "$wasmedge_path"

--- a/simple/Cargo.toml
+++ b/simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-simple"
-version = "0.13.2"
+version = "0.14.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Major changes:

- (BREAKING) Migrate to `WasmEdge v0.14`
- New CLI options: `--threads`, `--grammar`, and `--json-schema`

- `llama-core` crate
  - New APIs: `image_generation` for image generation, `image_edit` for image editing

**NOTICE**

For **developers on macOS**, it is strongly recommended to read [TLS on MacOS](https://wasmedge.org/docs/develop/rust/setup/#tls-on-macos) before building `llama-api-server.wasm` and `llama-chat.wasm` from source; in addition, prefix `RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable"` to `cargo build --target wasm32-wasip1 --release` command