### PR TITLE
Update chat.rs

### DIFF
--- a/api-server/llama-core/src/chat.rs
+++ b/api-server/llama-core/src/chat.rs
@@ -1662,16 +1662,16 @@ async fn update_n_predict(
             if !should_update {
                 should_update = true;
             }
-        }
-    } else if metadata.n_predict < available_completion_tokens {
-        #[cfg(feature = "logging")]
-        info!(target: "stdout", "Update n_predict from {} to {}", metadata.n_predict, available_completion_tokens);
+        } else if metadata.n_predict < available_completion_tokens {
+            #[cfg(feature = "logging")]
+            info!(target: "stdout", "Update n_predict from {} to {}", metadata.n_predict, available_completion_tokens);
 
-        // update n_predict
-        metadata.n_predict = available_completion_tokens;
+            // update n_predict
+            metadata.n_predict = available_completion_tokens;
 
-        if !should_update {
-            should_update = true;
+            if !should_update {
+                should_update = true;
+            }
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Michael Yuan <michael@secondstate.io>

The `chat_request.max_tokens` is never `None`. Even if the request does not contain this field, it will default to the server default (i.e., `1024`).

That means the `else` block is never executed. 

If a request sets a low `max_tokens`, all subsequent requests will "inherit" that low `n_predict` and never recover.

In this PR, I am moving this `else` block so that subsequent requests can reset the `n_predict` value.