### PR TITLE
Release 0.14.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13, macos-14]
+        os: [ubuntu-22.04, macos-13, macos-14, macos-15]
     steps:
       - name: Clone project
         id: checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
           mv wasi-sdk-24.0-x86_64-macos wasi-sdk-24.0
 
       - name: Download wasi-sdk for arm64-macos
-        if: matrix.os == 'macos-14'
+        if: matrix.os == 'macos-14' || matrix.os == 'macos-15'
         run: |
           curl -LO https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-24/wasi-sdk-24.0-arm64-macos.tar.gz
           tar -xzvf wasi-sdk-24.0-arm64-macos.tar.gz
@@ -87,7 +87,7 @@ jobs:
           cargo test -p endpoints --target x86_64-unknown-linux-gnu
 
       - name: Run tests on macos-14
-        if: matrix.os == 'macos-14'
+        if: matrix.os == 'macos-14' || matrix.os == 'macos-15'
         env:
           RUSTFLAGS: "--cfg wasmedge --cfg tokio_unstable"
         run: |

--- a/.github/workflows/test_api_server.yml
+++ b/.github/workflows/test_api_server.yml
@@ -31,7 +31,7 @@ on:
       - 'tests/*.hurl'
 
 jobs:
-  test-api-server:
+  test-api-server-ubuntu:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -65,6 +65,237 @@ jobs:
 
       - name: Build llama-api-server on linux
         env:
+          RUSTFLAGS: "--cfg wasmedge --cfg tokio_unstable"
+        run: |
+          cargo build -p llama-api-server --release
+          cp target/wasm32-wasip1/release/llama-api-server.wasm ./llama-api-server.wasm
+
+      - name: Start llama-api-server for testing chat completions
+        run: |
+          curl -LO https://huggingface.co/second-state/Qwen2-1.5B-Instruct-GGUF/resolve/main/Qwen2-1.5B-Instruct-Q3_K_M.gguf
+          nohup $HOME/.wasmedge/bin/wasmedge --dir .:. --nn-preload default:GGML:AUTO:Qwen2-1.5B-Instruct-Q3_K_M.gguf llama-api-server.wasm --model-name Qwen2-1.5B-Instruct --prompt-template chatml --ctx-size 4096 --socket-addr 0.0.0.0:8080 > ./start-llamaedge.log 2>&1 &
+          sleep 5
+          cat start-llamaedge.log
+
+      - name: Run test_chat.hurl
+        run: |
+          hurl --test --jobs 1 ./tests/test_chat.hurl
+
+      - name: Stop llama-api-server for testing chat completions
+        run: |
+          pkill -f wasmedge
+
+      - name: Start llama-api-server for testing embeddings
+        run: |
+          curl -LO https://huggingface.co/second-state/Nomic-embed-text-v1.5-Embedding-GGUF/resolve/main/nomic-embed-text-v1.5-f16.gguf
+          nohup $HOME/.wasmedge/bin/wasmedge --dir .:. --nn-preload default:GGML:AUTO:nomic-embed-text-v1.5-f16.gguf llama-api-server.wasm --model-name nomic-embed-text-v1.5 --prompt-template embedding --ctx-size 512 --socket-addr 0.0.0.0:8080 > ./start-llamaedge.log 2>&1 &
+          sleep 5
+          cat start-llamaedge.log
+
+      - name: Run test_embeddings.hurl
+        run: |
+          hurl --test --jobs 1 ./tests/test_embeddings.hurl
+
+      - name: Stop llama-api-server for testing chat completions
+        run: |
+          pkill -f wasmedge
+
+  test-api-server-macos-13:
+    runs-on: macos-13
+    needs: test-api-server-ubuntu
+    strategy:
+      matrix:
+        wasmedge_version: [0.14.1]
+    steps:
+      - name: Clone project
+        id: checkout
+        uses: actions/checkout@v3
+
+      - name: Install Rust-nightly
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+          target: wasm32-wasip1
+          components: rustfmt, clippy
+
+      - name: Install Rust-stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-wasip1
+
+      - name: Download wasi-sdk for x86_64-macos
+        run: |
+          curl -LO https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-24/wasi-sdk-24.0-x86_64-macos.tar.gz
+          tar -xzvf wasi-sdk-24.0-x86_64-macos.tar.gz
+          mv wasi-sdk-24.0-x86_64-macos wasi-sdk-24.0
+
+      - name: Install WasmEdge
+        run: |
+          curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v ${{ matrix.wasmedge_version }}
+          ls -al $HOME/.wasmedge/bin
+
+      - name: Install Hurl
+        run: |
+          brew install hurl
+
+      - name: Build llama-api-server
+        env:
+          WASI_SDK_PATH: /Users/runner/work/LlamaEdge/LlamaEdge/wasi-sdk-24.0
+          CC: "/Users/runner/work/LlamaEdge/LlamaEdge/wasi-sdk-24.0/bin/clang --sysroot=/Users/runner/work/LlamaEdge/LlamaEdge/wasi-sdk-24.0/share/wasi-sysroot"
+          RUSTFLAGS: "--cfg wasmedge --cfg tokio_unstable"
+        run: |
+          cargo build -p llama-api-server --release
+          cp target/wasm32-wasip1/release/llama-api-server.wasm ./llama-api-server.wasm
+
+      - name: Start llama-api-server for testing chat completions
+        run: |
+          curl -LO https://huggingface.co/second-state/Qwen2-1.5B-Instruct-GGUF/resolve/main/Qwen2-1.5B-Instruct-Q3_K_M.gguf
+          nohup $HOME/.wasmedge/bin/wasmedge --dir .:. --nn-preload default:GGML:AUTO:Qwen2-1.5B-Instruct-Q3_K_M.gguf llama-api-server.wasm --model-name Qwen2-1.5B-Instruct --prompt-template chatml --ctx-size 4096 --socket-addr 0.0.0.0:8080 > ./start-llamaedge.log 2>&1 &
+          sleep 5
+          cat start-llamaedge.log
+
+      - name: Run test_chat.hurl
+        run: |
+          hurl --test --jobs 1 ./tests/test_chat.hurl
+
+      - name: Stop llama-api-server for testing chat completions
+        run: |
+          pkill -f wasmedge
+
+      - name: Start llama-api-server for testing embeddings
+        run: |
+          curl -LO https://huggingface.co/second-state/Nomic-embed-text-v1.5-Embedding-GGUF/resolve/main/nomic-embed-text-v1.5-f16.gguf
+          nohup $HOME/.wasmedge/bin/wasmedge --dir .:. --nn-preload default:GGML:AUTO:nomic-embed-text-v1.5-f16.gguf llama-api-server.wasm --model-name nomic-embed-text-v1.5 --prompt-template embedding --ctx-size 512 --socket-addr 0.0.0.0:8080 > ./start-llamaedge.log 2>&1 &
+          sleep 5
+          cat start-llamaedge.log
+
+      - name: Run test_embeddings.hurl
+        run: |
+          hurl --test --jobs 1 ./tests/test_embeddings.hurl
+
+      - name: Stop llama-api-server for testing chat completions
+        run: |
+          pkill -f wasmedge
+
+  test-api-server-macos-14:
+    runs-on: macos-14
+    needs: test-api-server-macos-13
+    strategy:
+      matrix:
+        wasmedge_version: [0.14.1]
+    steps:
+      - name: Clone project
+        id: checkout
+        uses: actions/checkout@v3
+
+      - name: Install Rust-nightly
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+          target: wasm32-wasip1
+          components: rustfmt, clippy
+
+      - name: Install Rust-stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-wasip1
+
+      - name: Download wasi-sdk for arm64-macos
+        run: |
+          curl -LO https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-24/wasi-sdk-24.0-arm64-macos.tar.gz
+          tar -xzvf wasi-sdk-24.0-arm64-macos.tar.gz
+          mv wasi-sdk-24.0-arm64-macos wasi-sdk-24.0
+
+      - name: Install WasmEdge
+        run: |
+          curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v ${{ matrix.wasmedge_version }}
+          ls -al $HOME/.wasmedge/bin
+
+      - name: Install Hurl
+        run: |
+          brew install hurl
+
+      - name: Build llama-api-server
+        env:
+          WASI_SDK_PATH: /Users/runner/work/LlamaEdge/LlamaEdge/wasi-sdk-24.0
+          CC: "/Users/runner/work/LlamaEdge/LlamaEdge/wasi-sdk-24.0/bin/clang --sysroot=/Users/runner/work/LlamaEdge/LlamaEdge/wasi-sdk-24.0/share/wasi-sysroot"
+          RUSTFLAGS: "--cfg wasmedge --cfg tokio_unstable"
+        run: |
+          cargo build -p llama-api-server --release
+          cp target/wasm32-wasip1/release/llama-api-server.wasm ./llama-api-server.wasm
+
+      - name: Start llama-api-server for testing chat completions
+        run: |
+          curl -LO https://huggingface.co/second-state/Qwen2-1.5B-Instruct-GGUF/resolve/main/Qwen2-1.5B-Instruct-Q3_K_M.gguf
+          nohup $HOME/.wasmedge/bin/wasmedge --dir .:. --nn-preload default:GGML:AUTO:Qwen2-1.5B-Instruct-Q3_K_M.gguf llama-api-server.wasm --model-name Qwen2-1.5B-Instruct --prompt-template chatml --ctx-size 4096 --socket-addr 0.0.0.0:8080 > ./start-llamaedge.log 2>&1 &
+          sleep 5
+          cat start-llamaedge.log
+
+      - name: Run test_chat.hurl
+        run: |
+          hurl --test --jobs 1 ./tests/test_chat.hurl
+
+      - name: Stop llama-api-server for testing chat completions
+        run: |
+          pkill -f wasmedge
+
+      - name: Start llama-api-server for testing embeddings
+        run: |
+          curl -LO https://huggingface.co/second-state/Nomic-embed-text-v1.5-Embedding-GGUF/resolve/main/nomic-embed-text-v1.5-f16.gguf
+          nohup $HOME/.wasmedge/bin/wasmedge --dir .:. --nn-preload default:GGML:AUTO:nomic-embed-text-v1.5-f16.gguf llama-api-server.wasm --model-name nomic-embed-text-v1.5 --prompt-template embedding --ctx-size 512 --socket-addr 0.0.0.0:8080 > ./start-llamaedge.log 2>&1 &
+          sleep 5
+          cat start-llamaedge.log
+
+      - name: Run test_embeddings.hurl
+        run: |
+          hurl --test --jobs 1 ./tests/test_embeddings.hurl
+
+      - name: Stop llama-api-server for testing chat completions
+        run: |
+          pkill -f wasmedge
+
+  test-api-server-macos-15:
+    runs-on: macos-15
+    needs: test-api-server-macos-14
+    strategy:
+      matrix:
+        wasmedge_version: [0.14.1]
+    steps:
+      - name: Clone project
+        id: checkout
+        uses: actions/checkout@v3
+
+      - name: Install Rust-nightly
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+          target: wasm32-wasip1
+          components: rustfmt, clippy
+
+      - name: Install Rust-stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-wasip1
+
+      - name: Download wasi-sdk for arm64-macos
+        run: |
+          curl -LO https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-24/wasi-sdk-24.0-arm64-macos.tar.gz
+          tar -xzvf wasi-sdk-24.0-arm64-macos.tar.gz
+          mv wasi-sdk-24.0-arm64-macos wasi-sdk-24.0
+
+      - name: Install WasmEdge
+        run: |
+          curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- -v ${{ matrix.wasmedge_version }}
+          ls -al $HOME/.wasmedge/bin
+
+      - name: Install Hurl
+        run: |
+          brew install hurl
+
+      - name: Build llama-api-server
+        env:
+          WASI_SDK_PATH: /Users/runner/work/LlamaEdge/LlamaEdge/wasi-sdk-24.0
+          CC: "/Users/runner/work/LlamaEdge/LlamaEdge/wasi-sdk-24.0/bin/clang --sysroot=/Users/runner/work/LlamaEdge/LlamaEdge/wasi-sdk-24.0/share/wasi-sysroot"
           RUSTFLAGS: "--cfg wasmedge --cfg tokio_unstable"
         run: |
           cargo build -p llama-api-server --release

--- a/crates/chat-prompts/Cargo.toml
+++ b/crates/chat-prompts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chat-prompts"
-version = "0.17.2"
+version = "0.17.3"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/endpoints/Cargo.toml
+++ b/crates/endpoints/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endpoints"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/endpoints/src/embeddings.rs
+++ b/crates/endpoints/src/embeddings.rs
@@ -92,6 +92,11 @@ impl From<&String> for InputText {
         InputText::String(s.to_string())
     }
 }
+impl From<String> for InputText {
+    fn from(s: String) -> Self {
+        InputText::String(s)
+    }
+}
 impl From<&[String]> for InputText {
     fn from(s: &[String]) -> Self {
         InputText::ArrayOfStrings(s.to_vec())

--- a/crates/llama-core/Cargo.toml
+++ b/crates/llama-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-core"
-version = "0.21.1"
+version = "0.21.2"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/llama-core/src/rag.rs
+++ b/crates/llama-core/src/rag.rs
@@ -301,7 +301,7 @@ async fn qdrant_search_similar_points(
             let err_msg = e.to_string();
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "Fail to search similar points from the qdrant instance. Reason: {}", &err_msg);
+            error!(target: "stdout", "{}", &err_msg);
 
             Err(LlamaCoreError::Operation(err_msg))
         }

--- a/crates/llama-core/src/rag.rs
+++ b/crates/llama-core/src/rag.rs
@@ -120,7 +120,9 @@ pub async fn rag_query_to_embeddings(
 ///
 /// * `qdrant_collection_name` - Name of the Qdrant collection to be created.
 ///
-/// * `limit` - Max number of retrieved result.
+/// * `limit` - Number of retrieved results.
+///
+/// * `score_threshold` - The minimum score of the retrieved results.
 pub async fn rag_retrieve_context(
     query_embedding: &[f32],
     qdrant_url: impl AsRef<str>,

--- a/llama-api-server/Cargo.toml
+++ b/llama-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-api-server"
-version = "0.14.13"
+version = "0.14.14"
 edition = "2021"
 
 [dependencies]

--- a/llama-chat/Cargo.toml
+++ b/llama-chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-chat"
-version = "0.14.13"
+version = "0.14.14"
 edition = "2021"
 
 [dependencies]

--- a/llama-simple/Cargo.toml
+++ b/llama-simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-simple"
-version = "0.14.13"
+version = "0.14.14"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Major changes:

- `endpoints` crate
  - Extend `ChatCompletionRequest` with the `context_window` field. In the RAG scenario, the field decides the number of latest user messages used to retrieve context. The default value is `1`.
  - Extend `ChatCompletionRequestBuilder` with the `with_context_window` method.
  - Extend `RagChatCompletionsRequest` with the `context_window` field.
  - Extend `RagChatCompletionRequestBuilder` with the `with_context_window` method.
  - Support implicit conversion from `String` to `InputText`