### PR TITLE
Release 0.14.4

### DIFF
--- a/.github/workflows/test_api_server.yml
+++ b/.github/workflows/test_api_server.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        wasmedge_version: [0.14.0]
+        wasmedge_version: [0.14.1]
     steps:
       - name: Clone project
         id: checkout

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,17 +13,17 @@ resolver = "2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 endpoints = { path = "crates/endpoints", version = "^0.14" }
-chat-prompts = { path = "crates/chat-prompts", version = "^0.14" }
+chat-prompts = { path = "crates/chat-prompts", version = "^0.15" }
 thiserror = "1"
 uuid = { version = "1.4", features = ["v4", "fast-rng", "macro-diagnostics"] }
 clap = { version = "4.4.6", features = ["cargo", "derive"] }
 log = { version = "0.4.21", features = ["std", "kv", "kv_serde"] }
 wasi-logger = { version = "0.1.2", features = ["kv"] }
 either = "1.12.0"
-base64 = "=0.22.0"
+base64 = "=0.22.1"
 llama-core = { path = "crates/llama-core", features = ["logging"], version = "^0.17" }
 tokio = { version = "^1.36", features = ["io-util", "fs", "net", "time", "rt", "macros"] }
-anyhow = "1.0"
+anyhow = "1"
 once_cell = "1.18"
 wasmedge-wasi-nn = "0.8.0"
 futures = { version = "0.3.6", default-features = false, features = ["async-await", "std"] }

--- a/crates/chat-prompts/Cargo.toml
+++ b/crates/chat-prompts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chat-prompts"
-version = "0.14.1"
+version = "0.15.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"
@@ -13,7 +13,7 @@ description = "Chat prompt template"
 endpoints.workspace = true
 thiserror.workspace = true
 enum_dispatch = "0.3.12"
-image = "=0.25.0"
+image = "=0.25.2"
 base64.workspace = true
 clap.workspace = true
 serde.workspace = true

--- a/crates/chat-prompts/Cargo.toml
+++ b/crates/chat-prompts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chat-prompts"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/chat-prompts/Cargo.toml
+++ b/crates/chat-prompts/Cargo.toml
@@ -13,7 +13,7 @@ description = "Chat prompt template"
 endpoints.workspace = true
 thiserror.workspace = true
 enum_dispatch = "0.3.12"
-image = "=0.25.2"
+image = "=0.25.0"
 base64.workspace = true
 clap.workspace = true
 serde.workspace = true

--- a/crates/chat-prompts/README.md
+++ b/crates/chat-prompts/README.md
@@ -257,7 +257,8 @@ The available prompt templates are listed below:
   {user_message_2}<extra_id_1>Assistant
   {assistant_message_2}
   <extra_id_1>User
-  {user_message_3}<extra_id_1>Assistant\n
+  {user_message_3}
+  <extra_id_1>Assistant\n
   ```
 
   - Example: [second-state/Nemotron-Mini-4B-Instruct-GGUF](https://huggingface.co/second-state/Nemotron-Mini-4B-Instruct-GGUF)

--- a/crates/chat-prompts/README.md
+++ b/crates/chat-prompts/README.md
@@ -263,6 +263,25 @@ The available prompt templates are listed below:
 
   - Example: [second-state/Nemotron-Mini-4B-Instruct-GGUF](https://huggingface.co/second-state/Nemotron-Mini-4B-Instruct-GGUF)
 
+- `nemotron-tool`
+
+  ```text
+  <extra_id_0>System
+  {system_message}
+  <tool> {tool_1} </tool>
+  <tool> {tool_2} </tool>
+
+
+  <extra_id_1>User
+  {user_message_1}<extra_id_1>Assistant
+  <toolcall> {tool_call_message} </toolcall>
+  <extra_id_1>Tool
+  {tool_result_message}
+  <extra_id_1>Assistant\n
+  ```
+
+  - Example: [second-state/Nemotron-Mini-4B-Instruct-GGUF](https://huggingface.co/second-state/Nemotron-Mini-4B-Instruct-GGUF)
+
 - `octopus`
   - Prompt string
 

--- a/crates/chat-prompts/README.md
+++ b/crates/chat-prompts/README.md
@@ -245,6 +245,23 @@ The available prompt templates are listed below:
 
   - Example: [second-state/Mistral-7B-Instruct-v0.3-GGUF](https://huggingface.co/second-state/Mistral-7B-Instruct-v0.3-GGUF)
 
+- `nemotron-chat`
+
+  ```text
+  <extra_id_0>System
+  {system_message}
+  <extra_id_1>User
+  {user_message_1}<extra_id_1>Assistant
+  {assistant_message_1}
+  <extra_id_1>User
+  {user_message_2}<extra_id_1>Assistant
+  {assistant_message_2}
+  <extra_id_1>User
+  {user_message_3}<extra_id_1>Assistant\n
+  ```
+
+  - Example: [second-state/Nemotron-Mini-4B-Instruct-GGUF](https://huggingface.co/second-state/Nemotron-Mini-4B-Instruct-GGUF)
+
 - `octopus`
   - Prompt string
 

--- a/crates/chat-prompts/README.md
+++ b/crates/chat-prompts/README.md
@@ -326,6 +326,30 @@ The available prompt templates are listed below:
 
   - Example: [second-state/Phi-3-medium-4k-instruct-GGUF](https://huggingface.co/second-state/Phi-3-medium-4k-instruct-GGUF)
 
+- `qwen-2.5-coder`
+
+  - File-Level Code Completion (Fill in the middle)
+
+      ```text
+      <|fim_prefix|>{prefix_code}<|fim_suffix|>{suffix_code}<|fim_middle|>
+      ```
+
+      *Reference: https://github.com/QwenLM/Qwen2.5-Coder?tab=readme-ov-file#3-file-level-code-completion-fill-in-the-middle*
+
+  - Repository-Level Code Completion
+
+    ```text
+    <|repo_name|>{repo_name}
+    <|file_sep|>{file_path1}
+    {file_content1}
+    <|file_sep|>{file_path2}
+    {file_content2}
+    ```
+
+    *Reference: https://github.com/QwenLM/Qwen2.5-Coder?tab=readme-ov-file#4-repository-level-code-completion*
+
+  - Example: [second-state/Qwen2.5-Coder-7B-Instruct-GGUF](https://huggingface.co/second-state/Qwen2.5-Coder-7B-Instruct-GGUF)
+
 - `solar-instruct`
   - Prompt string
 

--- a/crates/chat-prompts/src/chat/mod.rs
+++ b/crates/chat-prompts/src/chat/mod.rs
@@ -9,6 +9,7 @@ pub mod intel;
 pub mod llama;
 pub mod mediatek;
 pub mod mistral;
+pub mod nvidia;
 pub mod octopus;
 pub mod openchat;
 pub mod phi;
@@ -30,6 +31,7 @@ use intel::*;
 use llama::*;
 use mediatek::BreezeInstructPrompt;
 use mistral::*;
+use nvidia::NemotronChatPrompt;
 use octopus::*;
 use openchat::*;
 use phi::*;
@@ -91,6 +93,7 @@ pub enum ChatPrompt {
     Glm4ChatPrompt,
     GroqLlama3ToolPrompt,
     BreezeInstructPrompt,
+    NemotronChatPrompt,
 }
 impl From<PromptTemplateType> for ChatPrompt {
     fn from(ty: PromptTemplateType) -> Self {
@@ -156,6 +159,7 @@ impl From<PromptTemplateType> for ChatPrompt {
             PromptTemplateType::BreezeInstruct => {
                 ChatPrompt::BreezeInstructPrompt(BreezeInstructPrompt)
             }
+            PromptTemplateType::NemotronChat => ChatPrompt::NemotronChatPrompt(NemotronChatPrompt),
             PromptTemplateType::Embedding => {
                 panic!("Embedding prompt template is not used for building chat prompts")
             }

--- a/crates/chat-prompts/src/chat/mod.rs
+++ b/crates/chat-prompts/src/chat/mod.rs
@@ -13,6 +13,7 @@ pub mod nvidia;
 pub mod octopus;
 pub mod openchat;
 pub mod phi;
+pub mod qwen;
 pub mod solar;
 pub mod vicuna;
 pub mod wizard;
@@ -35,6 +36,7 @@ use nvidia::{NemotronChatPrompt, NemotronToolPrompt};
 use octopus::*;
 use openchat::*;
 use phi::*;
+use qwen::Qwen25CoderInstructPrompt;
 use solar::*;
 use vicuna::*;
 use wizard::*;
@@ -95,6 +97,7 @@ pub enum ChatPrompt {
     BreezeInstructPrompt,
     NemotronChatPrompt,
     NemotronToolPrompt,
+    Qwen25CoderInstructPrompt,
 }
 impl From<PromptTemplateType> for ChatPrompt {
     fn from(ty: PromptTemplateType) -> Self {
@@ -162,6 +165,9 @@ impl From<PromptTemplateType> for ChatPrompt {
             }
             PromptTemplateType::NemotronChat => ChatPrompt::NemotronChatPrompt(NemotronChatPrompt),
             PromptTemplateType::NemotronTool => ChatPrompt::NemotronToolPrompt(NemotronToolPrompt),
+            PromptTemplateType::Qwen25Coder => {
+                ChatPrompt::Qwen25CoderInstructPrompt(Qwen25CoderInstructPrompt)
+            }
             PromptTemplateType::Embedding => {
                 panic!("Embedding prompt template is not used for building chat prompts")
             }

--- a/crates/chat-prompts/src/chat/mod.rs
+++ b/crates/chat-prompts/src/chat/mod.rs
@@ -31,7 +31,7 @@ use intel::*;
 use llama::*;
 use mediatek::BreezeInstructPrompt;
 use mistral::*;
-use nvidia::NemotronChatPrompt;
+use nvidia::{NemotronChatPrompt, NemotronToolPrompt};
 use octopus::*;
 use openchat::*;
 use phi::*;
@@ -94,6 +94,7 @@ pub enum ChatPrompt {
     GroqLlama3ToolPrompt,
     BreezeInstructPrompt,
     NemotronChatPrompt,
+    NemotronToolPrompt,
 }
 impl From<PromptTemplateType> for ChatPrompt {
     fn from(ty: PromptTemplateType) -> Self {
@@ -160,6 +161,7 @@ impl From<PromptTemplateType> for ChatPrompt {
                 ChatPrompt::BreezeInstructPrompt(BreezeInstructPrompt)
             }
             PromptTemplateType::NemotronChat => ChatPrompt::NemotronChatPrompt(NemotronChatPrompt),
+            PromptTemplateType::NemotronTool => ChatPrompt::NemotronToolPrompt(NemotronToolPrompt),
             PromptTemplateType::Embedding => {
                 panic!("Embedding prompt template is not used for building chat prompts")
             }

--- a/crates/chat-prompts/src/chat/nvidia.rs
+++ b/crates/chat-prompts/src/chat/nvidia.rs
@@ -2,7 +2,8 @@ use super::BuildChatPrompt;
 use crate::error::{PromptError, Result};
 use endpoints::chat::{
     ChatCompletionAssistantMessage, ChatCompletionRequestMessage, ChatCompletionSystemMessage,
-    ChatCompletionUserMessage, ChatCompletionUserMessageContent, ContentPart,
+    ChatCompletionToolMessage, ChatCompletionUserMessage, ChatCompletionUserMessageContent,
+    ContentPart, Tool,
 };
 
 /// Generate prompts for the `nemotron-mini-instruct` model.
@@ -100,6 +101,218 @@ impl BuildChatPrompt for NemotronChatPrompt {
                 }
                 ChatCompletionRequestMessage::Assistant(message) => {
                     prompt = self.append_assistant_message(&prompt, message)?;
+                }
+                _ => continue,
+            }
+        }
+
+        prompt.push_str("\n<extra_id_1>Assistant\n");
+
+        Ok(prompt)
+    }
+}
+
+/// Generate prompts for the models using ChatML template.
+#[derive(Debug, Default, Clone)]
+pub struct NemotronToolPrompt;
+impl NemotronToolPrompt {
+    /// Create a system prompt from a chat completion request message.
+    fn create_system_prompt(&self, message: &ChatCompletionSystemMessage) -> String {
+        let content = message.content();
+        match content.is_empty() {
+            true => String::from("<|im_start|>system\nAnswer as concisely as possible.<|im_end|>"),
+            false => format!(
+                "<|im_start|>system\n{system_prompt}<|im_end|>",
+                system_prompt = content
+            ),
+        }
+    }
+
+    fn create_system_prompt_tool(
+        &self,
+        message: &ChatCompletionSystemMessage,
+        tools: Option<&[Tool]>,
+    ) -> String {
+        let content = message.content();
+        match content.is_empty() {
+            true => match tools {
+                Some(tools) => {
+                    let available_tools = serde_json::to_string(tools).unwrap();
+                    let tools = format!("<tool> {} </tool>", available_tools);
+
+                    let begin = r#"<extra_id_0>System\nYou are a helpful, respectful and honest assistant. Always answer as short as possible, while being safe."#;
+
+                    format!("{}\n\n{}", begin, tools)
+                }
+                None => {
+                    String::from("<extra_id_0>System\nYou are a helpful, respectful and honest assistant. Always answer as short as possible, while being safe.")
+                }
+            },
+            false => match tools {
+                Some(tools) => {
+                    let available_tools = serde_json::to_string(tools).unwrap();
+                    let tools = format!("<tool> {} </tool>", available_tools);
+
+                    let begin = format!(
+                        "<extra_id_0>System\n{system_prompt}", system_prompt=content
+                    );
+
+                    format!("{}\n\n{}", begin, tools)
+                }
+                None => {
+                    format!(
+                        "<extra_id_0>System\n{system_prompt}", system_prompt=content
+                    )
+                }
+            },
+        }
+    }
+
+    /// Create a user prompt from a chat completion request message.
+    fn append_user_message(
+        &self,
+        chat_history: impl AsRef<str>,
+        system_prompt: impl AsRef<str>,
+        message: &ChatCompletionUserMessage,
+    ) -> String {
+        let content = match message.content() {
+            ChatCompletionUserMessageContent::Text(text) => text.to_string(),
+            ChatCompletionUserMessageContent::Parts(parts) => {
+                let mut content = String::new();
+                for part in parts {
+                    if let ContentPart::Text(text_content) = part {
+                        content.push_str(text_content.text());
+                        content.push('\n');
+                    }
+                }
+                content
+            }
+        };
+
+        match chat_history.as_ref().is_empty() {
+            true => format!(
+                "{system_prompt}\n\n<extra_id_1>User\n{user_message}",
+                system_prompt = system_prompt.as_ref().trim(),
+                user_message = content.trim(),
+            ),
+            false => format!(
+                "{chat_history}\n<extra_id_1>User\n{user_message}",
+                chat_history = chat_history.as_ref().trim(),
+                user_message = content.trim(),
+            ),
+        }
+    }
+
+    /// create an assistant prompt from a chat completion request message.
+    fn append_assistant_message(
+        &self,
+        chat_history: impl AsRef<str>,
+        message: &ChatCompletionAssistantMessage,
+    ) -> Result<String> {
+        let content = match message.content() {
+            Some(content) => content.to_string(),
+            // Note that the content is optional if `tool_calls` is specified.
+            None => match message.tool_calls().is_some() {
+                true => String::new(),
+                false => return Err(PromptError::NoAssistantMessage),
+            },
+        };
+
+        Ok(format!(
+            "{chat_history}<extra_id_1>Assistant\n{assistant_message}",
+            chat_history = chat_history.as_ref().trim(),
+            assistant_message = content.trim(),
+        ))
+    }
+
+    /// create a tool prompt from a chat completion request message.
+    fn append_tool_message(
+        &self,
+        chat_history: impl AsRef<str>,
+        message: &ChatCompletionToolMessage,
+    ) -> String {
+        format!(
+            "{chat_history}\n<extra_id_1>Tool\n{tool_message}",
+            chat_history = chat_history.as_ref().trim(),
+            tool_message = message.content().trim(),
+        )
+    }
+}
+impl BuildChatPrompt for NemotronToolPrompt {
+    fn build(&self, messages: &mut Vec<ChatCompletionRequestMessage>) -> Result<String> {
+        if messages.is_empty() {
+            return Err(crate::error::PromptError::NoMessages);
+        }
+
+        // system prompt
+        let system_prompt = match messages[0] {
+            ChatCompletionRequestMessage::System(ref message) => self.create_system_prompt(message),
+            _ => String::from("<|im_start|>system\nAnswer as concisely as possible.<|im_end|>"),
+        };
+
+        // append user/assistant messages
+        let mut prompt = String::new();
+        for message in messages {
+            match message {
+                ChatCompletionRequestMessage::User(message) => {
+                    prompt = self.append_user_message(&prompt, &system_prompt, message);
+                }
+                ChatCompletionRequestMessage::Assistant(message) => {
+                    prompt = self.append_assistant_message(&prompt, message)?;
+                }
+                ChatCompletionRequestMessage::Tool(message) => {
+                    prompt = self.append_tool_message(&prompt, message);
+                }
+                _ => continue,
+            }
+        }
+
+        prompt.push_str("\n<|im_start|>assistant");
+
+        Ok(prompt)
+    }
+
+    fn build_with_tools(
+        &self,
+        messages: &mut Vec<ChatCompletionRequestMessage>,
+        tools: Option<&[Tool]>,
+    ) -> Result<String> {
+        if messages.is_empty() {
+            return Err(crate::error::PromptError::NoMessages);
+        }
+
+        // system prompt
+        let system_prompt = match messages[0] {
+            ChatCompletionRequestMessage::System(ref message) => {
+                self.create_system_prompt_tool(message, tools)
+            }
+            _ => match tools {
+                Some(tools) => {
+                    let available_tools = serde_json::to_string(tools).unwrap();
+                    let tools = format!("<tool> {} </tool>", available_tools);
+
+                    let begin = r#"<extra_id_0>System\nYou are a helpful, respectful and honest assistant. Always answer as short as possible, while being safe."#;
+
+                    format!("{}\n\n{}", begin, tools)
+                }
+                None => {
+                    String::from("<|im_start|>system\nAnswer as concisely as possible.<|im_end|>")
+                }
+            },
+        };
+
+        // append user/assistant messages
+        let mut prompt = String::new();
+        for message in messages {
+            match message {
+                ChatCompletionRequestMessage::User(message) => {
+                    prompt = self.append_user_message(&prompt, &system_prompt, message);
+                }
+                ChatCompletionRequestMessage::Assistant(message) => {
+                    prompt = self.append_assistant_message(&prompt, message)?;
+                }
+                ChatCompletionRequestMessage::Tool(message) => {
+                    prompt = self.append_tool_message(&prompt, message);
                 }
                 _ => continue,
             }

--- a/crates/chat-prompts/src/chat/nvidia.rs
+++ b/crates/chat-prompts/src/chat/nvidia.rs
@@ -105,7 +105,7 @@ impl BuildChatPrompt for NemotronChatPrompt {
             }
         }
 
-        prompt.push_str("<extra_id_1>Assistant\n");
+        prompt.push_str("\n<extra_id_1>Assistant\n");
 
         Ok(prompt)
     }

--- a/crates/chat-prompts/src/chat/nvidia.rs
+++ b/crates/chat-prompts/src/chat/nvidia.rs
@@ -288,12 +288,18 @@ impl BuildChatPrompt for NemotronToolPrompt {
             }
             _ => match tools {
                 Some(tools) => {
-                    let available_tools = serde_json::to_string(tools).unwrap();
-                    let tools = format!("<tool> {} </tool>", available_tools);
+                    let mut tools_s = String::new();
+                    for tool in tools {
+                        let available_tool = serde_json::to_string(&tool.function).unwrap();
+
+                        let tool = format!("<tool> {} </tool>\n", available_tool);
+
+                        tools_s.push_str(&tool);
+                    }
 
                     let begin = r#"<extra_id_0>System\nYou are a helpful, respectful and honest assistant. Always answer as short as possible, while being safe."#;
 
-                    format!("{}\n\n{}", begin, tools)
+                    format!("{}\n{}", begin, tools_s.trim())
                 }
                 None => {
                     String::from("<|im_start|>system\nAnswer as concisely as possible.<|im_end|>")

--- a/crates/chat-prompts/src/chat/nvidia.rs
+++ b/crates/chat-prompts/src/chat/nvidia.rs
@@ -1,0 +1,112 @@
+use super::BuildChatPrompt;
+use crate::error::{PromptError, Result};
+use endpoints::chat::{
+    ChatCompletionAssistantMessage, ChatCompletionRequestMessage, ChatCompletionSystemMessage,
+    ChatCompletionUserMessage, ChatCompletionUserMessageContent, ContentPart,
+};
+
+/// Generate prompts for the `nemotron-mini-instruct` model.
+#[derive(Debug, Default, Clone)]
+pub struct NemotronChatPrompt;
+impl NemotronChatPrompt {
+    /// Create a system prompt from a chat completion request message.
+    fn create_system_prompt(&self, message: &ChatCompletionSystemMessage) -> String {
+        let content = message.content();
+        match content.is_empty() {
+            true => String::from("<extra_id_0>System\nYou are a helpful, respectful and honest assistant. Always answer as short as possible, while being safe."),
+            false =>format!(
+                "<extra_id_0>System\n{system_prompt}", system_prompt=content
+            )
+        }
+    }
+
+    /// Create a user prompt from a chat completion request message.
+    fn append_user_message(
+        &self,
+        chat_history: impl AsRef<str>,
+        system_prompt: impl AsRef<str>,
+        message: &ChatCompletionUserMessage,
+    ) -> String {
+        let content = match message.content() {
+            ChatCompletionUserMessageContent::Text(text) => text.to_string(),
+            ChatCompletionUserMessageContent::Parts(parts) => {
+                let mut content = String::new();
+                for part in parts {
+                    if let ContentPart::Text(text_content) = part {
+                        content.push_str(text_content.text());
+                        content.push('\n');
+                    }
+                }
+                content
+            }
+        };
+
+        match chat_history.as_ref().is_empty() {
+            true => format!(
+                "{system_prompt}\n<extra_id_1>User\n{user_message}",
+                system_prompt = system_prompt.as_ref().trim(),
+                user_message = content.trim(),
+            ),
+            false => format!(
+                "{chat_history}\n<extra_id_1>User\n{user_message}",
+                chat_history = chat_history.as_ref().trim(),
+                user_message = content.trim(),
+            ),
+        }
+    }
+
+    /// create an assistant prompt from a chat completion request message.
+    fn append_assistant_message(
+        &self,
+        chat_history: impl AsRef<str>,
+        message: &ChatCompletionAssistantMessage,
+    ) -> Result<String> {
+        let content = match message.content() {
+            Some(content) => content.to_string(),
+            // Note that the content is optional if `tool_calls` is specified.
+            None => match message.tool_calls().is_some() {
+                true => String::new(),
+                false => return Err(PromptError::NoAssistantMessage),
+            },
+        };
+
+        Ok(format!(
+            "{chat_history}<extra_id_1>Assistant\n{assistant_message}",
+            chat_history = chat_history.as_ref().trim(),
+            assistant_message = content.trim(),
+        ))
+    }
+}
+impl BuildChatPrompt for NemotronChatPrompt {
+    fn build(&self, messages: &mut Vec<ChatCompletionRequestMessage>) -> Result<String> {
+        if messages.is_empty() {
+            return Err(crate::error::PromptError::NoMessages);
+        }
+
+        // system prompt
+        let system_prompt = match messages[0] {
+            ChatCompletionRequestMessage::System(ref message) => {
+                self.create_system_prompt(message)
+            }
+            _ => String::from("<extra_id_0>System\nYou are a helpful, respectful and honest assistant. Always answer as short as possible, while being safe."),
+        };
+
+        // append user/assistant messages
+        let mut prompt = String::new();
+        for message in messages {
+            match message {
+                ChatCompletionRequestMessage::User(message) => {
+                    prompt = self.append_user_message(&prompt, &system_prompt, message);
+                }
+                ChatCompletionRequestMessage::Assistant(message) => {
+                    prompt = self.append_assistant_message(&prompt, message)?;
+                }
+                _ => continue,
+            }
+        }
+
+        prompt.push_str("<extra_id_1>Assistant\n");
+
+        Ok(prompt)
+    }
+}

--- a/crates/chat-prompts/src/chat/qwen.rs
+++ b/crates/chat-prompts/src/chat/qwen.rs
@@ -1,0 +1,49 @@
+use super::BuildChatPrompt;
+use crate::error::{PromptError, Result};
+use endpoints::chat::{
+    ChatCompletionRequestMessage, ChatCompletionUserMessage, ChatCompletionUserMessageContent,
+    ContentPart,
+};
+
+/// Generate prompts for the `Qwen2.5-Coder` model.
+#[derive(Debug, Default, Clone)]
+pub struct Qwen25CoderInstructPrompt;
+impl Qwen25CoderInstructPrompt {
+    /// Create a user prompt from a chat completion request message.
+    fn append_user_message(&self, message: &ChatCompletionUserMessage) -> String {
+        let content = match message.content() {
+            ChatCompletionUserMessageContent::Text(text) => text.to_string(),
+            ChatCompletionUserMessageContent::Parts(parts) => {
+                let mut content = String::new();
+                for part in parts {
+                    if let ContentPart::Text(text_content) = part {
+                        content.push_str(text_content.text());
+                        content.push('\n');
+                    }
+                }
+                content
+            }
+        };
+
+        content.trim().to_owned()
+    }
+}
+impl BuildChatPrompt for Qwen25CoderInstructPrompt {
+    fn build(&self, messages: &mut Vec<ChatCompletionRequestMessage>) -> Result<String> {
+        if messages.is_empty() {
+            return Err(crate::error::PromptError::NoMessages);
+        }
+
+        // get the last message
+        let last_message = messages.last().unwrap();
+        match last_message {
+            ChatCompletionRequestMessage::User(message) => {
+                let prompt = self.append_user_message(message);
+                Ok(prompt)
+            }
+            _ => Err(PromptError::BadMessages(
+                "The last message is not a user message.".to_string(),
+            )),
+        }
+    }
+}

--- a/crates/chat-prompts/src/lib.rs
+++ b/crates/chat-prompts/src/lib.rs
@@ -87,6 +87,8 @@ pub enum PromptTemplateType {
     NemotronChat,
     #[value(name = "nemotron-tool")]
     NemotronTool,
+    #[value(name = "qwen-2.5-coder")]
+    Qwen25Coder,
     #[value(name = "embedding")]
     Embedding,
     #[value(name = "none")]
@@ -132,6 +134,7 @@ impl PromptTemplateType {
             | PromptTemplateType::SolarInstruct
             | PromptTemplateType::Vicuna11Chat
             | PromptTemplateType::StableLMZephyr
+            | PromptTemplateType::Qwen25Coder
             | PromptTemplateType::Embedding
             | PromptTemplateType::Null => false,
         }
@@ -180,6 +183,7 @@ impl FromStr for PromptTemplateType {
             "mediatek-breeze" => Ok(PromptTemplateType::BreezeInstruct),
             "nemotron-chat" => Ok(PromptTemplateType::NemotronChat),
             "nemotron-tool" => Ok(PromptTemplateType::NemotronTool),
+            "qwen-2.5-coder" => Ok(PromptTemplateType::Qwen25Coder),
             "embedding" => Ok(PromptTemplateType::Embedding),
             "none" => Ok(PromptTemplateType::Null),
             _ => Err(error::PromptError::UnknownPromptTemplateType(
@@ -228,6 +232,7 @@ impl std::fmt::Display for PromptTemplateType {
             PromptTemplateType::BreezeInstruct => write!(f, "mediatek-breeze"),
             PromptTemplateType::NemotronChat => write!(f, "nemotron-chat"),
             PromptTemplateType::NemotronTool => write!(f, "nemotron-tool"),
+            PromptTemplateType::Qwen25Coder => write!(f, "qwen-2.5-coder"),
             PromptTemplateType::Embedding => write!(f, "embedding"),
             PromptTemplateType::Null => write!(f, "none"),
         }

--- a/crates/chat-prompts/src/lib.rs
+++ b/crates/chat-prompts/src/lib.rs
@@ -85,6 +85,8 @@ pub enum PromptTemplateType {
     BreezeInstruct,
     #[value(name = "nemotron-chat")]
     NemotronChat,
+    #[value(name = "nemotron-tool")]
+    NemotronTool,
     #[value(name = "embedding")]
     Embedding,
     #[value(name = "none")]
@@ -115,7 +117,8 @@ impl PromptTemplateType {
             | PromptTemplateType::GroqLlama3Tool
             | PromptTemplateType::BreezeInstruct
             | PromptTemplateType::DeepseekChat25
-            | PromptTemplateType::NemotronChat => true,
+            | PromptTemplateType::NemotronChat
+            | PromptTemplateType::NemotronTool => true,
             PromptTemplateType::MistralInstruct
             | PromptTemplateType::MistralTool
             | PromptTemplateType::MistralLite
@@ -176,6 +179,7 @@ impl FromStr for PromptTemplateType {
             "groq-llama3-tool" => Ok(PromptTemplateType::GroqLlama3Tool),
             "mediatek-breeze" => Ok(PromptTemplateType::BreezeInstruct),
             "nemotron-chat" => Ok(PromptTemplateType::NemotronChat),
+            "nemotron-tool" => Ok(PromptTemplateType::NemotronTool),
             "embedding" => Ok(PromptTemplateType::Embedding),
             "none" => Ok(PromptTemplateType::Null),
             _ => Err(error::PromptError::UnknownPromptTemplateType(
@@ -223,6 +227,7 @@ impl std::fmt::Display for PromptTemplateType {
             PromptTemplateType::GroqLlama3Tool => write!(f, "groq-llama3-tool"),
             PromptTemplateType::BreezeInstruct => write!(f, "mediatek-breeze"),
             PromptTemplateType::NemotronChat => write!(f, "nemotron-chat"),
+            PromptTemplateType::NemotronTool => write!(f, "nemotron-tool"),
             PromptTemplateType::Embedding => write!(f, "embedding"),
             PromptTemplateType::Null => write!(f, "none"),
         }

--- a/crates/chat-prompts/src/lib.rs
+++ b/crates/chat-prompts/src/lib.rs
@@ -83,6 +83,8 @@ pub enum PromptTemplateType {
     GroqLlama3Tool,
     #[value(name = "mediatek-breeze")]
     BreezeInstruct,
+    #[value(name = "nemotron-chat")]
+    NemotronChat,
     #[value(name = "embedding")]
     Embedding,
     #[value(name = "none")]
@@ -112,7 +114,8 @@ impl PromptTemplateType {
             | PromptTemplateType::Glm4Chat
             | PromptTemplateType::GroqLlama3Tool
             | PromptTemplateType::BreezeInstruct
-            | PromptTemplateType::DeepseekChat25 => true,
+            | PromptTemplateType::DeepseekChat25
+            | PromptTemplateType::NemotronChat => true,
             PromptTemplateType::MistralInstruct
             | PromptTemplateType::MistralTool
             | PromptTemplateType::MistralLite
@@ -172,6 +175,7 @@ impl FromStr for PromptTemplateType {
             "glm-4-chat" => Ok(PromptTemplateType::Glm4Chat),
             "groq-llama3-tool" => Ok(PromptTemplateType::GroqLlama3Tool),
             "mediatek-breeze" => Ok(PromptTemplateType::BreezeInstruct),
+            "nemotron-chat" => Ok(PromptTemplateType::NemotronChat),
             "embedding" => Ok(PromptTemplateType::Embedding),
             "none" => Ok(PromptTemplateType::Null),
             _ => Err(error::PromptError::UnknownPromptTemplateType(
@@ -218,6 +222,7 @@ impl std::fmt::Display for PromptTemplateType {
             PromptTemplateType::Glm4Chat => write!(f, "glm-4-chat"),
             PromptTemplateType::GroqLlama3Tool => write!(f, "groq-llama3-tool"),
             PromptTemplateType::BreezeInstruct => write!(f, "mediatek-breeze"),
+            PromptTemplateType::NemotronChat => write!(f, "nemotron-chat"),
             PromptTemplateType::Embedding => write!(f, "embedding"),
             PromptTemplateType::Null => write!(f, "none"),
         }

--- a/crates/endpoints/Cargo.toml
+++ b/crates/endpoints/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endpoints"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/endpoints/Cargo.toml
+++ b/crates/endpoints/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endpoints"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/endpoints/src/audio/translation.rs
+++ b/crates/endpoints/src/audio/translation.rs
@@ -8,7 +8,7 @@ use serde::{
 use std::fmt;
 
 /// Represents a rquest for translating audio into English.
-#[derive(Debug, Serialize, Default)]
+#[derive(Debug, Serialize)]
 pub struct TranslationRequest {
     /// The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
     pub file: FileObject,
@@ -17,7 +17,7 @@ pub struct TranslationRequest {
     /// An optional text to guide the model's style or continue a previous audio segment. The prompt should be in English.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prompt: Option<String>,
-    /// The format of the transcript output, in one of these options: `json`, `text`, `srt`, `verbose_json`, or `vtt`.
+    /// The format of the transcript output, in one of these options: `json`, `text`, `srt`, `verbose_json`, or `vtt`. Defaults to `json`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response_format: Option<String>,
     /// The sampling temperature, between 0 and 1. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. If set to 0, the model will use [log probability](https://en.wikipedia.org/wiki/Log_probability) to automatically increase the temperature until certain thresholds are hit. Defaults to 0.0.
@@ -138,6 +138,10 @@ impl<'de> Deserialize<'de> for TranslationRequest {
 
                 let file = file.ok_or_else(|| de::Error::missing_field("file"))?;
 
+                if response_format.is_none() {
+                    response_format = Some("json".to_string());
+                }
+
                 if temperature.is_none() {
                     temperature = Some(0.0);
                 }
@@ -166,6 +170,18 @@ impl<'de> Deserialize<'de> for TranslationRequest {
             "language",
         ];
         deserializer.deserialize_struct("TranslationRequest", FIELDS, TranslationRequestVisitor)
+    }
+}
+impl Default for TranslationRequest {
+    fn default() -> Self {
+        TranslationRequest {
+            file: FileObject::default(),
+            model: None,
+            prompt: None,
+            response_format: Some("json".to_string()),
+            temperature: Some(0.0),
+            language: Some("en".to_string()),
+        }
     }
 }
 

--- a/crates/endpoints/src/chat.rs
+++ b/crates/endpoints/src/chat.rs
@@ -453,6 +453,10 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
                     n_choice = Some(1);
                 }
 
+                if stream.is_none() {
+                    stream = Some(false);
+                }
+
                 // Construct ChatCompletionRequest with all fields
                 Ok(ChatCompletionRequest {
                     model,

--- a/crates/llama-core/Cargo.toml
+++ b/crates/llama-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-core"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/llama-core/Cargo.toml
+++ b/crates/llama-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-core"
-version = "0.17.1"
+version = "0.17.2"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/llama-core/src/audio.rs
+++ b/crates/llama-core/src/audio.rs
@@ -45,10 +45,13 @@ pub async fn audio_transcriptions(
     };
 
     #[cfg(feature = "logging")]
-    info!(target: "stdout", "translation enabled: {}", graph.metadata.translate);
+    info!(target: "stdout", "transcription status: {}", !graph.metadata.translate);
 
     // check if translation is disabled so that transcription tasks can be done
     if graph.metadata.translate {
+        #[cfg(feature = "logging")]
+        info!(target: "stdout", "switch to the transcription mode");
+
         // enable translation
         graph.metadata.translate = false;
 
@@ -56,7 +59,10 @@ pub async fn audio_transcriptions(
         let metadata = graph.metadata.clone();
 
         #[cfg(feature = "logging")]
-        info!(target: "stdout", "Update the model metadata to disable translation.");
+        info!(target: "stdout", "metadata: {:?}", &metadata);
+
+        #[cfg(feature = "logging")]
+        info!(target: "stdout", "set the metadata to the model.");
 
         match serde_json::to_string(&metadata) {
             Ok(config) => {
@@ -74,10 +80,7 @@ pub async fn audio_transcriptions(
         };
 
         #[cfg(feature = "logging")]
-        info!(target: "stdout", "Disabled translation");
-
-        // update the metadata
-        graph.metadata.translate = false;
+        info!(target: "stdout", "enabled transcription mode");
     }
 
     let path = Path::new("archives")
@@ -319,10 +322,13 @@ pub async fn audio_translations(
     };
 
     #[cfg(feature = "logging")]
-    info!(target: "stdout", "translation enabled: {}", graph.metadata.translate);
+    info!(target: "stdout", "translation status: {}", graph.metadata.translate);
 
     // update metadata
     if !graph.metadata.translate {
+        #[cfg(feature = "logging")]
+        info!(target: "stdout", "switch to the translation mode");
+
         // update the metadata
         graph.metadata.translate = true;
 
@@ -330,7 +336,10 @@ pub async fn audio_translations(
         let metadata = graph.metadata.clone();
 
         #[cfg(feature = "logging")]
-        info!(target: "stdout", "Update the model metadata to enable translation.");
+        info!(target: "stdout", "metadata: {:?}", &metadata);
+
+        #[cfg(feature = "logging")]
+        info!(target: "stdout", "set the metadata to the model.");
 
         match serde_json::to_string(&metadata) {
             Ok(config) => {
@@ -348,7 +357,7 @@ pub async fn audio_translations(
         };
 
         #[cfg(feature = "logging")]
-        info!(target: "stdout", "enabled translation");
+        info!(target: "stdout", "enabled translation mode");
     }
 
     let path = Path::new("archives")

--- a/crates/llama-core/src/chat.rs
+++ b/crates/llama-core/src/chat.rs
@@ -1198,6 +1198,9 @@ fn parse_tool_calls(
             }
         }
         PromptTemplateType::GroqLlama3Tool => {
+            #[cfg(feature = "logging")]
+            info!(target: "stdout", "raw input: {}", input);
+
             match regex::Regex::new(r"(?s)<tool_call>((.|\r|\n)*?)</tool_call>") {
                 Ok(re) => {
                     let mut values: Vec<serde_json::Value> = vec![];
@@ -1488,7 +1491,100 @@ fn parse_tool_calls(
             #[cfg(feature = "logging")]
             info!(target: "stdout", "raw input: {}", input);
 
-            unimplemented!("The tool use is not supported for the prompt template: NemotronTool.");
+            match regex::Regex::new(r"(?s)<toolcall>\s*(.*?)\s*</toolcall>") {
+                Ok(re) => {
+                    let mut values: Vec<serde_json::Value> = vec![];
+                    for cap in re.captures_iter(input) {
+                        #[cfg(feature = "logging")]
+                        info!(target: "stdout", "captured: {}", &cap[0]);
+
+                        #[cfg(feature = "logging")]
+                        info!(target: "stdout", "extracted: {}", &cap[1]);
+
+                        let matched = cap[1].trim();
+
+                        #[cfg(feature = "logging")]
+                        info!(target: "stdout", "captured: {}", matched);
+
+                        match serde_json::from_str::<serde_json::Value>(matched) {
+                            Ok(value) => values.push(value),
+                            Err(e) => {
+                                let err_msg = format!(
+                                    "Failed to deserialize generated tool calls. Reason: {}",
+                                    e
+                                );
+
+                                #[cfg(feature = "logging")]
+                                error!(target: "stdout", "{}", &err_msg);
+
+                                return Err(LlamaCoreError::Operation(err_msg));
+                            }
+                        }
+                    }
+
+                    let mut tool_calls: Vec<ToolCall> = vec![];
+                    for value in values.iter() {
+                        let name = match value.get("name") {
+                            Some(name) => name.to_string().replace("\"", ""),
+                            None => {
+                                let err_msg = format!(
+                                    "Failed to get the name of the function. Tool call: {:?}",
+                                    value
+                                );
+
+                                #[cfg(feature = "logging")]
+                                error!(target: "stdout", "{}", &err_msg);
+
+                                return Err(LlamaCoreError::Operation(err_msg));
+                            }
+                        };
+
+                        let arguments = match value.get("arguments") {
+                            Some(arguments) => arguments.to_string(),
+                            None => {
+                                let err_msg = format!(
+                                    "Failed to get the arguments of the function. Tool call: {:?}",
+                                    value
+                                );
+
+                                #[cfg(feature = "logging")]
+                                error!(target: "stdout", "{}", &err_msg);
+
+                                return Err(LlamaCoreError::Operation(err_msg));
+                            }
+                        };
+
+                        let function = Function { name, arguments };
+
+                        let tool_call = ToolCall {
+                            id: "call_abc123".to_string(),
+                            ty: "function".to_string(),
+                            function,
+                        };
+
+                        tool_calls.push(tool_call);
+                    }
+
+                    let parsed = ParseResult {
+                        raw: input.to_owned(),
+                        content: None,
+                        tool_calls,
+                    };
+
+                    #[cfg(feature = "logging")]
+                    info!(target: "stdout", "parsed result: {:?}", parsed);
+
+                    Ok(parsed)
+                }
+                Err(e) => {
+                    let err_msg = format!("Failed to create a regex pattern. Reason: {}", e);
+
+                    #[cfg(feature = "logging")]
+                    error!(target: "stdout", "{}", &err_msg);
+
+                    Err(LlamaCoreError::Operation(err_msg))
+                }
+            }
         }
         _ => Err(LlamaCoreError::Operation(format!(
             "The tool use is only supported for prompt templates: {}, {}, {}, {}, and {}.",

--- a/crates/llama-core/src/chat.rs
+++ b/crates/llama-core/src/chat.rs
@@ -2711,8 +2711,14 @@ fn compute_stream(
                     // compute
                     match graph.compute_single() {
                         Ok(_) => {
+                            #[cfg(feature = "logging")]
+                            info!(target: "stdout", "Compute the chat stream chunk successfully.");
+
                             // Retrieve the output
                             let output_buffer = get_output_buffer_single(graph, OUTPUT_TENSOR)?;
+
+                            #[cfg(feature = "logging")]
+                            info!(target: "stdout", "retrieved the output buffer");
 
                             // decode the output buffer to a utf8 string
                             let output = match String::from_utf8(output_buffer.clone()) {
@@ -2762,6 +2768,9 @@ fn compute_stream(
                                 }
                             };
 
+                            #[cfg(feature = "logging")]
+                            info!(target: "stdout", "decoded the output buffer");
+
                             let created = SystemTime::now()
                                 .duration_since(std::time::UNIX_EPOCH)
                                 .map_err(|e| {
@@ -2792,6 +2801,9 @@ fn compute_stream(
                                 }],
                                 usage: None,
                             };
+
+                            #[cfg(feature = "logging")]
+                            info!(target: "stdout", "created chat completion chunk");
 
                             // serialize chat completion chunk
                             let chunk_str =
@@ -3202,9 +3214,15 @@ fn compute_stream(
                             // compute
                             match graph.compute_single() {
                                 Ok(_) => {
+                                    #[cfg(feature = "logging")]
+                                    info!(target: "stdout", "Compute the chat stream chunk successfully.");
+
                                     // Retrieve the output
                                     let output_buffer =
                                         get_output_buffer_single(graph, OUTPUT_TENSOR)?;
+
+                                    #[cfg(feature = "logging")]
+                                    info!(target: "stdout", "retrieved the output buffer");
 
                                     // decode the output buffer to a utf8 string
                                     let output = match String::from_utf8(output_buffer.clone()) {
@@ -3254,6 +3272,9 @@ fn compute_stream(
                                         }
                                     };
 
+                                    #[cfg(feature = "logging")]
+                                    info!(target: "stdout", "decoded the output buffer");
+
                                     let created = SystemTime::now()
                                         .duration_since(std::time::UNIX_EPOCH)
                                         .map_err(|e| {
@@ -3286,6 +3307,9 @@ fn compute_stream(
                                         }],
                                         usage: None,
                                     };
+
+                                    #[cfg(feature = "logging")]
+                                    info!(target: "stdout", "created chat completion chunk");
 
                                     // serialize chat completion chunk
                                     let chunk_str = serde_json::to_string(&chat_completion_chunk)
@@ -3729,8 +3753,15 @@ fn compute_stream(
                     // compute
                     match graph.compute_single() {
                         Ok(_) => {
+                            #[cfg(feature = "logging")]
+                            info!(target: "stdout", "Compute the chat stream chunk successfully.");
+
                             // Retrieve the output
                             let output_buffer = get_output_buffer_single(graph, OUTPUT_TENSOR)?;
+
+                            #[cfg(feature = "logging")]
+                            info!(target: "stdout", "retrieved the output buffer");
+
                             // decode the output buffer to a utf8 string
                             let output = match String::from_utf8(output_buffer.clone()) {
                                 Ok(token) => token,
@@ -3777,6 +3808,9 @@ fn compute_stream(
                                 }
                             };
 
+                            #[cfg(feature = "logging")]
+                            info!(target: "stdout", "decoded the output buffer");
+
                             let created = SystemTime::now()
                                 .duration_since(std::time::UNIX_EPOCH)
                                 .map_err(|e| {
@@ -3807,6 +3841,9 @@ fn compute_stream(
                                 }],
                                 usage: None,
                             };
+
+                            #[cfg(feature = "logging")]
+                            info!(target: "stdout", "created chat completion chunk");
 
                             // serialize chat completion chunk
                             let chunk_str =

--- a/crates/llama-core/src/chat.rs
+++ b/crates/llama-core/src/chat.rs
@@ -2633,11 +2633,11 @@ impl futures::Stream for ChatStream {
                 &mut this.stream_state,
             );
 
-            #[cfg(feature = "logging")]
-            info!(target: "stdout", "Get the next item: {:?}", &x);
-
             match x {
                 Ok(x) => {
+                    #[cfg(feature = "logging")]
+                    info!(target: "stdout", "next item: {}", &x);
+
                     if x != "[GGML] End of sequence" && !x.is_empty() {
                         Poll::Ready(Some(Ok(x)))
                     } else {
@@ -2678,6 +2678,9 @@ fn compute_stream(
         || *context_full_state == ContextFullState::EndOfSequence
         || *stream_state == StreamState::EndOfSequence
     {
+        #[cfg(feature = "logging")]
+        info!(target: "stdout", "Return the chat stream chunk!");
+
         return Ok("[GGML] End of sequence".to_string());
     }
 

--- a/crates/llama-core/src/chat.rs
+++ b/crates/llama-core/src/chat.rs
@@ -792,6 +792,7 @@ fn compute_by_graph(
                         && graph.metadata.prompt_template != PromptTemplateType::GroqLlama3Tool
                         && graph.metadata.prompt_template != PromptTemplateType::Llama3Tool
                         && graph.metadata.prompt_template != PromptTemplateType::InternLM2Tool
+                        && graph.metadata.prompt_template != PromptTemplateType::NemotronTool
                     {
                         let err_msg = "The tool use is only supported for 'mistral-chat' and 'chatml' prompt templates.";
 
@@ -1482,6 +1483,12 @@ fn parse_tool_calls(
             info!(target: "stdout", "parsed result: {:?}", parsed);
 
             Ok(parsed)
+        }
+        PromptTemplateType::NemotronTool => {
+            #[cfg(feature = "logging")]
+            info!(target: "stdout", "raw input: {}", input);
+
+            unimplemented!("The tool use is not supported for the prompt template: NemotronTool.");
         }
         _ => Err(LlamaCoreError::Operation(format!(
             "The tool use is only supported for prompt templates: {}, {}, {}, {}, and {}.",

--- a/crates/llama-core/src/chat.rs
+++ b/crates/llama-core/src/chat.rs
@@ -1879,6 +1879,15 @@ fn post_process(
         } else {
             s.to_owned()
         }
+    } else if *template_ty == PromptTemplateType::NemotronTool
+        || *template_ty == PromptTemplateType::NemotronChat
+    {
+        let s = output.as_ref().trim();
+        if s.ends_with("</s>") {
+            s.trim_end_matches("</s>").trim().to_owned()
+        } else {
+            s.to_owned()
+        }
     } else {
         output.as_ref().trim().to_owned()
     };

--- a/llama-api-server/Cargo.toml
+++ b/llama-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-api-server"
-version = "0.14.3"
+version = "0.14.4"
 edition = "2021"
 
 [dependencies]

--- a/llama-chat/Cargo.toml
+++ b/llama-chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-chat"
-version = "0.14.3"
+version = "0.14.4"
 edition = "2021"
 
 [dependencies]

--- a/llama-simple/Cargo.toml
+++ b/llama-simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-simple"
-version = "0.14.3"
+version = "0.14.4"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Major changes:

- `chat-prompts` crate
  - New prompt types: `nemotron-tool`, `nemotron-chat`, and `qwen-2.5-coder`

- `endpoints` crate
  - Improve the default values of `TranslationRequest`
  - Customize the deserialization of `ChatCompletionRequest`

**Note**: this release runs on [WasmEdge v0.14.1](https://github.com/WasmEdge/WasmEdge/releases/tag/0.14.1)