### PR TITLE
Release 0.15.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-endpoints = { path = "crates/endpoints", version = "^0.22" }
+endpoints = { path = "crates/endpoints", version = "^0.23" }
 chat-prompts = { path = "crates/chat-prompts", version = "^0.18" }
 thiserror = "1"
 uuid = { version = "1.4", features = ["v4", "fast-rng", "macro-diagnostics"] }

--- a/crates/chat-prompts/Cargo.toml
+++ b/crates/chat-prompts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chat-prompts"
-version = "0.18.4"
+version = "0.18.5"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/chat-prompts/README.md
+++ b/crates/chat-prompts/README.md
@@ -323,6 +323,16 @@ The available prompt templates are listed below:
 
   - Example: [second-state/Mistral-7B-Instruct-v0.3-GGUF](https://huggingface.co/second-state/Mistral-7B-Instruct-v0.3-GGUF)
 
+- `moxin-chat`
+
+  ```text
+  <s> [INST] {system_message}
+
+  {user_message_1} [/INST] {assistant_message_1}</s> [INST] {user_message_2} [/INST]
+  ```
+
+  - Example: [second-state/moxin-chat-7b-GGUF](https://huggingface.co/second-state/moxin-chat-7b-GGUF)
+
 - `nemotron-chat`
 
   ```text

--- a/crates/endpoints/Cargo.toml
+++ b/crates/endpoints/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endpoints"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/endpoints/src/audio/speech.rs
+++ b/crates/endpoints/src/audio/speech.rs
@@ -29,7 +29,7 @@ pub struct SpeechRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub noise_scale: Option<f64>,
     /// Speed of speaking (1 = normal, < 1 is faster, > 1 is slower). Defaults to `1.0`. This param is only supported for `Piper`.
-    length_scale: Option<f64>,
+    pub length_scale: Option<f64>,
     /// Variation in phoneme lengths. Defaults to `0.8`. This param is only supported for `Piper`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub noise_w: Option<f64>,
@@ -38,7 +38,7 @@ pub struct SpeechRequest {
     pub sentence_silence: Option<f64>,
     /// Seconds of extra silence to insert after a single phoneme. This param is only supported for `Piper`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    phoneme_silence: Option<f64>,
+    pub phoneme_silence: Option<f64>,
     /// stdin input is lines of JSON instead of plain text. This param is only supported for `Piper`.
     /// The input format should be:
     /// ```json
@@ -312,5 +312,4 @@ pub enum SpeechFormat {
     // Aac,
     // Flac,
     // Pcm,
-    Raw, // 16-bit mono PCM for Piper
 }

--- a/crates/llama-core/Cargo.toml
+++ b/crates/llama-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-core"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/llama-core/Cargo.toml
+++ b/crates/llama-core/Cargo.toml
@@ -20,7 +20,7 @@ uuid.workspace = true
 once_cell.workspace = true
 futures.workspace = true
 reqwest.workspace = true
-qdrant = { package = "qdrant_rest_client", version = "0.1.4", git = "https://github.com/second-state/qdrant-rest-client.git", branch = "main", optional = true }
+qdrant = { package = "qdrant_rest_client", version = "0.2.0", optional = true }
 text-splitter = { version = "^0.7", features = ["tiktoken-rs", "markdown"] }
 tiktoken-rs = "^0.5"
 wasi-logger = { workspace = true, optional = true }

--- a/crates/llama-core/src/error.rs
+++ b/crates/llama-core/src/error.rs
@@ -16,11 +16,17 @@ pub enum LlamaCoreError {
     Backend(#[from] BackendError),
     /// Errors thrown by the Search Backend
     #[cfg(feature = "search")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "search")))]
     #[error("{0}")]
     Search(String),
     /// Errors in file not found.
     #[error("File not found.")]
     FileNotFound,
+    /// Errors in Qdrant.
+    #[cfg(feature = "rag")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rag")))]
+    #[error("Qdrant error:{0}")]
+    Qdrant(String),
 }
 
 /// Error types for wasi-nn errors.

--- a/crates/llama-core/src/rag.rs
+++ b/crates/llama-core/src/rag.rs
@@ -277,7 +277,7 @@ async fn qdrant_create_collection(
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
 
-        return Err(LlamaCoreError::Operation(err_msg));
+        return Err(LlamaCoreError::Qdrant(err_msg));
     }
 
     Ok(())
@@ -319,12 +319,12 @@ async fn qdrant_persist_embeddings(
         .upsert_points(collection_name.as_ref(), points)
         .await
     {
-        let err_msg = format!("Failed to upsert points. Reason: {}", e);
+        let err_msg = format!("{}", e);
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
 
-        return Err(LlamaCoreError::Operation(err_msg));
+        return Err(LlamaCoreError::Qdrant(err_msg));
     }
 
     Ok(())
@@ -361,7 +361,7 @@ async fn qdrant_search_similar_points(
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);
 
-            Err(LlamaCoreError::Operation(err_msg))
+            Err(LlamaCoreError::Qdrant(err_msg))
         }
     }
 }

--- a/llama-api-server/Cargo.toml
+++ b/llama-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-api-server"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 
 [dependencies]

--- a/llama-api-server/README.md
+++ b/llama-api-server/README.md
@@ -11,6 +11,7 @@ LlamaEdge API server offers OpenAI-compatible REST APIs. It can accelerate devel
   - [Get LlamaEdge API server](#get-llamaedge-api-server)
   - [Get model](#get-model)
   - [Run LlamaEdge API server](#run-llamaedge-api-server)
+    - [API Key](#api-key)
   - [Endpoints](#endpoints)
     - [List models](#list-models)
     - [Chat completions](#chat-completions)
@@ -100,7 +101,6 @@ wasmedge --dir .:. --nn-preload default:GGML:AUTO:Meta-Llama-3-8B-Instruct-Q5_K_
   --prompt-template llama-3-chat \
   --ctx-size 4096 \
   --model-name llama-3-8b
-
 ```
 
 The command above starts the API server on the default socket address. Besides, there are also some other options specified in the command:
@@ -110,6 +110,29 @@ The command above starts the API server on the default socket address. Besides, 
 - The `--nn-preload default:GGML:AUTO:Meta-Llama-3-8B-Instruct-Q5_K_M.gguf` option specifies the Llama model to be used by the API server. The pattern of the argument is `<name>:<encoding>:<target>:<model path>`. Here, the model used is `Meta-Llama-3-8B-Instruct-Q5_K_M.gguf`; and we give it an alias `default` as its name in the runtime environment. You can change the model name here if you're not using llama-3-8b.
 - The `--prompt-template llama-3-chat` is the prompt template for the model.
 - The `--model-name llama-3-8b` specifies the model name. It is used in the chat request.
+
+### API Key
+
+To run the API server with a API key, use `API_KEY` environment variable to specify the API key:
+
+```bash
+export LLAMA_API_KEY=<your-api-key>
+wasmedge --dir .:. --env API_KEY=$LLAMA_API_KEY \
+  --nn-preload default:GGML:AUTO:Meta-Llama-3-8B-Instruct-Q5_K_M.gguf \
+  llama-api-server.wasm \
+  --prompt-template llama-3-chat \
+  --ctx-size 4096 \
+  --model-name llama-3-8b
+```
+
+After launching the API server, each request to the server should set the correct API key, for example,
+
+```bash
+curl --location 'http://localhost:8080/v1/chat/completions' \
+--header 'Authorization: Bearer <your-api-key>' \
+--header 'Content-Type: application/json' \
+--data '...'
+```
 
 ## Endpoints
 

--- a/llama-api-server/src/error.rs
+++ b/llama-api-server/src/error.rs
@@ -51,6 +51,24 @@ pub(crate) fn bad_request(msg: impl AsRef<str>) -> Response<Body> {
         .unwrap()
 }
 
+pub(crate) fn unauthorized(msg: impl AsRef<str>) -> Response<Body> {
+    let err_msg = match msg.as_ref().is_empty() {
+        true => "401 Unauthorized".to_string(),
+        false => format!("401 Unauthorized: {}", msg.as_ref()),
+    };
+
+    // log error
+    error!(target: "stdout", "{}", &err_msg);
+
+    Response::builder()
+        .header("Access-Control-Allow-Origin", "*")
+        .header("Access-Control-Allow-Methods", "*")
+        .header("Access-Control-Allow-Headers", "*")
+        .status(hyper::StatusCode::UNAUTHORIZED)
+        .body(Body::from(err_msg))
+        .unwrap()
+}
+
 pub(crate) fn invalid_endpoint(msg: impl AsRef<str>) -> Response<Body> {
     let err_msg = match msg.as_ref().is_empty() {
         true => "404 The requested service endpoint is not found".to_string(),

--- a/llama-api-server/src/main.rs
+++ b/llama-api-server/src/main.rs
@@ -980,7 +980,7 @@ async fn handle_request(
 
             if let Some(stored_api_key) = LLAMA_API_KEY.get() {
                 if api_key != stored_api_key {
-                    let err_msg = format!("Invalid API key.");
+                    let err_msg = "Invalid API key.";
                     return Ok(error::unauthorized(err_msg));
                 }
             }

--- a/llama-chat/Cargo.toml
+++ b/llama-chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-chat"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 
 [dependencies]

--- a/llama-simple/Cargo.toml
+++ b/llama-simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-simple"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Major changes:

- (New) Support API key ( Fixes #247 )
  - Use `API_KEY` environment variable to set api-key when start API server, for example
    ```bash
    export LLAMA_API_KEY=12345-6789-abcdef
    wasmedge --dir .:. --env API_KEY=$LLAMA_API_KEY --nn-preload default:GGML:AUTO:moxin-chat-7b-Q5_K_M.gguf \
      llama-api-server.wasm \
      --model-name moxin-chat-7b \
      --prompt-template moxin-chat \
      --reverse-prompt "[INST]" \
      --ctx-size 32000
    ```
  - Send each request with the corresponding api-key, for example
    ```bash
    curl --location 'http://localhost:8080/v1/chat/completions' \
    --header 'Authorization: Bearer 12345-6789-abcdef' \
    --header 'Content-Type: application/json' \
    --data '...'
    ```