### PR TITLE
Added the options.ctx_size from the command line arguments...

### DIFF
--- a/llama-simple/src/main.rs
+++ b/llama-simple/src/main.rs
@@ -101,6 +101,7 @@ fn main() -> Result<(), String> {
         .set(*ctx_size as usize * 6)
         .expect("Fail to parse prompt context size");
     println!("[INFO] prompt context size: {size}", size = ctx_size);
+    options.ctx_size = *ctx_size as u64;
 
     // number of tokens to predict
     let n_predict = matches.get_one::<u32>("n_predict").unwrap();


### PR DESCRIPTION
I was getting out memory messages when using this model:
`meta-llama-3.1-8b-instruct-q5_k_m.gguf`

This model should run on my machine without a problem since I have 64 GB of RAM and 2 RTX 3080 and the requirement is 32GB. I tried tweaking the command line to find a set of arguments that would allow me to run this model on my machine. I always got the same output:

```
[INFO] prompt context size: 1024
[INFO] Number of tokens to predict: 1024
[INFO] Number of layers to run on the GPU: 100
[INFO] no mmap: false
[INFO] Batch size for prompt processing: 1024
[INFO] Log enable: true
....
2024-11-28 08:24:54.024] [info] [WASI-NN] llama.cpp: llama_new_context_with_model: n_ctx      = 131072
[2024-11-28 08:24:54.024] [info] [WASI-NN] llama.cpp: llama_new_context_with_model: n_batch    = 1024
[2024-11-28 08:24:54.024] [info] [WASI-NN] llama.cpp: llama_new_context_with_model: n_ubatch   = 1024
[2024-11-28 08:24:54.024] [info] [WASI-NN] llama.cpp: llama_new_context_with_model: flash_attn = 0
[2024-11-28 08:24:54.024] [info] [WASI-NN] llama.cpp: llama_new_context_with_model: freq_base  = 500000.0
[2024-11-28 08:24:54.024] [info] [WASI-NN] llama.cpp: llama_new_context_with_model: freq_scale = 1
[2024-11-28 08:24:54.028] [error] [WASI-NN] llama.cpp: ggml_backend_cuda_buffer_type_alloc_buffer: allocating 8192.00 MiB on device 0: cudaMalloc failed: out of memory
[2024-11-28 08:24:54.028] [error] [WASI-NN] llama.cpp: llama_kv_cache_init: failed to allocate buffer for kv cache
[2024-11-28 08:24:54.028] [error] [WASI-NN] llama.cpp: llama_new_context_with_model: llama_kv_cache_init() failed for self-attention cache
```

You can see that the n_ctx from llama.cpp is `131072` even though I set `1024`.

When looking through the llama-simple app I noticed that the `options.ctx_size` was not being set, and when serializing ctx_size was 0.