### PR TITLE
Release 0.15.0

### DIFF
--- a/.github/workflows/test_api_server.yml
+++ b/.github/workflows/test_api_server.yml
@@ -195,6 +195,22 @@ jobs:
         run: |
           pkill -f wasmedge
 
+      - name: Start llama-api-server for testing `--config` CLI option
+        run: |
+          curl -LO https://huggingface.co/second-state/Qwen2-1.5B-Instruct-GGUF/resolve/main/Qwen2-1.5B-Instruct-Q3_K_M.gguf
+          cp ./tests/assets/config.yaml ./config.yaml
+          nohup $HOME/.wasmedge/bin/wasmedge --dir .:. --nn-preload default:GGML:AUTO:Qwen2-1.5B-Instruct-Q3_K_M.gguf llama-api-server.wasm --config config.yaml > ./start-llamaedge.log 2>&1 &
+          sleep 15
+          cat start-llamaedge.log
+
+      - name: Run test_chat.hurl
+        run: |
+          hurl --test --jobs 1 ./tests/test_chat.hurl
+
+      - name: Stop llama-api-server for testing chat completions
+        run: |
+          pkill -f wasmedge
+
   test-api-server-macos-14:
     runs-on: macos-14
     needs: test-api-server-macos-13
@@ -273,6 +289,22 @@ jobs:
         run: |
           pkill -f wasmedge
 
+      - name: Start llama-api-server for testing `--config` CLI option
+        run: |
+          curl -LO https://huggingface.co/second-state/Qwen2-1.5B-Instruct-GGUF/resolve/main/Qwen2-1.5B-Instruct-Q3_K_M.gguf
+          cp ./tests/assets/config.yaml ./config.yaml
+          nohup $HOME/.wasmedge/bin/wasmedge --dir .:. --nn-preload default:GGML:AUTO:Qwen2-1.5B-Instruct-Q3_K_M.gguf llama-api-server.wasm --config config.yaml > ./start-llamaedge.log 2>&1 &
+          sleep 15
+          cat start-llamaedge.log
+
+      - name: Run test_chat.hurl
+        run: |
+          hurl --test --jobs 1 ./tests/test_chat.hurl
+
+      - name: Stop llama-api-server for testing chat completions
+        run: |
+          pkill -f wasmedge
+
   test-api-server-macos-15:
     runs-on: macos-15
     needs: test-api-server-macos-14
@@ -346,6 +378,22 @@ jobs:
       - name: Run test_embeddings.hurl
         run: |
           hurl --test --jobs 1 ./tests/test_embeddings.hurl
+
+      - name: Stop llama-api-server for testing chat completions
+        run: |
+          pkill -f wasmedge
+
+      - name: Start llama-api-server for testing `--config` CLI option
+        run: |
+          curl -LO https://huggingface.co/second-state/Qwen2-1.5B-Instruct-GGUF/resolve/main/Qwen2-1.5B-Instruct-Q3_K_M.gguf
+          cp ./tests/assets/config.yaml ./config.yaml
+          nohup $HOME/.wasmedge/bin/wasmedge --dir .:. --nn-preload default:GGML:AUTO:Qwen2-1.5B-Instruct-Q3_K_M.gguf llama-api-server.wasm --config config.yaml > ./start-llamaedge.log 2>&1 &
+          sleep 15
+          cat start-llamaedge.log
+
+      - name: Run test_chat.hurl
+        run: |
+          hurl --test --jobs 1 ./tests/test_chat.hurl
 
       - name: Stop llama-api-server for testing chat completions
         run: |

--- a/.github/workflows/test_api_server.yml
+++ b/.github/workflows/test_api_server.yml
@@ -104,7 +104,8 @@ jobs:
       - name: Start llama-api-server for testing `--config` CLI option
         run: |
           curl -LO https://huggingface.co/second-state/Qwen2-1.5B-Instruct-GGUF/resolve/main/Qwen2-1.5B-Instruct-Q3_K_M.gguf
-          nohup $HOME/.wasmedge/bin/wasmedge --dir .:. --nn-preload default:GGML:AUTO:Qwen2-1.5B-Instruct-Q3_K_M.gguf llama-api-server.wasm --config ./tests/config.yaml > ./start-llamaedge.log 2>&1 &
+          cp ./tests/config.yaml ./config.yaml
+          nohup $HOME/.wasmedge/bin/wasmedge --dir .:. --nn-preload default:GGML:AUTO:Qwen2-1.5B-Instruct-Q3_K_M.gguf llama-api-server.wasm --config config.yaml > ./start-llamaedge.log 2>&1 &
           sleep 15
           cat start-llamaedge.log
 

--- a/.github/workflows/test_api_server.yml
+++ b/.github/workflows/test_api_server.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Start llama-api-server for testing `--config` CLI option
         run: |
           curl -LO https://huggingface.co/second-state/Qwen2-1.5B-Instruct-GGUF/resolve/main/Qwen2-1.5B-Instruct-Q3_K_M.gguf
-          cp ./tests/config.yaml ./config.yaml
+          cp ./tests/assets/config.yaml ./config.yaml
           nohup $HOME/.wasmedge/bin/wasmedge --dir .:. --nn-preload default:GGML:AUTO:Qwen2-1.5B-Instruct-Q3_K_M.gguf llama-api-server.wasm --config config.yaml > ./start-llamaedge.log 2>&1 &
           sleep 15
           cat start-llamaedge.log

--- a/.github/workflows/test_api_server.yml
+++ b/.github/workflows/test_api_server.yml
@@ -101,6 +101,21 @@ jobs:
         run: |
           pkill -f wasmedge
 
+      - name: Start llama-api-server for testing `--config` CLI option
+        run: |
+          curl -LO https://huggingface.co/second-state/Qwen2-1.5B-Instruct-GGUF/resolve/main/Qwen2-1.5B-Instruct-Q3_K_M.gguf
+          nohup $HOME/.wasmedge/bin/wasmedge --dir .:. --nn-preload default:GGML:AUTO:Qwen2-1.5B-Instruct-Q3_K_M.gguf llama-api-server.wasm --config ./tests/config.yaml > ./start-llamaedge.log 2>&1 &
+          sleep 15
+          cat start-llamaedge.log
+
+      - name: Run test_chat.hurl
+        run: |
+          hurl --test --jobs 1 ./tests/test_chat.hurl
+
+      - name: Stop llama-api-server for testing chat completions
+        run: |
+          pkill -f wasmedge
+
   test-api-server-macos-13:
     runs-on: macos-13
     needs: test-api-server-ubuntu

--- a/.github/workflows/test_api_server.yml
+++ b/.github/workflows/test_api_server.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         wasmedge_version: [0.14.1]
-        ggml_version: [b3651]
+        ggml_version: [b4273]
     steps:
       - name: Clone project
         id: checkout
@@ -107,7 +107,7 @@ jobs:
     strategy:
       matrix:
         wasmedge_version: [0.14.1]
-        ggml_version: [b3651]
+        ggml_version: [b4273]
     steps:
       - name: Clone project
         id: checkout
@@ -185,7 +185,7 @@ jobs:
     strategy:
       matrix:
         wasmedge_version: [0.14.1]
-        ggml_version: [b3651]
+        ggml_version: [b4273]
     steps:
       - name: Clone project
         id: checkout
@@ -263,7 +263,7 @@ jobs:
     strategy:
       matrix:
         wasmedge_version: [0.14.1]
-        ggml_version: [b3651]
+        ggml_version: [b4273]
     steps:
       - name: Clone project
         id: checkout

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-endpoints = { path = "crates/endpoints", version = "^0.21" }
+endpoints = { path = "crates/endpoints", version = "^0.22" }
 chat-prompts = { path = "crates/chat-prompts", version = "^0.18" }
 thiserror = "1"
 uuid = { version = "1.4", features = ["v4", "fast-rng", "macro-diagnostics"] }
@@ -21,7 +21,7 @@ log = { version = "0.4.21", features = ["std", "kv", "kv_serde"] }
 wasi-logger = { version = "0.1.2", features = ["kv"] }
 either = "1.12.0"
 base64 = "=0.22.1"
-llama-core = { path = "crates/llama-core", features = ["logging"], version = "^0.24" }
+llama-core = { path = "crates/llama-core", features = ["logging"], version = "^0.25" }
 tokio = { version = "^1.36", features = ["io-util", "fs", "net", "time", "rt", "macros"] }
 anyhow = "1"
 once_cell = "1.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-endpoints = { path = "crates/endpoints", version = "^0.19" }
+endpoints = { path = "crates/endpoints", version = "^0.20" }
 chat-prompts = { path = "crates/chat-prompts", version = "^0.18" }
 thiserror = "1"
 uuid = { version = "1.4", features = ["v4", "fast-rng", "macro-diagnostics"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-endpoints = { path = "crates/endpoints", version = "^0.20" }
+endpoints = { path = "crates/endpoints", version = "^0.21" }
 chat-prompts = { path = "crates/chat-prompts", version = "^0.18" }
 thiserror = "1"
 uuid = { version = "1.4", features = ["v4", "fast-rng", "macro-diagnostics"] }
@@ -21,7 +21,7 @@ log = { version = "0.4.21", features = ["std", "kv", "kv_serde"] }
 wasi-logger = { version = "0.1.2", features = ["kv"] }
 either = "1.12.0"
 base64 = "=0.22.1"
-llama-core = { path = "crates/llama-core", features = ["logging"], version = "^0.23" }
+llama-core = { path = "crates/llama-core", features = ["logging"], version = "^0.24" }
 tokio = { version = "^1.36", features = ["io-util", "fs", "net", "time", "rt", "macros"] }
 anyhow = "1"
 once_cell = "1.18"

--- a/crates/chat-prompts/Cargo.toml
+++ b/crates/chat-prompts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chat-prompts"
-version = "0.18.2"
+version = "0.18.3"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/chat-prompts/Cargo.toml
+++ b/crates/chat-prompts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chat-prompts"
-version = "0.18.1"
+version = "0.18.2"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/chat-prompts/Cargo.toml
+++ b/crates/chat-prompts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chat-prompts"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/chat-prompts/Cargo.toml
+++ b/crates/chat-prompts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chat-prompts"
-version = "0.18.3"
+version = "0.18.4"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/chat-prompts/src/chat/mod.rs
+++ b/crates/chat-prompts/src/chat/mod.rs
@@ -11,6 +11,7 @@ pub mod llama;
 pub mod mediatek;
 pub mod minicpm;
 pub mod mistral;
+pub mod moxin;
 pub mod nvidia;
 pub mod octopus;
 pub mod openchat;
@@ -35,6 +36,7 @@ use llama::*;
 use mediatek::BreezeInstructPrompt;
 use minicpm::*;
 use mistral::*;
+use moxin::*;
 use nvidia::{NemotronChatPrompt, NemotronToolPrompt};
 use octopus::*;
 use openchat::*;
@@ -102,6 +104,7 @@ pub enum ChatPrompt {
     FunctionaryV32ToolPrompt,
     FunctionaryV31ToolPrompt,
     MiniCPMVPrompt,
+    MoxinChatPrompt,
 }
 impl From<PromptTemplateType> for ChatPrompt {
     fn from(ty: PromptTemplateType) -> Self {
@@ -176,6 +179,7 @@ impl From<PromptTemplateType> for ChatPrompt {
                 ChatPrompt::FunctionaryV31ToolPrompt(FunctionaryV31ToolPrompt)
             }
             PromptTemplateType::MiniCPMV => ChatPrompt::MiniCPMVPrompt(MiniCPMVPrompt),
+            PromptTemplateType::MoxinChat => ChatPrompt::MoxinChatPrompt(MoxinChatPrompt),
             PromptTemplateType::Embedding => {
                 panic!("Embedding prompt template is not used for building chat prompts")
             }

--- a/crates/chat-prompts/src/chat/moxin.rs
+++ b/crates/chat-prompts/src/chat/moxin.rs
@@ -1,0 +1,118 @@
+use super::BuildChatPrompt;
+use crate::error::{PromptError, Result};
+use endpoints::chat::{
+    ChatCompletionAssistantMessage, ChatCompletionRequestMessage, ChatCompletionSystemMessage,
+    ChatCompletionUserMessage, ChatCompletionUserMessageContent, ContentPart,
+};
+
+/// Generate prompts for the `moxin-chat-7b` model.
+#[derive(Debug, Default, Clone)]
+pub struct MoxinChatPrompt;
+impl MoxinChatPrompt {
+    /// Create a system prompt from a chat completion request message.
+    fn create_system_prompt(&self, message: &ChatCompletionSystemMessage) -> String {
+        let content = message.content();
+        match content.is_empty() {
+            true => String::from(
+                "<s> [INST] You are an AI assistant. Answer questions as concisely and accurately as possible.",
+            ),
+            false => format!("<s> [INST] {system_prompt}", system_prompt = content),
+        }
+    }
+
+    /// Create a user prompt from a chat completion request message.
+    fn append_user_message(
+        &self,
+        chat_history: impl AsRef<str>,
+        system_prompt: impl AsRef<str>,
+        message: &ChatCompletionUserMessage,
+    ) -> String {
+        let content = match message.content() {
+            ChatCompletionUserMessageContent::Text(text) => text.to_string(),
+            ChatCompletionUserMessageContent::Parts(parts) => {
+                let mut content = String::new();
+                for part in parts {
+                    if let ContentPart::Text(text_content) = part {
+                        content.push_str(text_content.text());
+                        content.push('\n');
+                    }
+                }
+                content
+            }
+        };
+
+        match chat_history.as_ref().is_empty() {
+            true => match system_prompt.as_ref().is_empty() {
+                true => {
+                    format!(
+                        "<s> [INST] {user_message} [/INST]",
+                        user_message = content.trim(),
+                    )
+                }
+                false => {
+                    format!(
+                        "{system_prompt}\n\n{user_message} [/INST]",
+                        system_prompt = system_prompt.as_ref().trim(),
+                        user_message = content.trim(),
+                    )
+                }
+            },
+            false => format!(
+                "{chat_history} [INST] {user_message} [/INST]",
+                chat_history = chat_history.as_ref().trim(),
+                user_message = content.trim(),
+            ),
+        }
+    }
+
+    /// create an assistant prompt from a chat completion request message.
+    fn append_assistant_message(
+        &self,
+        chat_history: impl AsRef<str>,
+        message: &ChatCompletionAssistantMessage,
+    ) -> Result<String> {
+        let content = match message.content() {
+            Some(content) => content.to_string(),
+            // Note that the content is optional if `tool_calls` is specified.
+            None => match message.tool_calls().is_some() {
+                true => String::new(),
+                false => return Err(PromptError::NoAssistantMessage),
+            },
+        };
+
+        Ok(format!(
+            "{chat_history} {assistant_message}</s>",
+            chat_history = chat_history.as_ref().trim(),
+            assistant_message = content.trim(),
+        ))
+    }
+}
+impl BuildChatPrompt for MoxinChatPrompt {
+    fn build(&self, messages: &mut Vec<ChatCompletionRequestMessage>) -> Result<String> {
+        if messages.is_empty() {
+            return Err(crate::error::PromptError::NoMessages);
+        }
+
+        // system prompt
+        let system_prompt = match messages[0] {
+            ChatCompletionRequestMessage::System(ref message) => self.create_system_prompt(message),
+            _ => String::from("<s> [INST] You are an AI assistant. Answer questions as concisely and accurately as possible."),
+        };
+
+        // append user/assistant messages
+        let mut prompt = String::new();
+        for message in messages {
+            match message {
+                ChatCompletionRequestMessage::User(message) => {
+                    prompt = self.append_user_message(&prompt, &system_prompt, message);
+                }
+                ChatCompletionRequestMessage::Assistant(message) => {
+                    prompt = self.append_assistant_message(&prompt, message)?;
+                }
+                _ => continue,
+            }
+        }
+
+        Ok(prompt)
+    }
+}

--- a/crates/chat-prompts/src/lib.rs
+++ b/crates/chat-prompts/src/lib.rs
@@ -93,6 +93,8 @@ pub enum PromptTemplateType {
     FunctionaryV31,
     #[value(name = "minicpmv")]
     MiniCPMV,
+    #[value(name = "moxin-chat")]
+    MoxinChat,
     #[value(name = "embedding")]
     Embedding,
     #[value(name = "none")]
@@ -125,7 +127,8 @@ impl PromptTemplateType {
             | PromptTemplateType::DeepseekChat25
             | PromptTemplateType::NemotronChat
             | PromptTemplateType::NemotronTool
-            | PromptTemplateType::MiniCPMV => true,
+            | PromptTemplateType::MiniCPMV
+            | PromptTemplateType::MoxinChat => true,
             PromptTemplateType::MistralInstruct
             | PromptTemplateType::MistralTool
             | PromptTemplateType::MistralLite
@@ -192,6 +195,7 @@ impl FromStr for PromptTemplateType {
             "functionary-32" => Ok(PromptTemplateType::FunctionaryV32),
             "functionary-31" => Ok(PromptTemplateType::FunctionaryV31),
             "minicpmv" => Ok(PromptTemplateType::MiniCPMV),
+            "moxin-chat" => Ok(PromptTemplateType::MoxinChat),
             "embedding" => Ok(PromptTemplateType::Embedding),
             "none" => Ok(PromptTemplateType::Null),
             _ => Err(error::PromptError::UnknownPromptTemplateType(
@@ -243,6 +247,7 @@ impl std::fmt::Display for PromptTemplateType {
             PromptTemplateType::FunctionaryV32 => write!(f, "functionary-32"),
             PromptTemplateType::FunctionaryV31 => write!(f, "functionary-31"),
             PromptTemplateType::MiniCPMV => write!(f, "minicpmv"),
+            PromptTemplateType::MoxinChat => write!(f, "moxin-chat"),
             PromptTemplateType::Embedding => write!(f, "embedding"),
             PromptTemplateType::Null => write!(f, "none"),
         }

--- a/crates/endpoints/Cargo.toml
+++ b/crates/endpoints/Cargo.toml
@@ -20,6 +20,7 @@ serde_json.workspace = true
 
 [features]
 default = []
+full = ["rag", "whisper"]
 rag = []
 whisper = []
 

--- a/crates/endpoints/Cargo.toml
+++ b/crates/endpoints/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endpoints"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/endpoints/Cargo.toml
+++ b/crates/endpoints/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endpoints"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/endpoints/Cargo.toml
+++ b/crates/endpoints/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endpoints"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/endpoints/Cargo.toml
+++ b/crates/endpoints/Cargo.toml
@@ -21,6 +21,7 @@ serde_json.workspace = true
 [features]
 default = []
 rag = []
+whisper = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/endpoints/src/audio/mod.rs
+++ b/crates/endpoints/src/audio/mod.rs
@@ -1,5 +1,9 @@
 //! Define types for turning audio into text or text into audio.
 
 pub mod speech;
+#[cfg(feature = "whisper")]
+#[cfg_attr(docsrs, doc(cfg(feature = "whisper")))]
 pub mod transcription;
+#[cfg(feature = "whisper")]
+#[cfg_attr(docsrs, doc(cfg(feature = "whisper")))]
 pub mod translation;

--- a/crates/endpoints/src/embeddings.rs
+++ b/crates/endpoints/src/embeddings.rs
@@ -23,15 +23,18 @@ pub struct EmbeddingRequest {
 
     /// The URL of the VectorDB server.
     #[cfg(feature = "rag")]
-    #[serde(rename = "url_vdb_server", skip_serializing_if = "Option::is_none")]
-    pub qdrant_url: Option<String>,
+    #[serde(rename = "vdb_server_url", skip_serializing_if = "Option::is_none")]
+    pub vdb_server_url: Option<String>,
     /// The name of the collection in VectorDB.
     #[cfg(feature = "rag")]
-    #[serde(rename = "collection_name", skip_serializing_if = "Option::is_none")]
-    pub qdrant_collection_name: Option<String>,
+    #[serde(
+        rename = "vdb_collection_name",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub vdb_collection_name: Option<String>,
     /// The API key for the VectorDB server.
     #[cfg(feature = "rag")]
-    #[serde(rename = "api_key", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "vdb_api_key", skip_serializing_if = "Option::is_none")]
     pub vdb_api_key: Option<String>,
 }
 
@@ -43,9 +46,9 @@ fn test_embedding_serialize_embedding_request() {
         encoding_format: None,
         user: None,
         #[cfg(feature = "rag")]
-        qdrant_url: None,
+        vdb_server_url: None,
         #[cfg(feature = "rag")]
-        qdrant_collection_name: None,
+        vdb_collection_name: None,
         #[cfg(feature = "rag")]
         vdb_api_key: None,
     };
@@ -61,9 +64,9 @@ fn test_embedding_serialize_embedding_request() {
         encoding_format: None,
         user: None,
         #[cfg(feature = "rag")]
-        qdrant_url: None,
+        vdb_server_url: None,
         #[cfg(feature = "rag")]
-        qdrant_collection_name: None,
+        vdb_collection_name: None,
         #[cfg(feature = "rag")]
         vdb_api_key: None,
     };
@@ -99,6 +102,12 @@ fn test_embedding_deserialize_embedding_request() {
     );
     assert_eq!(embedding_request.encoding_format, None);
     assert_eq!(embedding_request.user, None);
+    #[cfg(feature = "rag")]
+    assert_eq!(embedding_request.vdb_server_url, None);
+    #[cfg(feature = "rag")]
+    assert_eq!(embedding_request.vdb_collection_name, None);
+    #[cfg(feature = "rag")]
+    assert_eq!(embedding_request.vdb_api_key, None);
 }
 
 /// Defines the input text for the embedding request.

--- a/crates/endpoints/src/embeddings.rs
+++ b/crates/endpoints/src/embeddings.rs
@@ -29,6 +29,10 @@ pub struct EmbeddingRequest {
     #[cfg(feature = "rag")]
     #[serde(rename = "collection_name", skip_serializing_if = "Option::is_none")]
     pub qdrant_collection_name: Option<String>,
+    /// The API key for the VectorDB server.
+    #[cfg(feature = "rag")]
+    #[serde(rename = "api_key", skip_serializing_if = "Option::is_none")]
+    pub vdb_api_key: Option<String>,
 }
 
 #[test]
@@ -42,6 +46,8 @@ fn test_embedding_serialize_embedding_request() {
         qdrant_url: None,
         #[cfg(feature = "rag")]
         qdrant_collection_name: None,
+        #[cfg(feature = "rag")]
+        vdb_api_key: None,
     };
     let serialized = serde_json::to_string(&embedding_request).unwrap();
     assert_eq!(
@@ -58,6 +64,8 @@ fn test_embedding_serialize_embedding_request() {
         qdrant_url: None,
         #[cfg(feature = "rag")]
         qdrant_collection_name: None,
+        #[cfg(feature = "rag")]
+        vdb_api_key: None,
     };
     let serialized = serde_json::to_string(&embedding_request).unwrap();
     assert_eq!(

--- a/crates/llama-core/Cargo.toml
+++ b/crates/llama-core/Cargo.toml
@@ -20,7 +20,7 @@ uuid.workspace = true
 once_cell.workspace = true
 futures.workspace = true
 reqwest.workspace = true
-qdrant = { package = "qdrant_rest_client", version = "0.1.2", optional = true }
+qdrant = { package = "qdrant_rest_client", version = "0.1.3", git = "https://github.com/second-state/qdrant-rest-client.git", branch = "main", optional = true }
 text-splitter = { version = "^0.7", features = ["tiktoken-rs", "markdown"] }
 tiktoken-rs = "^0.5"
 wasi-logger = { workspace = true, optional = true }

--- a/crates/llama-core/Cargo.toml
+++ b/crates/llama-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-core"
-version = "0.24.0"
+version = "0.24.1"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/llama-core/Cargo.toml
+++ b/crates/llama-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-core"
-version = "0.23.3"
+version = "0.23.4"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/llama-core/Cargo.toml
+++ b/crates/llama-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-core"
-version = "0.25.0"
+version = "0.25.1"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/llama-core/Cargo.toml
+++ b/crates/llama-core/Cargo.toml
@@ -36,10 +36,11 @@ ignored = ["wasi-logger"]
 
 [features]
 default = []
-full = ["logging", "search", "rag"]
+full = ["logging", "search", "rag", "whisper"]
 logging = ["wasi-logger", "log"]
 search = []
 rag = ["endpoints/rag", "qdrant"]
+whisper = ["endpoints/whisper"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/llama-core/Cargo.toml
+++ b/crates/llama-core/Cargo.toml
@@ -20,7 +20,7 @@ uuid.workspace = true
 once_cell.workspace = true
 futures.workspace = true
 reqwest.workspace = true
-qdrant = { package = "qdrant_rest_client", version = "0.1.3", git = "https://github.com/second-state/qdrant-rest-client.git", branch = "main", optional = true }
+qdrant = { package = "qdrant_rest_client", version = "0.1.4", git = "https://github.com/second-state/qdrant-rest-client.git", branch = "main", optional = true }
 text-splitter = { version = "^0.7", features = ["tiktoken-rs", "markdown"] }
 tiktoken-rs = "^0.5"
 wasi-logger = { workspace = true, optional = true }

--- a/crates/llama-core/Cargo.toml
+++ b/crates/llama-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-core"
-version = "0.23.4"
+version = "0.24.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/llama-core/Cargo.toml
+++ b/crates/llama-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-core"
-version = "0.24.1"
+version = "0.25.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/llama-core/src/audio.rs
+++ b/crates/llama-core/src/audio.rs
@@ -48,18 +48,17 @@ pub async fn audio_transcriptions(
     // check if the model metadata should be updated
     {
         let mut should_update = false;
-        let mut metadata = graph.metadata.clone();
 
         #[cfg(feature = "logging")]
-        info!(target: "stdout", "current metadata: {:?}", &metadata);
+        info!(target: "stdout", "current metadata: {:?}", &graph.metadata);
 
         #[cfg(feature = "logging")]
         info!(target: "stdout", "Check model metadata.");
 
         // check `translate` field
-        if metadata.translate {
+        if graph.metadata.translate {
             // update the metadata
-            metadata.translate = false;
+            graph.metadata.translate = false;
 
             if !should_update {
                 should_update = true;
@@ -68,9 +67,9 @@ pub async fn audio_transcriptions(
 
         // check `language` field
         if let Some(language) = &request.language {
-            if *language != metadata.language {
+            if *language != graph.metadata.language {
                 // update the metadata
-                metadata.language = language.clone();
+                graph.metadata.language = language.clone();
 
                 if !should_update {
                     should_update = true;
@@ -80,9 +79,9 @@ pub async fn audio_transcriptions(
 
         // check `detect_language` field
         if let Some(detect_language) = &request.detect_language {
-            if *detect_language != metadata.detect_language {
+            if *detect_language != graph.metadata.detect_language {
                 // update the metadata
-                metadata.detect_language = *detect_language;
+                graph.metadata.detect_language = *detect_language;
 
                 if !should_update {
                     should_update = true;
@@ -92,9 +91,9 @@ pub async fn audio_transcriptions(
 
         // check `offset_time` field
         if let Some(offset_time) = &request.offset_time {
-            if *offset_time != metadata.offset_time {
+            if *offset_time != graph.metadata.offset_time {
                 // update the metadata
-                metadata.offset_time = *offset_time;
+                graph.metadata.offset_time = *offset_time;
 
                 if !should_update {
                     should_update = true;
@@ -104,9 +103,9 @@ pub async fn audio_transcriptions(
 
         // check `duration` field
         if let Some(duration) = &request.duration {
-            if *duration != metadata.duration {
+            if *duration != graph.metadata.duration {
                 // update the metadata
-                metadata.duration = *duration;
+                graph.metadata.duration = *duration;
 
                 if !should_update {
                     should_update = true;
@@ -116,9 +115,9 @@ pub async fn audio_transcriptions(
 
         // check `max_context` field
         if let Some(max_context) = &request.max_context {
-            if *max_context != metadata.max_context {
+            if *max_context != graph.metadata.max_context {
                 // update the metadata
-                metadata.max_context = *max_context;
+                graph.metadata.max_context = *max_context;
 
                 if !should_update {
                     should_update = true;
@@ -128,9 +127,9 @@ pub async fn audio_transcriptions(
 
         // check `max_len` field
         if let Some(max_len) = &request.max_len {
-            if *max_len != metadata.max_len {
+            if *max_len != graph.metadata.max_len {
                 // update the metadata
-                metadata.max_len = *max_len;
+                graph.metadata.max_len = *max_len;
 
                 if !should_update {
                     should_update = true;
@@ -140,9 +139,9 @@ pub async fn audio_transcriptions(
 
         // check `temperature` field
         if let Some(temperature) = &request.temperature {
-            if *temperature != metadata.temperature {
+            if *temperature != graph.metadata.temperature {
                 // update the metadata
-                metadata.temperature = *temperature;
+                graph.metadata.temperature = *temperature;
 
                 if !should_update {
                     should_update = true;
@@ -152,9 +151,9 @@ pub async fn audio_transcriptions(
 
         // check `split_on_word` field
         if let Some(split_on_word) = &request.split_on_word {
-            if *split_on_word != metadata.split_on_word {
+            if *split_on_word != graph.metadata.split_on_word {
                 // update the metadata
-                metadata.split_on_word = *split_on_word;
+                graph.metadata.split_on_word = *split_on_word;
 
                 if !should_update {
                     should_update = true;
@@ -164,9 +163,9 @@ pub async fn audio_transcriptions(
 
         // check `prompt` field
         if let Some(prompt) = &request.prompt {
-            if *prompt != metadata.prompt {
+            if *prompt != graph.metadata.prompt {
                 // update the metadata
-                metadata.prompt = prompt.clone();
+                graph.metadata.prompt = prompt.clone();
 
                 if !should_update {
                     should_update = true;
@@ -175,13 +174,13 @@ pub async fn audio_transcriptions(
         }
 
         #[cfg(feature = "logging")]
-        info!(target: "stdout", "metadata: {:?}", &metadata);
+        info!(target: "stdout", "metadata: {:?}", &graph.metadata);
 
         if should_update {
             #[cfg(feature = "logging")]
             info!(target: "stdout", "Set the metadata to the model.");
 
-            match serde_json::to_string(&metadata) {
+            match serde_json::to_string(&graph.metadata) {
                 Ok(config) => {
                     // update metadata
                     set_tensor_data(&mut graph, 1, config.as_bytes(), [1])?;
@@ -341,15 +340,16 @@ pub async fn audio_translations(
     // check if the model metadata should be updated
     {
         let mut should_update = false;
-        let mut metadata = graph.metadata.clone();
+
+        #[cfg(feature = "logging")]
+        info!(target: "stdout", "current metadata: {:?}", &graph.metadata);
 
         #[cfg(feature = "logging")]
         info!(target: "stdout", "Check model metadata.");
 
         // check `translate` field
-        if !metadata.translate {
-            // update the metadata
-            metadata.translate = true;
+        if !graph.metadata.translate {
+            graph.metadata.translate = true;
 
             if !should_update {
                 should_update = true;
@@ -358,9 +358,8 @@ pub async fn audio_translations(
 
         // check `language` field
         if let Some(language) = &request.language {
-            if *language != metadata.language {
-                // update the metadata
-                metadata.language = language.clone();
+            if *language != graph.metadata.language {
+                graph.metadata.language = language.clone();
 
                 if !should_update {
                     should_update = true;
@@ -370,9 +369,8 @@ pub async fn audio_translations(
 
         // check `detect_language` field
         if let Some(detect_language) = &request.detect_language {
-            if *detect_language != metadata.detect_language {
-                // update the metadata
-                metadata.detect_language = *detect_language;
+            if *detect_language != graph.metadata.detect_language {
+                graph.metadata.detect_language = *detect_language;
 
                 if !should_update {
                     should_update = true;
@@ -382,9 +380,9 @@ pub async fn audio_translations(
 
         // check `offset_time` field
         if let Some(offset_time) = &request.offset_time {
-            if *offset_time != metadata.offset_time {
+            if *offset_time != graph.metadata.offset_time {
                 // update the metadata
-                metadata.offset_time = *offset_time;
+                graph.metadata.offset_time = *offset_time;
 
                 if !should_update {
                     should_update = true;
@@ -394,9 +392,8 @@ pub async fn audio_translations(
 
         // check `duration` field
         if let Some(duration) = &request.duration {
-            if *duration != metadata.duration {
-                // update the metadata
-                metadata.duration = *duration;
+            if *duration != graph.metadata.duration {
+                graph.metadata.duration = *duration;
 
                 if !should_update {
                     should_update = true;
@@ -406,9 +403,8 @@ pub async fn audio_translations(
 
         // check `max_context` field
         if let Some(max_context) = &request.max_context {
-            if *max_context != metadata.max_context {
-                // update the metadata
-                metadata.max_context = *max_context;
+            if *max_context != graph.metadata.max_context {
+                graph.metadata.max_context = *max_context;
 
                 if !should_update {
                     should_update = true;
@@ -418,9 +414,8 @@ pub async fn audio_translations(
 
         // check `max_len` field
         if let Some(max_len) = &request.max_len {
-            if *max_len != metadata.max_len {
-                // update the metadata
-                metadata.max_len = *max_len;
+            if *max_len != graph.metadata.max_len {
+                graph.metadata.max_len = *max_len;
 
                 if !should_update {
                     should_update = true;
@@ -430,9 +425,8 @@ pub async fn audio_translations(
 
         // check `temperature` field
         if let Some(temperature) = &request.temperature {
-            if *temperature != metadata.temperature {
-                // update the metadata
-                metadata.temperature = *temperature;
+            if *temperature != graph.metadata.temperature {
+                graph.metadata.temperature = *temperature;
 
                 if !should_update {
                     should_update = true;
@@ -442,9 +436,8 @@ pub async fn audio_translations(
 
         // check `split_on_word` field
         if let Some(split_on_word) = &request.split_on_word {
-            if *split_on_word != metadata.split_on_word {
-                // update the metadata
-                metadata.split_on_word = *split_on_word;
+            if *split_on_word != graph.metadata.split_on_word {
+                graph.metadata.split_on_word = *split_on_word;
 
                 if !should_update {
                     should_update = true;
@@ -454,9 +447,8 @@ pub async fn audio_translations(
 
         // check `prompt` field
         if let Some(prompt) = &request.prompt {
-            if *prompt != metadata.prompt {
-                // update the metadata
-                metadata.prompt = prompt.clone();
+            if *prompt != graph.metadata.prompt {
+                graph.metadata.prompt = prompt.clone();
 
                 if !should_update {
                     should_update = true;
@@ -465,13 +457,13 @@ pub async fn audio_translations(
         }
 
         #[cfg(feature = "logging")]
-        info!(target: "stdout", "metadata: {:?}", &metadata);
+        info!(target: "stdout", "metadata: {:?}", &graph.metadata);
 
         if should_update {
             #[cfg(feature = "logging")]
             info!(target: "stdout", "Set the metadata to the model.");
 
-            match serde_json::to_string(&metadata) {
+            match serde_json::to_string(&graph.metadata) {
                 Ok(config) => {
                     // update metadata
                     set_tensor_data(&mut graph, 1, config.as_bytes(), [1])?;

--- a/crates/llama-core/src/chat.rs
+++ b/crates/llama-core/src/chat.rs
@@ -1971,7 +1971,11 @@ fn post_process(
         } else {
             s.to_owned()
         }
-    } else if *template_ty == PromptTemplateType::Llama2Chat {
+    } else if *template_ty == PromptTemplateType::Llama2Chat
+        || *template_ty == PromptTemplateType::MoxinChat
+        || *template_ty == PromptTemplateType::NemotronTool
+        || *template_ty == PromptTemplateType::NemotronChat
+    {
         let s = output.as_ref().trim();
         if s.ends_with("</s>") {
             s.trim_end_matches("</s>").trim().to_owned()
@@ -1993,15 +1997,6 @@ fn post_process(
         let s = output.as_ref().trim();
         if s.ends_with("<|end|>") {
             s.trim_end_matches("<|end|>").trim().to_owned()
-        } else {
-            s.to_owned()
-        }
-    } else if *template_ty == PromptTemplateType::NemotronTool
-        || *template_ty == PromptTemplateType::NemotronChat
-    {
-        let s = output.as_ref().trim();
-        if s.ends_with("</s>") {
-            s.trim_end_matches("</s>").trim().to_owned()
         } else {
             s.to_owned()
         }

--- a/crates/llama-core/src/chat.rs
+++ b/crates/llama-core/src/chat.rs
@@ -1972,7 +1972,6 @@ fn post_process(
             s.to_owned()
         }
     } else if *template_ty == PromptTemplateType::Llama2Chat
-        || *template_ty == PromptTemplateType::MoxinChat
         || *template_ty == PromptTemplateType::NemotronTool
         || *template_ty == PromptTemplateType::NemotronChat
     {
@@ -2009,6 +2008,15 @@ fn post_process(
             s = s.trim_end_matches("<|eom_id|>").trim();
         }
         s.to_owned()
+    } else if *template_ty == PromptTemplateType::MoxinChat {
+        let s = output.as_ref().trim();
+        if s.ends_with("</s>") {
+            s.trim_end_matches("</s>").trim().to_owned()
+        } else if s.ends_with("[INST]") {
+            s.trim_end_matches("[INST]").trim().to_owned()
+        } else {
+            s.to_owned()
+        }
     } else {
         output.as_ref().trim().to_owned()
     };

--- a/crates/llama-core/src/chat.rs
+++ b/crates/llama-core/src/chat.rs
@@ -798,12 +798,12 @@ fn compute_by_graph(
                         && graph.metadata.prompt_template != PromptTemplateType::FunctionaryV32
                         && graph.metadata.prompt_template != PromptTemplateType::FunctionaryV31
                     {
-                        let err_msg = "The tool use is only supported for 'mistral-tool', 'chatml', 'groq-llama3-tool', 'llama-3-tool', 'internlm-2-tool', 'nemotron-tool', 'functionary-31', and 'functionary-32' prompt templates.";
+                        let err_msg = format!("Unsupported prompt template: {}. The tool use is only supported for 'mistral-tool', 'chatml-tool', 'groq-llama3-tool', 'llama-3-tool', 'internlm-2-tool', 'nemotron-tool', 'functionary-31', and 'functionary-32' prompt templates.", graph.metadata.prompt_template);
 
                         #[cfg(feature = "logging")]
                         error!(target: "stdout", "{}", &err_msg);
 
-                        return Err(LlamaCoreError::Operation(err_msg.into()));
+                        return Err(LlamaCoreError::Operation(err_msg));
                     }
 
                     let parsed_result = parse_tool_calls(&message, graph.metadata.prompt_template)?;

--- a/crates/llama-core/src/files.rs
+++ b/crates/llama-core/src/files.rs
@@ -1,3 +1,5 @@
+//! Define APIs for file operations.
+
 use crate::{error::LlamaCoreError, ARCHIVES_DIR};
 use base64::{engine::general_purpose, Engine as _};
 use endpoints::files::{DeleteFileStatus, FileObject, ListFilesResponse};

--- a/crates/llama-core/src/lib.rs
+++ b/crates/llama-core/src/lib.rs
@@ -26,9 +26,9 @@ pub mod utils;
 
 pub use error::LlamaCoreError;
 pub use graph::{EngineType, Graph, GraphBuilder};
-pub use metadata::{
-    ggml::GgmlMetadata, piper::PiperMetadata, whisper::WhisperMetadata, BaseMetadata,
-};
+#[cfg(feature = "whisper")]
+use metadata::whisper::WhisperMetadata;
+pub use metadata::{ggml::GgmlMetadata, piper::PiperMetadata, BaseMetadata};
 
 use once_cell::sync::OnceCell;
 use std::{
@@ -54,6 +54,7 @@ pub(crate) static SD_TEXT_TO_IMAGE: OnceCell<Mutex<TextToImage>> = OnceCell::new
 // stable diffusion context for the image-to-image task
 pub(crate) static SD_IMAGE_TO_IMAGE: OnceCell<Mutex<ImageToImage>> = OnceCell::new();
 // context for the audio task
+#[cfg(feature = "whisper")]
 pub(crate) static AUDIO_GRAPH: OnceCell<Mutex<Graph<WhisperMetadata>>> = OnceCell::new();
 // context for the piper task
 pub(crate) static PIPER_GRAPH: OnceCell<Mutex<Graph<PiperMetadata>>> = OnceCell::new();
@@ -952,6 +953,7 @@ pub enum StableDiffusionTask {
 }
 
 /// Initialize the whisper context
+#[cfg(feature = "whisper")]
 pub fn init_whisper_context(whisper_metadata: &WhisperMetadata) -> Result<(), LlamaCoreError> {
     // create and initialize the audio context
     let graph = GraphBuilder::new(EngineType::Whisper)?

--- a/crates/llama-core/src/lib.rs
+++ b/crates/llama-core/src/lib.rs
@@ -62,6 +62,8 @@ pub(crate) static PIPER_GRAPH: OnceCell<Mutex<Graph<PiperMetadata>>> = OnceCell:
 pub(crate) const MAX_BUFFER_SIZE: usize = 2usize.pow(14) * 15 + 128;
 pub(crate) const OUTPUT_TENSOR: usize = 0;
 const PLUGIN_VERSION: usize = 1;
+
+/// The directory for storing the archives in wasm virtual file system.
 pub const ARCHIVES_DIR: &str = "archives";
 
 /// Initialize the ggml context

--- a/crates/llama-core/src/lib.rs
+++ b/crates/llama-core/src/lib.rs
@@ -966,8 +966,8 @@ pub fn init_whisper_context(whisper_metadata: &WhisperMetadata) -> Result<(), Ll
             #[cfg(feature = "logging")]
             info!(target: "stdout", "Re-initialize the audio context");
 
-            let mut locked_graph = match mutex_graph.lock() {
-                Ok(locked_graph) => locked_graph,
+            match mutex_graph.lock() {
+                Ok(mut locked_graph) => *locked_graph = graph,
                 Err(e) => {
                     let err_msg = format!("Failed to lock the graph. Reason: {}", e);
 
@@ -976,9 +976,7 @@ pub fn init_whisper_context(whisper_metadata: &WhisperMetadata) -> Result<(), Ll
 
                     return Err(LlamaCoreError::InitContext(err_msg));
                 }
-            };
-
-            *locked_graph = graph;
+            }
         }
         None => {
             #[cfg(feature = "logging")]

--- a/crates/llama-core/src/metadata/ggml.rs
+++ b/crates/llama-core/src/metadata/ggml.rs
@@ -1,3 +1,5 @@
+//! Define metadata for the ggml model.
+
 use super::BaseMetadata;
 use chat_prompts::PromptTemplateType;
 use serde::{Deserialize, Serialize};

--- a/crates/llama-core/src/metadata/mod.rs
+++ b/crates/llama-core/src/metadata/mod.rs
@@ -1,9 +1,12 @@
+//! Define the types for model metadata.
+
 pub mod ggml;
 pub mod piper;
 #[cfg(feature = "whisper")]
 #[cfg_attr(docsrs, doc(cfg(feature = "whisper")))]
 pub mod whisper;
 
+/// Base metadata trait
 pub trait BaseMetadata {
     fn model_name(&self) -> &str;
     fn model_alias(&self) -> &str;

--- a/crates/llama-core/src/metadata/mod.rs
+++ b/crates/llama-core/src/metadata/mod.rs
@@ -1,5 +1,7 @@
 pub mod ggml;
 pub mod piper;
+#[cfg(feature = "whisper")]
+#[cfg_attr(docsrs, doc(cfg(feature = "whisper")))]
 pub mod whisper;
 
 pub trait BaseMetadata {

--- a/crates/llama-core/src/metadata/piper.rs
+++ b/crates/llama-core/src/metadata/piper.rs
@@ -1,3 +1,5 @@
+//! Define metadata for the piper model.
+
 use super::BaseMetadata;
 use serde::{Deserialize, Serialize};
 

--- a/crates/llama-core/src/metadata/whisper.rs
+++ b/crates/llama-core/src/metadata/whisper.rs
@@ -1,3 +1,5 @@
+//! Define metadata for the whisper model.
+
 use super::BaseMetadata;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};

--- a/crates/llama-core/src/metadata/whisper.rs
+++ b/crates/llama-core/src/metadata/whisper.rs
@@ -1,5 +1,6 @@
 use super::BaseMetadata;
 use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
 
 /// The sample rate of the audio input
 pub const WHISPER_SAMPLE_RATE: usize = 16000;
@@ -18,6 +19,11 @@ impl WhisperMetadataBuilder {
         };
 
         Self { metadata }
+    }
+
+    pub fn with_model_path(mut self, model_path: impl AsRef<Path>) -> Self {
+        self.metadata.model_path = model_path.as_ref().to_path_buf();
+        self
     }
 
     pub fn enable_plugin_log(mut self, enable: bool) -> Self {
@@ -129,6 +135,9 @@ pub struct WhisperMetadata {
     // this field not defined for the beckend plugin
     #[serde(skip_serializing)]
     pub model_alias: String,
+    // path to the model file
+    #[serde(skip_serializing)]
+    pub model_path: PathBuf,
 
     #[serde(rename = "enable-log")]
     pub log_enable: bool,
@@ -185,6 +194,7 @@ impl Default for WhisperMetadata {
         Self {
             model_name: String::new(),
             model_alias: String::new(),
+            model_path: PathBuf::new(),
             log_enable: false,
             debug_log: false,
             threads: 4,

--- a/crates/llama-core/src/rag.rs
+++ b/crates/llama-core/src/rag.rs
@@ -36,7 +36,7 @@ pub async fn rag_doc_chunks_to_embeddings(
         return Err(LlamaCoreError::Operation(err_msg));
     }
 
-    let qdrant_url = match embedding_request.qdrant_url.as_deref() {
+    let qdrant_url = match embedding_request.vdb_server_url.as_deref() {
         Some(url) => url.to_string(),
         None => {
             let err_msg = "The VectorDB server URL is not provided.";
@@ -47,7 +47,7 @@ pub async fn rag_doc_chunks_to_embeddings(
             return Err(LlamaCoreError::Operation(err_msg.into()));
         }
     };
-    let qdrant_collection_name = match embedding_request.qdrant_collection_name.as_deref() {
+    let qdrant_collection_name = match embedding_request.vdb_collection_name.as_deref() {
         Some(name) => name.to_string(),
         None => {
             let err_msg = "The VectorDB collection name is not provided.";
@@ -74,6 +74,8 @@ pub async fn rag_doc_chunks_to_embeddings(
 
     // create a Qdrant client
     let mut qdrant_client = qdrant::Qdrant::new_with_url(qdrant_url);
+
+    // set the API key if provided
     if let Some(key) = embedding_request.vdb_api_key.as_deref() {
         if !key.is_empty() {
             #[cfg(feature = "logging")]
@@ -147,16 +149,17 @@ pub async fn rag_query_to_embeddings(
 /// * `score_threshold` - The minimum score of the retrieved results.
 pub async fn rag_retrieve_context(
     query_embedding: &[f32],
-    qdrant_url: impl AsRef<str>,
-    qdrant_collection_name: impl AsRef<str>,
+    vdb_server_url: impl AsRef<str>,
+    vdb_collection_name: impl AsRef<str>,
     limit: usize,
     score_threshold: Option<f32>,
+    vdb_api_key: Option<String>,
 ) -> Result<RetrieveObject, LlamaCoreError> {
     #[cfg(feature = "logging")]
     {
         info!(target: "stdout", "Retrieve context.");
 
-        info!(target: "stdout", "qdrant_url: {}, qdrant_collection_name: {}, limit: {}, score_threshold: {}", qdrant_url.as_ref(), qdrant_collection_name.as_ref(), limit, score_threshold.unwrap_or_default());
+        info!(target: "stdout", "qdrant_url: {}, qdrant_collection_name: {}, limit: {}, score_threshold: {}", vdb_server_url.as_ref(), vdb_collection_name.as_ref(), limit, score_threshold.unwrap_or_default());
     }
 
     let running_mode = running_mode()?;
@@ -173,12 +176,22 @@ pub async fn rag_retrieve_context(
     }
 
     // create a Qdrant client
-    let qdrant_client = qdrant::Qdrant::new_with_url(qdrant_url.as_ref().to_string());
+    let mut qdrant_client = qdrant::Qdrant::new_with_url(vdb_server_url.as_ref().to_string());
+
+    // set the API key if provided
+    if let Some(key) = vdb_api_key.as_deref() {
+        if !key.is_empty() {
+            #[cfg(feature = "logging")]
+            debug!(target: "stdout", "Set the API key for the VectorDB server.");
+
+            qdrant_client.set_api_key(key);
+        }
+    }
 
     // search for similar points
     let scored_points = match qdrant_search_similar_points(
         &qdrant_client,
-        qdrant_collection_name.as_ref(),
+        vdb_collection_name.as_ref(),
         query_embedding,
         limit,
         score_threshold,

--- a/crates/llama-core/src/rag.rs
+++ b/crates/llama-core/src/rag.rs
@@ -73,7 +73,15 @@ pub async fn rag_doc_chunks_to_embeddings(
     let dim = embeddings[0].embedding.len();
 
     // create a Qdrant client
-    let qdrant_client = qdrant::Qdrant::new_with_url(qdrant_url);
+    let mut qdrant_client = qdrant::Qdrant::new_with_url(qdrant_url);
+    if let Some(key) = embedding_request.vdb_api_key.as_deref() {
+        if !key.is_empty() {
+            #[cfg(feature = "logging")]
+            debug!(target: "stdout", "Set the API key for the VectorDB server.");
+
+            qdrant_client.set_api_key(key);
+        }
+    }
 
     // create a collection
     qdrant_create_collection(&qdrant_client, &qdrant_collection_name, dim).await?;

--- a/llama-api-server/Cargo.toml
+++ b/llama-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-api-server"
-version = "0.14.17"
+version = "0.15.0"
 edition = "2021"
 
 [dependencies]

--- a/llama-api-server/Cargo.toml
+++ b/llama-api-server/Cargo.toml
@@ -9,6 +9,7 @@ endpoints.workspace = true
 chat-prompts.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+serde_yaml = "^0.9"
 hyper = { version = "0.14", features = ["full"] }
 tokio.workspace = true
 thiserror.workspace = true

--- a/llama-api-server/README.md
+++ b/llama-api-server/README.md
@@ -622,7 +622,7 @@ If the Web UI is ready, you can navigate to `http://127.0.0.1:8080` to open the 
 You can set the log level of the API server by setting the `LLAMA_LOG` environment variable. For example, to set the log level to `debug`, you can run the following command:
 
 ```bash
-wasmedge --dir .:. --env RUST_LOG=debug \
+wasmedge --dir .:. --env LLAMA_LOG=debug \
     --nn-preload default:GGML:AUTO:Meta-Llama-3-8B-Instruct-Q5_K_M.gguf \
     llama-api-server.wasm \
     --model-name llama-3-8b \

--- a/llama-api-server/README.md
+++ b/llama-api-server/README.md
@@ -558,7 +558,7 @@ Options:
   -b, --batch-size <BATCH_SIZE>
           Sets batch sizes for chat and/or embedding models. To run both chat and embedding models, the sizes should be separated by comma without space, for example, '--batch-size 128,64'. The first value is for the chat model, and the second is for the embedding model [default: 512,512]
   -p, --prompt-template <PROMPT_TEMPLATE>
-          Sets prompt templates for chat and/or embedding models, respectively. To run both chat and embedding models, the prompt templates should be separated by comma without space, for example, '--prompt-template llama-2-chat,embedding'. The first value is for the chat model, and the second is for the embedding model [possible values: llama-2-chat, llama-3-chat, llama-3-tool, mistral-instruct, mistral-tool, mistrallite, openchat, codellama-instruct, codellama-super-instruct, human-assistant, vicuna-1.0-chat, vicuna-1.1-chat, vicuna-llava, chatml, chatml-tool, internlm-2-tool, baichuan-2, wizard-coder, zephyr, stablelm-zephyr, intel-neural, deepseek-chat, deepseek-coder, deepseek-chat-2, deepseek-chat-25, solar-instruct, phi-2-chat, phi-2-instruct, phi-3-chat, phi-3-instruct, gemma-instruct, octopus, glm-4-chat, groq-llama3-tool, mediatek-breeze, nemotron-chat, nemotron-tool, functionary-32, functionary-31, embedding, none]
+          Sets prompt templates for chat and/or embedding models, respectively. To run both chat and embedding models, the prompt templates should be separated by comma without space, for example, '--prompt-template llama-2-chat,embedding'. The first value is for the chat model, and the second is for the embedding model [possible values: llama-2-chat, llama-3-chat, llama-3-tool, mistral-instruct, mistral-tool, mistrallite, openchat, codellama-instruct, codellama-super-instruct, human-assistant, vicuna-1.0-chat, vicuna-1.1-chat, vicuna-llava, chatml, chatml-tool, internlm-2-tool, baichuan-2, wizard-coder, zephyr, stablelm-zephyr, intel-neural, deepseek-chat, deepseek-coder, deepseek-chat-2, deepseek-chat-25, solar-instruct, phi-2-chat, phi-2-instruct, phi-3-chat, phi-3-instruct, gemma-instruct, octopus, glm-4-chat, groq-llama3-tool, mediatek-breeze, nemotron-chat, nemotron-tool, functionary-32, functionary-31, minicpmv, embedding, none]
   -r, --reverse-prompt <REVERSE_PROMPT>
           Halt generation at PROMPT, return control
   -n, --n-predict <N_PREDICT>
@@ -586,13 +586,15 @@ Options:
       --grammar <GRAMMAR>
           BNF-like grammar to constrain generations (see samples in grammars/ dir) [default: ]
       --json-schema <JSON_SCHEMA>
-          JSON schema to constrain generations (https://json-schema.org/), e.g. `{}` for any JSON object. For schemas w/ external $refs, use --grammar + example/json_schema_to_grammar.py instead
+          JSON schema to constrain generations (<https://json-schema.org/>), e.g. `{}` for any JSON object. For schemas w/ external $refs, use --grammar + example/json_schema_to_grammar.py instead
       --llava-mmproj <LLAVA_MMPROJ>
           Path to the multimodal projector file
       --socket-addr <SOCKET_ADDR>
           Socket address of LlamaEdge API Server instance. For example, `0.0.0.0:8080`
       --port <PORT>
           Port number [default: 8080]
+      --config <CONFIG>
+          Path to the configuration file (*.yaml)
       --web-ui <WEB_UI>
           Root path for the Web UI files [default: chatbot-ui]
       --log-prompts

--- a/llama-api-server/src/main.rs
+++ b/llama-api-server/src/main.rs
@@ -18,8 +18,8 @@ use hyper::{
 };
 use llama_core::metadata::ggml::GgmlMetadataBuilder;
 use once_cell::sync::OnceCell;
-use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, net::SocketAddr, path::PathBuf};
+use serde::{de, Deserialize, Serialize};
+use std::{collections::HashMap, fs, net::SocketAddr, path::PathBuf};
 use tokio::net::TcpListener;
 use utils::LogLevel;
 
@@ -34,6 +34,7 @@ const DEFAULT_PORT: &str = "8080";
 #[derive(Debug, Parser)]
 #[command(name = "LlamaEdge API Server", version = env!("CARGO_PKG_VERSION"), author = env!("CARGO_PKG_AUTHORS"), about = "LlamaEdge API Server")]
 #[command(group = ArgGroup::new("socket_address_group").multiple(false).args(&["socket_addr", "port"]))]
+#[command(group = ArgGroup::new("config_group").multiple(false).args(&["config", "prompt_template"]))]
 struct Cli {
     /// Sets names for chat and/or embedding models. To run both chat and embedding models, the names should be separated by comma without space, for example, '--model-name Llama-2-7b,all-minilm'. The first value is for the chat model, and the second is for the embedding model.
     #[arg(short, long, value_delimiter = ',', default_value = "default")]
@@ -59,7 +60,7 @@ struct Cli {
     #[arg(short, long, value_delimiter = ',', default_value = "512,512", value_parser = clap::value_parser!(u64))]
     batch_size: Vec<u64>,
     /// Sets prompt templates for chat and/or embedding models, respectively. To run both chat and embedding models, the prompt templates should be separated by comma without space, for example, '--prompt-template llama-2-chat,embedding'. The first value is for the chat model, and the second is for the embedding model.
-    #[arg(short, long, value_delimiter = ',', value_parser = clap::value_parser!(PromptTemplateType), required = true)]
+    #[arg(short, long, value_delimiter = ',', value_parser = clap::value_parser!(PromptTemplateType), group = "config_group", required = true)]
     prompt_template: Vec<PromptTemplateType>,
     /// Halt generation at PROMPT, return control.
     #[arg(short, long)]
@@ -113,7 +114,7 @@ struct Cli {
     #[arg(long, default_value = DEFAULT_PORT, value_parser = clap::value_parser!(u16), group = "socket_address_group")]
     port: u16,
     /// Path to the configuration file (*.yaml)
-    #[arg(long)]
+    #[arg(long, group = "config_group")]
     config: Option<PathBuf>,
     /// Root path for the Web UI files
     #[arg(long, default_value = "chatbot-ui")]
@@ -129,44 +130,456 @@ struct Cli {
     log_all: bool,
 }
 
+#[derive(Debug)]
+struct CliConfig {
+    /// Sets names for chat and/or embedding models. To run both chat and embedding models, the names should be separated by comma without space, for example, '--model-name Llama-2-7b,all-minilm'. The first value is for the chat model, and the second is for the embedding model.
+    model_name: Vec<String>,
+    /// Model aliases for chat and embedding models
+    model_alias: Vec<String>,
+    /// Sets context sizes for chat and/or embedding models. To run both chat and embedding models, the sizes should be separated by comma without space, for example, '--ctx-size 4096,384'. The first value is for the chat model, and the second is for the embedding model.
+    ctx_size: Vec<u64>,
+    /// Sets batch sizes for chat and/or embedding models. To run both chat and embedding models, the sizes should be separated by comma without space, for example, '--batch-size 128,64'. The first value is for the chat model, and the second is for the embedding model.
+    batch_size: Vec<u64>,
+    /// Sets prompt templates for chat and/or embedding models, respectively. To run both chat and embedding models, the prompt templates should be separated by comma without space, for example, '--prompt-template llama-2-chat,embedding'. The first value is for the chat model, and the second is for the embedding model.
+    prompt_template: Vec<PromptTemplateType>,
+    /// Halt generation at PROMPT, return control.
+    reverse_prompt: Option<String>,
+    /// Number of tokens to predict
+    n_predict: u64,
+    /// Number of layers to run on the GPU
+    n_gpu_layers: u64,
+    /// The main GPU to use.
+    main_gpu: Option<u64>,
+    /// How split tensors should be distributed accross GPUs. If None the model is not split; otherwise, a comma-separated list of non-negative values, e.g., "3,2" presents 60% of the data to GPU 0 and 40% to GPU 1.
+    tensor_split: Option<String>,
+    /// Number of threads to use during computation
+    threads: u64,
+    /// Disable memory mapping for file access of chat models
+    no_mmap: bool,
+    /// Temperature for sampling
+    temp: f64,
+    /// An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. 1.0 = disabled
+    top_p: f64,
+    /// Penalize repeat sequence of tokens
+    repeat_penalty: f64,
+    /// Repeat alpha presence penalty. 0.0 = disabled
+    presence_penalty: f64,
+    /// Repeat alpha frequency penalty. 0.0 = disabled
+    frequency_penalty: f64,
+    /// BNF-like grammar to constrain generations (see samples in grammars/ dir).
+    grammar: Option<String>,
+    /// JSON schema to constrain generations (<https://json-schema.org/>), e.g. `{}` for any JSON object. For schemas w/ external $refs, use --grammar + example/json_schema_to_grammar.py instead.
+    json_schema: Option<String>,
+    /// Path to the multimodal projector file
+    llava_mmproj: Option<String>,
+    /// Socket address of LlamaEdge API Server instance. For example, `0.0.0.0:8080`.
+    socket_addr: Option<SocketAddr>,
+}
+impl<'de> Deserialize<'de> for CliConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(field_identifier, rename_all = "kebab-case")]
+        enum Field {
+            ModelName,
+            ModelAlias,
+            CtxSize,
+            BatchSize,
+            PromptTemplate,
+            ReversePrompt,
+            NPredict,
+            NGpuLayers,
+            MainGpu,
+            TensorSplit,
+            Threads,
+            NoMmap,
+            Temp,
+            TopP,
+            RepeatPenalty,
+            PresencePenalty,
+            FrequencyPenalty,
+            Grammar,
+            JsonSchema,
+            LlavaMmproj,
+            SocketAddr,
+        }
+
+        struct CliConfigVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for CliConfigVisitor {
+            type Value = CliConfig;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("struct CliConfig")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<CliConfig, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut model_name = None;
+                let mut model_alias = None;
+                let mut ctx_size = None;
+                let mut batch_size = None;
+                let mut prompt_template: Option<Vec<String>> = None;
+                let mut reverse_prompt = None;
+                let mut n_predict = None;
+                let mut n_gpu_layers = None;
+                let mut main_gpu = None;
+                let mut tensor_split = None;
+                let mut threads = None;
+                let mut no_mmap = None;
+                let mut temp = None;
+                let mut top_p = None;
+                let mut repeat_penalty = None;
+                let mut presence_penalty = None;
+                let mut frequency_penalty = None;
+                let mut grammar: Option<String> = None;
+                let mut json_schema = None;
+                let mut llava_mmproj = None;
+                let mut socket_addr: Option<SocketAddr> = None;
+
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::ModelName => {
+                            if model_name.is_some() {
+                                return Err(de::Error::duplicate_field("model-name"));
+                            }
+
+                            model_name = Some(map.next_value()?)
+                        }
+                        Field::ModelAlias => {
+                            if model_alias.is_some() {
+                                return Err(de::Error::duplicate_field("model-alias"));
+                            }
+
+                            model_alias = Some(map.next_value()?)
+                        }
+                        Field::CtxSize => {
+                            if ctx_size.is_some() {
+                                return Err(de::Error::duplicate_field("ctx-size"));
+                            }
+
+                            ctx_size = Some(map.next_value()?)
+                        }
+                        Field::BatchSize => {
+                            if batch_size.is_some() {
+                                return Err(de::Error::duplicate_field("batch-size"));
+                            }
+
+                            batch_size = Some(map.next_value()?)
+                        }
+                        Field::PromptTemplate => {
+                            if prompt_template.is_some() {
+                                return Err(de::Error::duplicate_field("prompt-template"));
+                            }
+
+                            prompt_template = Some(map.next_value()?);
+
+                            // ! debug
+                            debug!(target: "stdout", "prompt_template: {:?}", prompt_template);
+                        }
+                        Field::ReversePrompt => {
+                            if reverse_prompt.is_some() {
+                                return Err(de::Error::duplicate_field("reverse-prompt"));
+                            }
+
+                            reverse_prompt = Some(map.next_value()?)
+                        }
+                        Field::NPredict => {
+                            if n_predict.is_some() {
+                                return Err(de::Error::duplicate_field("n-predict"));
+                            }
+
+                            n_predict = Some(map.next_value()?)
+                        }
+                        Field::NGpuLayers => {
+                            if n_gpu_layers.is_some() {
+                                return Err(de::Error::duplicate_field("n-gpu-layers"));
+                            }
+
+                            n_gpu_layers = Some(map.next_value()?)
+                        }
+                        Field::MainGpu => {
+                            if main_gpu.is_some() {
+                                return Err(de::Error::duplicate_field("main-gpu"));
+                            }
+
+                            main_gpu = Some(map.next_value()?)
+                        }
+                        Field::TensorSplit => {
+                            if tensor_split.is_some() {
+                                return Err(de::Error::duplicate_field("tensor-split"));
+                            }
+
+                            tensor_split = Some(map.next_value()?)
+                        }
+                        Field::Threads => {
+                            if threads.is_some() {
+                                return Err(de::Error::duplicate_field("threads"));
+                            }
+
+                            threads = Some(map.next_value()?)
+                        }
+                        Field::NoMmap => {
+                            if no_mmap.is_some() {
+                                return Err(de::Error::duplicate_field("no-mmap"));
+                            }
+
+                            no_mmap = Some(map.next_value()?)
+                        }
+                        Field::Temp => {
+                            if temp.is_some() {
+                                return Err(de::Error::duplicate_field("temp"));
+                            }
+
+                            temp = Some(map.next_value()?)
+                        }
+                        Field::TopP => {
+                            if top_p.is_some() {
+                                return Err(de::Error::duplicate_field("top-p"));
+                            }
+
+                            top_p = Some(map.next_value()?)
+                        }
+                        Field::RepeatPenalty => {
+                            if repeat_penalty.is_some() {
+                                return Err(de::Error::duplicate_field("repeat-penalty"));
+                            }
+
+                            repeat_penalty = Some(map.next_value()?)
+                        }
+                        Field::PresencePenalty => {
+                            if presence_penalty.is_some() {
+                                return Err(de::Error::duplicate_field("presence-penalty"));
+                            }
+
+                            presence_penalty = Some(map.next_value()?)
+                        }
+                        Field::FrequencyPenalty => {
+                            if frequency_penalty.is_some() {
+                                return Err(de::Error::duplicate_field("frequency-penalty"));
+                            }
+
+                            frequency_penalty = Some(map.next_value()?)
+                        }
+                        Field::Grammar => {
+                            if grammar.is_some() {
+                                return Err(de::Error::duplicate_field("grammar"));
+                            }
+
+                            grammar = Some(map.next_value()?)
+                        }
+                        Field::JsonSchema => {
+                            if json_schema.is_some() {
+                                return Err(de::Error::duplicate_field("json-schema"));
+                            }
+
+                            json_schema = Some(map.next_value()?)
+                        }
+                        Field::LlavaMmproj => {
+                            if llava_mmproj.is_some() {
+                                return Err(de::Error::duplicate_field("llava-mmproj"));
+                            }
+
+                            llava_mmproj = Some(map.next_value()?)
+                        }
+                        Field::SocketAddr => {
+                            if socket_addr.is_some() {
+                                return Err(de::Error::duplicate_field("socket-addr"));
+                            }
+
+                            socket_addr = Some(map.next_value()?)
+                        }
+                    }
+                }
+
+                let model_name = model_name
+                    .unwrap_or_else(|| vec!["default".to_string(), "embedding".to_string()]);
+
+                let model_alias = model_alias
+                    .unwrap_or_else(|| vec!["default".to_string(), "embedding".to_string()]);
+
+                let ctx_size = ctx_size.unwrap_or_else(|| vec![4096, 384]);
+
+                let batch_size = batch_size.unwrap_or_else(|| vec![512, 512]);
+
+                let prompt_template: Vec<PromptTemplateType> = match prompt_template {
+                    Some(prompt_template) => {
+                        prompt_template.iter().map(|p| p.parse().unwrap()).collect()
+                    }
+                    None => return Err(de::Error::missing_field("prompt-template")),
+                };
+
+                let reverse_prompt = reverse_prompt.unwrap_or_default();
+
+                let n_predict = n_predict.unwrap_or(1024);
+
+                let n_gpu_layers = n_gpu_layers.unwrap_or(100);
+
+                let main_gpu = main_gpu.unwrap();
+
+                let tensor_split = tensor_split.unwrap();
+
+                let threads = threads.unwrap_or(2);
+
+                let no_mmap = no_mmap.unwrap();
+
+                let temp = temp.unwrap_or(1.0);
+
+                let top_p = top_p.unwrap_or(1.0);
+
+                let repeat_penalty = repeat_penalty.unwrap_or(1.1);
+
+                let presence_penalty = presence_penalty.unwrap_or(0.0);
+
+                let frequency_penalty = frequency_penalty.unwrap_or(0.0);
+
+                let json_schema = json_schema.unwrap();
+
+                let llava_mmproj = llava_mmproj.unwrap();
+
+                Ok(CliConfig {
+                    model_name,
+                    model_alias,
+                    ctx_size,
+                    batch_size,
+                    prompt_template,
+                    reverse_prompt,
+                    n_predict,
+                    n_gpu_layers,
+                    main_gpu,
+                    tensor_split,
+                    threads,
+                    no_mmap,
+                    temp,
+                    top_p,
+                    repeat_penalty,
+                    presence_penalty,
+                    frequency_penalty,
+                    grammar,
+                    json_schema,
+                    llava_mmproj,
+                    socket_addr,
+                })
+            }
+        }
+
+        const FIELDS: &[&str] = &[
+            "model-name",
+            "model-alias",
+            "ctx-size",
+            "batch-size",
+            "prompt-template",
+            "reverse-prompt",
+            "n-predict",
+            "n-gpu-layers",
+            "main-gpu",
+            "tensor-split",
+            "threads",
+            "no-mmap",
+            "temp",
+            "top-p",
+            "repeat-penalty",
+            "presence-penalty",
+            "frequency-penalty",
+            "grammar",
+            "json-schema",
+            "llava-mmproj",
+            "socket-addr",
+        ];
+
+        deserializer.deserialize_struct("CliConfig", FIELDS, CliConfigVisitor)
+    }
+}
+
 #[allow(clippy::needless_return)]
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), ServerError> {
     let mut plugin_debug = false;
 
-    // get the environment variable `RUST_LOG`
-    let rust_log = std::env::var("RUST_LOG").unwrap_or_default().to_lowercase();
-    let (_, log_level) = match rust_log.is_empty() {
-        true => ("stdout", LogLevel::Info),
-        false => match rust_log.split_once("=") {
-            Some((target, level)) => (target, level.parse().unwrap_or(LogLevel::Info)),
-            None => ("stdout", rust_log.parse().unwrap_or(LogLevel::Info)),
-        },
-    };
+    // get the environment variable `LLAMA_LOG`
+    let log_level: LogLevel = std::env::var("LLAMA_LOG")
+        .unwrap_or("info".to_string())
+        .parse()
+        .unwrap_or(LogLevel::Info);
 
     if log_level == LogLevel::Debug || log_level == LogLevel::Trace {
         plugin_debug = true;
     }
-
     // set global logger
     wasi_logger::Logger::install().expect("failed to install wasi_logger::Logger");
     log::set_max_level(log_level.into());
 
-    // parse the command line arguments
-    let cli = Cli::parse();
+    info!(target: "stdout", "log_level: {}", log_level);
 
-    // ! debug
-    {
-        if let Some(config_file) = &cli.config {
-            if config_file.exists() {
-                // check if the extension is yaml first; then read config settings
-                unimplemented!()
-            }
-        }
-    }
+    // parse the command line arguments
+    let mut cli = Cli::parse();
 
     // log the version of the server
     info!(target: "stdout", "server version: {}", env!("CARGO_PKG_VERSION"));
+
+    if let Some(config_file) = &cli.config {
+        match config_file.exists() {
+            true => {
+                let yaml_content = match fs::read_to_string(config_file) {
+                    Ok(yaml_content) => yaml_content,
+                    Err(e) => {
+                        let err_msg = format!("Failed to read config file: {}", e);
+
+                        error!(target: "stdout", "{}", err_msg);
+
+                        return Err(ServerError::Operation(err_msg));
+                    }
+                };
+
+                let config: CliConfig = match serde_yaml::from_str(&yaml_content) {
+                    Ok(config) => config,
+                    Err(e) => {
+                        let err_msg = format!("Failed to parse YAML: {}", e);
+
+                        error!(target: "stdout", "{}", err_msg);
+
+                        return Err(ServerError::Operation(err_msg));
+                    }
+                };
+
+                debug!(target: "stdout", "config: {:?}", &config);
+
+                // update the CLI arguments with the config file
+                cli.model_name = config.model_name;
+                cli.model_alias = config.model_alias;
+                cli.ctx_size = config.ctx_size;
+                cli.batch_size = config.batch_size;
+                cli.prompt_template = config.prompt_template;
+                cli.reverse_prompt = config.reverse_prompt;
+                cli.n_predict = config.n_predict;
+                cli.n_gpu_layers = config.n_gpu_layers;
+                cli.main_gpu = config.main_gpu;
+                cli.tensor_split = config.tensor_split;
+                cli.threads = config.threads;
+                cli.no_mmap = Some(config.no_mmap);
+                cli.temp = config.temp;
+                cli.top_p = config.top_p;
+                cli.repeat_penalty = config.repeat_penalty;
+                cli.presence_penalty = config.presence_penalty;
+                cli.frequency_penalty = config.frequency_penalty;
+                cli.grammar = config.grammar.unwrap_or_default();
+                cli.json_schema = config.json_schema;
+                cli.llava_mmproj = config.llava_mmproj;
+                cli.socket_addr = config.socket_addr;
+            }
+            false => {
+                let err_msg = format!("Config file not found: {}", config_file.display());
+
+                error!(target: "stdout", "{}", err_msg);
+
+                return Err(ServerError::Operation(err_msg));
+            }
+        }
+    }
 
     // log model names
     if cli.model_name.is_empty() && cli.model_name.len() > 2 {

--- a/llama-api-server/src/main.rs
+++ b/llama-api-server/src/main.rs
@@ -99,10 +99,10 @@ struct Cli {
     frequency_penalty: f64,
     /// BNF-like grammar to constrain generations (see samples in grammars/ dir).
     #[arg(long, default_value = "")]
-    pub grammar: String,
+    grammar: String,
     /// JSON schema to constrain generations (<https://json-schema.org/>), e.g. `{}` for any JSON object. For schemas w/ external $refs, use --grammar + example/json_schema_to_grammar.py instead.
     #[arg(long)]
-    pub json_schema: Option<String>,
+    json_schema: Option<String>,
     /// Path to the multimodal projector file
     #[arg(long)]
     llava_mmproj: Option<String>,
@@ -112,6 +112,9 @@ struct Cli {
     /// Port number
     #[arg(long, default_value = DEFAULT_PORT, value_parser = clap::value_parser!(u16), group = "socket_address_group")]
     port: u16,
+    /// Path to the configuration file (*.yaml)
+    #[arg(long)]
+    config: Option<PathBuf>,
     /// Root path for the Web UI files
     #[arg(long, default_value = "chatbot-ui")]
     web_ui: PathBuf,
@@ -151,6 +154,16 @@ async fn main() -> Result<(), ServerError> {
 
     // parse the command line arguments
     let cli = Cli::parse();
+
+    // ! debug
+    {
+        if let Some(config_file) = &cli.config {
+            if config_file.exists() {
+                // check if the extension is yaml first; then read config settings
+                unimplemented!()
+            }
+        }
+    }
 
     // log the version of the server
     info!(target: "stdout", "server version: {}", env!("CARGO_PKG_VERSION"));

--- a/llama-chat/Cargo.toml
+++ b/llama-chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-chat"
-version = "0.14.17"
+version = "0.15.0"
 edition = "2021"
 
 [dependencies]

--- a/llama-simple/Cargo.toml
+++ b/llama-simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-simple"
-version = "0.14.17"
+version = "0.15.0"
 edition = "2021"
 
 [dependencies]

--- a/llama-simple/src/main.rs
+++ b/llama-simple/src/main.rs
@@ -101,6 +101,7 @@ fn main() -> Result<(), String> {
         .set(*ctx_size as usize * 6)
         .expect("Fail to parse prompt context size");
     println!("[INFO] prompt context size: {size}", size = ctx_size);
+    options.ctx_size = *ctx_size as u64;
 
     // number of tokens to predict
     let n_predict = matches.get_one::<u32>("n_predict").unwrap();

--- a/tests/assets/config.yaml
+++ b/tests/assets/config.yaml
@@ -2,57 +2,59 @@
 
 # Model configuration
 
-# comma-separated list for chat and embedding models. Comma-separated list for chat and embedding models, for example, ["model_1","model_2"].
+# Comma-separated list for chat and embedding models: first for chat model, second for embedding model, for example, ["chat_model_name","embedding_model_name"].
 model-name: ["Qwen2-1.5B-Instruct"]
-# aliases for models. Comma-separated list for chat and embedding models, for example, ["default","embedding"].
+# Aliases for models. Comma-separated list for chat and embedding models: first for chat model, second for embedding model, for example, ["default","embedding"].
 model-alias: ["default"]
-# required, context sizes for models. Comma-separated list for chat and embedding models, for example, [4096,384].
+# Context sizes. Comma-separated list for chat and embedding models: first for chat model, second for embedding model, for example, [4096,384].
 ctx-size: [4096]
-# required,batch sizes for models. Comma-separated list for chat and embedding models, for example, [512,512].
+# Batch sizes. Comma-separated list for chat and embedding models: first for chat model, second for embedding model, for example, [512,512].
 batch-size: [512]
-# required, prompt templates for models. Comma-separated list for chat and embedding models, for example, ["llama-2-chat","embedding"].
+# Prompt templates. Comma-separated list for chat and embedding models: first for chat model, second for embedding model, for example, ["llama-2-chat","embedding"].
 prompt-template: ["chatml"]
-# optional halt generation prompt.
+# Optional. Halt generation prompt for chat model.
 reverse-prompt: null
 
-# Generation parameters
+# The following parameters are for chat model.
 
-# number of tokens to predict
+## Generation parameters
+
+# Number of tokens to predict
 n-predict: 1024
-# number of layers to run on GPU
+# Number of layers to run on GPU
 n-gpu-layers: 100
-# main GPU to use
+# Main GPU to use
 main-gpu: null
 # GPU tensor split ratio (e.g., "3,2")
 tensor-split: null
-# number of computation threads
+# Number of computation threads
 threads: 2
-# disable memory mapping for chat models
+# Disable memory mapping for chat models
 no-mmap: false
 
-# Sampling parameters
+## Sampling parameters
 
-# temperature for sampling
+# Temperature for sampling
 temp: 1.0
-# nucleus sampling threshold
+# Nucleus sampling threshold
 top-p: 1.0
-# penalty for repeated tokens
+# Penalty for repeated tokens
 repeat-penalty: 1.1
-# repeat alpha presence penalty
+# Repeat alpha presence penalty
 presence-penalty: 0.0
-# repeat alpha frequency penalty
+# Repeat alpha frequency penalty
 frequency-penalty: 0.0
 
-# Generation constraints
+## Generation constraints
 
 # BNF-like grammar for generation
 grammar: ""
 # JSON schema for generation constraints
 json-schema: null
-# path to multimodal projector file
+# Path to multimodal projector file
 llava-mmproj: null
 
-# Server configuration
+## Server configuration
 
-# socket address
+# Socket address
 socket-addr: "0.0.0.0:8080"

--- a/tests/assets/config.yaml
+++ b/tests/assets/config.yaml
@@ -1,0 +1,58 @@
+# This file is used to test the configuration of the LlamaEdge API Server.
+
+# Model configuration
+
+# comma-separated list for chat and embedding models. Comma-separated list for chat and embedding models, for example, ["model_1","model_2"].
+model-name: ["Qwen2-1.5B-Instruct"]
+# aliases for models. Comma-separated list for chat and embedding models, for example, ["default","embedding"].
+model-alias: ["default"]
+# required, context sizes for models. Comma-separated list for chat and embedding models, for example, [4096,384].
+ctx-size: [4096]
+# required,batch sizes for models. Comma-separated list for chat and embedding models, for example, [512,512].
+batch-size: [512]
+# required, prompt templates for models. Comma-separated list for chat and embedding models, for example, ["llama-2-chat","embedding"].
+prompt-template: ["chatml"]
+# optional halt generation prompt.
+reverse-prompt: null
+
+# Generation parameters
+
+# number of tokens to predict
+n-predict: 1024
+# number of layers to run on GPU
+n-gpu-layers: 100
+# main GPU to use
+main-gpu: null
+# GPU tensor split ratio (e.g., "3,2")
+tensor-split: null
+# number of computation threads
+threads: 2
+# disable memory mapping for chat models
+no-mmap: false
+
+# Sampling parameters
+
+# temperature for sampling
+temp: 1.0
+# nucleus sampling threshold
+top-p: 1.0
+# penalty for repeated tokens
+repeat-penalty: 1.1
+# repeat alpha presence penalty
+presence-penalty: 0.0
+# repeat alpha frequency penalty
+frequency-penalty: 0.0
+
+# Generation constraints
+
+# BNF-like grammar for generation
+grammar: ""
+# JSON schema for generation constraints
+json-schema: null
+# path to multimodal projector file
+llava-mmproj: null
+
+# Server configuration
+
+# socket address
+socket-addr: "0.0.0.0:8080"


### PR DESCRIPTION
Major changes:

- Support [moxin-chat-7b](https://huggingface.co/second-state/moxin-chat-7b-GGUF) model
- Add `--config` CLI option, which allows users to launch the llama-api-server through a YAML configuration file. 
- Upgrade dependencies: `llama-core v0.25.1`, `chat-prompts v0.18.4`, and `endpoints v0.22.0`
- Fixed the issue of setting `ctx_size` from the CLI option in `llama-simple` (by @aespinoza)