### PR TITLE
Release 0.16.0

### DIFF
--- a/.github/workflows/test_api_server.yml
+++ b/.github/workflows/test_api_server.yml
@@ -12,23 +12,23 @@ on:
       - fix-*
       - test-*
     paths:
-      - '.github/workflows/test_api_server.yml'
-      - '**/Cargo.toml'
-      - '**/*.rs'
-      - '**/*.sh'
-      - '**/.cargo/config.toml'
-      - 'tests/*.hurl'
+      - ".github/workflows/test_api_server.yml"
+      - "**/Cargo.toml"
+      - "**/*.rs"
+      - "**/*.sh"
+      - "**/.cargo/config.toml"
+      - "tests/*.hurl"
   pull_request:
     branches:
       - dev
       - main
     types: [opened, synchronize, reopened]
     paths:
-      - '.github/workflows/**'
-      - '**/Cargo.toml'
-      - '**/*.rs'
-      - '**/*.sh'
-      - 'tests/*.hurl'
+      - ".github/workflows/**"
+      - "**/Cargo.toml"
+      - "**/*.rs"
+      - "**/*.sh"
+      - "tests/*.hurl"
 
 jobs:
   test-api-server-ubuntu:
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         wasmedge_version: [0.14.1]
-        ggml_version: [b4273]
+        ggml_version: [b4381]
     steps:
       - name: Clone project
         id: checkout

--- a/.github/workflows/test_api_server.yml
+++ b/.github/workflows/test_api_server.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         wasmedge_version: [0.14.1]
-        ggml_version: [b4381]
+        ggml_version: [b4419]
     steps:
       - name: Clone project
         id: checkout

--- a/.github/workflows/test_api_server.yml
+++ b/.github/workflows/test_api_server.yml
@@ -123,7 +123,7 @@ jobs:
     strategy:
       matrix:
         wasmedge_version: [0.14.1]
-        ggml_version: [b4273]
+        ggml_version: [b4419]
     steps:
       - name: Clone project
         id: checkout
@@ -217,7 +217,7 @@ jobs:
     strategy:
       matrix:
         wasmedge_version: [0.14.1]
-        ggml_version: [b4273]
+        ggml_version: [b4419]
     steps:
       - name: Clone project
         id: checkout
@@ -311,7 +311,7 @@ jobs:
     strategy:
       matrix:
         wasmedge_version: [0.14.1]
-        ggml_version: [b4273]
+        ggml_version: [b4419]
     steps:
       - name: Clone project
         id: checkout

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ resolver = "2"
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-endpoints = { path = "crates/endpoints", version = "^0.23" }
-chat-prompts = { path = "crates/chat-prompts", version = "^0.18" }
+endpoints = { path = "crates/endpoints", version = "^0.24" }
+chat-prompts = { path = "crates/chat-prompts", version = "^0.19" }
 thiserror = "1"
 uuid = { version = "1.4", features = ["v4", "fast-rng", "macro-diagnostics"] }
 clap = { version = "4.4.6", features = ["cargo", "derive"] }
@@ -21,7 +21,7 @@ log = { version = "0.4.21", features = ["std", "kv", "kv_serde"] }
 wasi-logger = { version = "0.1.2", features = ["kv"] }
 either = "1.12.0"
 base64 = "=0.22.1"
-llama-core = { path = "crates/llama-core", features = ["logging"], version = "^0.25" }
+llama-core = { path = "crates/llama-core", features = ["logging"], version = "^0.26" }
 tokio = { version = "^1.36", features = ["io-util", "fs", "net", "time", "rt", "macros"] }
 anyhow = "1"
 once_cell = "1.18"

--- a/crates/chat-prompts/Cargo.toml
+++ b/crates/chat-prompts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chat-prompts"
-version = "0.18.6"
+version = "0.19.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/chat-prompts/README.md
+++ b/crates/chat-prompts/README.md
@@ -294,6 +294,23 @@ The available prompt templates are listed below:
     {{ user_message_2 }}<|eot_id|><|start_header_id|>assistant<|end_header_id|>
     ```
 
+- `llama-3-tool`
+  - Prompt string
+
+    ```text
+    <|begin_of_text|><|start_header_id|>system<|end_header_id|>
+
+    {system_message}<|eot_id|><|start_header_id|>user<|end_header_id|>
+
+    Given the following functions, please respond with a JSON for a function call with its proper arguments that best answers the given prompt.
+
+    Respond in the format {"name": function name, "parameters": dictionary of argument name and its value}. Do not use variables.
+
+    [{"type":"function","function":{"name":"get_current_weather","description":"Get the current weather in a given location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","description":"The temperature unit to use. Infer this from the users location.","enum":["celsius","fahrenheit"]}},"required":["location","unit"]}}}]
+
+    Question: {user_message}<|eot_id|><|start_header_id|>assistant<|end_header_id|>
+    ```
+
 - `mediatek-breeze`
   - Prompt string
 

--- a/crates/chat-prompts/README.md
+++ b/crates/chat-prompts/README.md
@@ -453,6 +453,19 @@ The available prompt templates are listed below:
 
   - Example: [second-state/Phi-3-medium-4k-instruct-GGUF](https://huggingface.co/second-state/Phi-3-medium-4k-instruct-GGUF)
 
+- `phi-4-chat`
+  - Prompt string
+
+    ```text
+    <|im_start|>system<|im_sep|>
+    {system_message}<|im_end|>
+    <|im_start|>user<|im_sep|>
+    {user_message}<|im_end|>
+    <|im_start|>assistant<|im_sep|>
+    ```
+
+  - Example: [second-state/phi-4-GGUF](https://huggingface.co/second-state/phi-4-GGUF)
+
 - `solar-instruct`
   - Prompt string
 

--- a/crates/chat-prompts/README.md
+++ b/crates/chat-prompts/README.md
@@ -131,6 +131,19 @@ The available prompt templates are listed below:
 
   - Example: [second-state/E5-Mistral-7B-Instruct-Embedding-GGUF](https://huggingface.co/second-state/E5-Mistral-7B-Instruct-Embedding-GGUF)
 
+- `falcon3`
+  - Prompt string
+
+    ```text
+    <|system|>
+    {system_message}
+    <|user|>
+    {user_message}
+    <|assistant|>
+    ```
+
+  - Example: [second-state/Falcon3-7B-Instruct-GGUF](https://huggingface.co/second-state/Falcon3-7B-Instruct-GGUF)
+
 - `functionary-31`
 
   - Prompt string

--- a/crates/chat-prompts/README.md
+++ b/crates/chat-prompts/README.md
@@ -303,6 +303,15 @@ The available prompt templates are listed below:
 
   - Example: [second-state/Breeze-7B-Instruct-v1_0-GGUF](https://huggingface.co/second-state/Breeze-7B-Instruct-v1_0-GGUF)
 
+- `megrez`
+  - Prompt string
+
+    ```text
+    <|role_start|>system<|role_end|>{system_message}<|turn_end|><|role_start|>user<|role_end|>{user_message}<|turn_end|><|role_start|>assistant<|role_end|>
+    ```
+
+  - Example: [second-state/Megrez-3B-Instruct-GGUF](https://huggingface.co/second-state/Megrez-3B-Instruct-GGUF)
+
 - `mistral-instruct`
   - Prompt string
 

--- a/crates/chat-prompts/src/chat/deepseek.rs
+++ b/crates/chat-prompts/src/chat/deepseek.rs
@@ -305,7 +305,7 @@ impl BuildChatPrompt for DeepseekChat2Prompt {
     }
 }
 
-/// Generate prompts for the `DeepSeek-V2.5` models.
+/// Generate prompts for the `DeepSeek-v2.5` and `DeepSeek-v3` models.
 #[derive(Debug, Default, Clone)]
 pub struct DeepseekChat25Prompt;
 impl DeepseekChat25Prompt {

--- a/crates/chat-prompts/src/chat/falcon.rs
+++ b/crates/chat-prompts/src/chat/falcon.rs
@@ -1,0 +1,108 @@
+use super::BuildChatPrompt;
+use crate::error::{PromptError, Result};
+use endpoints::chat::{
+    ChatCompletionAssistantMessage, ChatCompletionRequestMessage, ChatCompletionSystemMessage,
+    ChatCompletionUserMessage, ChatCompletionUserMessageContent, ContentPart,
+};
+
+/// Generate chat prompt for the `falcon3-instruct` model.
+#[derive(Debug, Default, Clone)]
+pub struct FalconChatPrompt;
+impl FalconChatPrompt {
+    /// Create a system prompt from a chat completion request message.
+    fn create_system_prompt(&self, message: &ChatCompletionSystemMessage) -> String {
+        let content = message.content();
+        match content.is_empty() {
+            true => String::from("<|system|>\nYou are a helpful friendly assistant Falcon3 from TII, try to follow instructions as much as possible."),
+            false => format!("<|system|>\n{content}"),
+        }
+    }
+
+    /// Create a user prompt from a chat completion request message.
+    fn append_user_message(
+        &self,
+        chat_history: impl AsRef<str>,
+        system_prompt: impl AsRef<str>,
+        message: &ChatCompletionUserMessage,
+    ) -> String {
+        let content = match message.content() {
+            ChatCompletionUserMessageContent::Text(text) => text.to_string(),
+            ChatCompletionUserMessageContent::Parts(parts) => {
+                let mut content = String::new();
+                for part in parts {
+                    if let ContentPart::Text(text_content) = part {
+                        content.push_str(text_content.text());
+                        content.push('\n');
+                    }
+                }
+                content
+            }
+        };
+
+        match chat_history.as_ref().is_empty() {
+            true => format!(
+                "{system_prompt}\n<|user|>\n{user_message}",
+                system_prompt = system_prompt.as_ref().trim(),
+                user_message = content.trim(),
+            ),
+            false => format!(
+                "{chat_history}\n<|user|>\n{user_message}",
+                chat_history = chat_history.as_ref().trim(),
+                user_message = content.trim(),
+            ),
+        }
+    }
+
+    /// create an assistant prompt from a chat completion request message.
+    fn append_assistant_message(
+        &self,
+        chat_history: impl AsRef<str>,
+        message: &ChatCompletionAssistantMessage,
+    ) -> Result<String> {
+        let content = match message.content() {
+            Some(content) => content.to_string(),
+            // Note that the content is optional if `tool_calls` is specified.
+            None => match message.tool_calls().is_some() {
+                true => String::new(),
+                false => return Err(PromptError::NoAssistantMessage),
+            },
+        };
+
+        Ok(format!(
+            "{chat_history}\n<|assistant|>\n{assistant_message}",
+            chat_history = chat_history.as_ref().trim(),
+            assistant_message = content.trim(),
+        ))
+    }
+}
+impl BuildChatPrompt for FalconChatPrompt {
+    fn build(&self, messages: &mut Vec<ChatCompletionRequestMessage>) -> Result<String> {
+        if messages.is_empty() {
+            return Err(crate::error::PromptError::NoMessages);
+        }
+
+        // system prompt
+        let system_prompt = match messages[0] {
+            ChatCompletionRequestMessage::System(ref message) => self.create_system_prompt(message),
+            _ => String::from("<|system|>\nYou are a helpful friendly assistant Falcon3 from TII, try to follow instructions as much as possible."),
+        };
+
+        // append user/assistant messages
+        let mut prompt = String::new();
+        for message in messages {
+            match message {
+                ChatCompletionRequestMessage::User(message) => {
+                    prompt = self.append_user_message(&prompt, &system_prompt, message);
+                }
+                ChatCompletionRequestMessage::Assistant(message) => {
+                    prompt = self.append_assistant_message(&prompt, message)?;
+                }
+                _ => continue,
+            }
+        }
+
+        prompt.push_str("\n<|assistant|>");
+
+        Ok(prompt)
+    }
+}

--- a/crates/chat-prompts/src/chat/megrez.rs
+++ b/crates/chat-prompts/src/chat/megrez.rs
@@ -1,0 +1,121 @@
+use super::BuildChatPrompt;
+use crate::error::{PromptError, Result};
+use endpoints::chat::{
+    ChatCompletionAssistantMessage, ChatCompletionRequestMessage, ChatCompletionSystemMessage,
+    ChatCompletionUserMessage, ChatCompletionUserMessageContent, ContentPart,
+};
+
+/// Generate prompts for the models using ChatML template.
+#[derive(Debug, Default, Clone)]
+pub struct MegrezPrompt;
+impl MegrezPrompt {
+    /// Create a system prompt from a chat completion request message.
+    fn create_system_prompt(&self, message: &ChatCompletionSystemMessage) -> String {
+        let content = message.content();
+        match content.is_empty() {
+            true => String::from("<|role_start|>system<|role_end|>You are a helpful assistant. Answer questions as concisely and accurately as possible.<|turn_end|>"),
+            false => format!(
+                "<|role_start|>system<|role_end|>{system_prompt}<|turn_end|>",
+                system_prompt = content
+            ),
+        }
+    }
+
+    /// Create a user prompt from a chat completion request message.
+    fn append_user_message(
+        &self,
+        chat_history: impl AsRef<str>,
+        system_prompt: impl AsRef<str>,
+        message: &ChatCompletionUserMessage,
+    ) -> String {
+        let content = match message.content() {
+            ChatCompletionUserMessageContent::Text(text) => text.to_string(),
+            ChatCompletionUserMessageContent::Parts(parts) => {
+                let mut content = String::new();
+                for part in parts {
+                    if let ContentPart::Text(text_content) = part {
+                        content.push_str(text_content.text());
+                        content.push('\n');
+                    }
+                }
+                content
+            }
+        };
+
+        match chat_history.as_ref().is_empty() {
+            true => match system_prompt.as_ref().is_empty() {
+                true => {
+                    format!(
+                        "<|role_start|>user<|role_end|>{user_message}<|turn_end|>",
+                        user_message = content.trim(),
+                    )
+                }
+                false => {
+                    format!(
+                        "{system_prompt}<|role_start|>user<|role_end|>{user_message}<|turn_end|>",
+                        system_prompt = system_prompt.as_ref().trim(),
+                        user_message = content.trim(),
+                    )
+                }
+            },
+            false => format!(
+                "{chat_history}<|role_start|>user<|role_end|>{user_message}<|turn_end|>",
+                chat_history = chat_history.as_ref().trim(),
+                user_message = content.trim(),
+            ),
+        }
+    }
+
+    /// create an assistant prompt from a chat completion request message.
+    fn append_assistant_message(
+        &self,
+        chat_history: impl AsRef<str>,
+        message: &ChatCompletionAssistantMessage,
+    ) -> Result<String> {
+        let content = match message.content() {
+            Some(content) => content.to_string(),
+            // Note that the content is optional if `tool_calls` is specified.
+            None => match message.tool_calls().is_some() {
+                true => String::new(),
+                false => return Err(PromptError::NoAssistantMessage),
+            },
+        };
+
+        Ok(format!(
+            "{chat_history}<|role_start|>assistant<|role_end|>{assistant_message}<|turn_end|>",
+            chat_history = chat_history.as_ref().trim(),
+            assistant_message = content.trim(),
+        ))
+    }
+}
+impl BuildChatPrompt for MegrezPrompt {
+    fn build(&self, messages: &mut Vec<ChatCompletionRequestMessage>) -> Result<String> {
+        if messages.is_empty() {
+            return Err(crate::error::PromptError::NoMessages);
+        }
+
+        // system prompt
+        let system_prompt = match messages[0] {
+            ChatCompletionRequestMessage::System(ref message) => self.create_system_prompt(message),
+            _ => String::from("<|role_start|>system<|role_end|>You are a helpful assistant. Answer questions as concisely and accurately as possible.<|turn_end|>"),
+        };
+
+        // append user/assistant messages
+        let mut prompt = String::new();
+        for message in messages {
+            match message {
+                ChatCompletionRequestMessage::User(message) => {
+                    prompt = self.append_user_message(&prompt, &system_prompt, message);
+                }
+                ChatCompletionRequestMessage::Assistant(message) => {
+                    prompt = self.append_assistant_message(&prompt, message)?;
+                }
+                _ => continue,
+            }
+        }
+
+        prompt.push_str("<|role_start|>assistant<|role_end|>");
+
+        Ok(prompt)
+    }
+}

--- a/crates/chat-prompts/src/chat/mod.rs
+++ b/crates/chat-prompts/src/chat/mod.rs
@@ -10,6 +10,7 @@ pub mod groq;
 pub mod intel;
 pub mod llama;
 pub mod mediatek;
+pub mod megrez;
 pub mod minicpm;
 pub mod mistral;
 pub mod moxin;
@@ -36,6 +37,7 @@ use groq::*;
 use intel::*;
 use llama::*;
 use mediatek::BreezeInstructPrompt;
+use megrez::*;
 use minicpm::*;
 use mistral::*;
 use moxin::*;
@@ -108,6 +110,7 @@ pub enum ChatPrompt {
     MiniCPMVPrompt,
     MoxinChatPrompt,
     FalconChatPrompt,
+    MegrezPrompt,
 }
 impl From<PromptTemplateType> for ChatPrompt {
     fn from(ty: PromptTemplateType) -> Self {
@@ -184,6 +187,7 @@ impl From<PromptTemplateType> for ChatPrompt {
             PromptTemplateType::MiniCPMV => ChatPrompt::MiniCPMVPrompt(MiniCPMVPrompt),
             PromptTemplateType::MoxinChat => ChatPrompt::MoxinChatPrompt(MoxinChatPrompt),
             PromptTemplateType::Falcon3 => ChatPrompt::FalconChatPrompt(FalconChatPrompt),
+            PromptTemplateType::Megrez => ChatPrompt::MegrezPrompt(MegrezPrompt),
             PromptTemplateType::Embedding => {
                 panic!("Embedding prompt template is not used for building chat prompts")
             }

--- a/crates/chat-prompts/src/chat/mod.rs
+++ b/crates/chat-prompts/src/chat/mod.rs
@@ -158,6 +158,9 @@ impl From<PromptTemplateType> for ChatPrompt {
             PromptTemplateType::DeepseekChat25 => {
                 ChatPrompt::DeepseekChat25Prompt(DeepseekChat25Prompt)
             }
+            PromptTemplateType::DeepseekChat3 => {
+                ChatPrompt::DeepseekChat25Prompt(DeepseekChat25Prompt)
+            }
             PromptTemplateType::SolarInstruct => {
                 ChatPrompt::SolarInstructPrompt(SolarInstructPrompt)
             }

--- a/crates/chat-prompts/src/chat/mod.rs
+++ b/crates/chat-prompts/src/chat/mod.rs
@@ -100,6 +100,7 @@ pub enum ChatPrompt {
     Phi2InstructPrompt,
     Phi3ChatPrompt,
     Phi3InstructPrompt,
+    Phi4ChatPrompt,
     GemmaInstructPrompt,
     OctopusPrompt,
     Glm4ChatPrompt,
@@ -171,6 +172,7 @@ impl From<PromptTemplateType> for ChatPrompt {
             PromptTemplateType::Phi2Instruct => ChatPrompt::Phi2InstructPrompt(Phi2InstructPrompt),
             PromptTemplateType::Phi3Chat => ChatPrompt::Phi3ChatPrompt(Phi3ChatPrompt),
             PromptTemplateType::Phi3Instruct => ChatPrompt::Phi3InstructPrompt(Phi3InstructPrompt),
+            PromptTemplateType::Phi4Chat => ChatPrompt::Phi4ChatPrompt(Phi4ChatPrompt),
             PromptTemplateType::GemmaInstruct => {
                 ChatPrompt::GemmaInstructPrompt(GemmaInstructPrompt)
             }

--- a/crates/chat-prompts/src/chat/mod.rs
+++ b/crates/chat-prompts/src/chat/mod.rs
@@ -2,6 +2,7 @@ pub mod baichuan;
 pub mod belle;
 pub mod chatml;
 pub mod deepseek;
+pub mod falcon;
 pub mod functionary;
 pub mod gemma;
 pub mod glm;
@@ -27,6 +28,7 @@ use belle::*;
 use chatml::*;
 use deepseek::*;
 use endpoints::chat::{ChatCompletionRequestMessage, Tool};
+use falcon::*;
 use functionary::{FunctionaryV31ToolPrompt, FunctionaryV32ToolPrompt};
 use gemma::*;
 use glm::*;
@@ -105,6 +107,7 @@ pub enum ChatPrompt {
     FunctionaryV31ToolPrompt,
     MiniCPMVPrompt,
     MoxinChatPrompt,
+    FalconChatPrompt,
 }
 impl From<PromptTemplateType> for ChatPrompt {
     fn from(ty: PromptTemplateType) -> Self {
@@ -180,6 +183,7 @@ impl From<PromptTemplateType> for ChatPrompt {
             }
             PromptTemplateType::MiniCPMV => ChatPrompt::MiniCPMVPrompt(MiniCPMVPrompt),
             PromptTemplateType::MoxinChat => ChatPrompt::MoxinChatPrompt(MoxinChatPrompt),
+            PromptTemplateType::Falcon3 => ChatPrompt::FalconChatPrompt(FalconChatPrompt),
             PromptTemplateType::Embedding => {
                 panic!("Embedding prompt template is not used for building chat prompts")
             }

--- a/crates/chat-prompts/src/chat/mod.rs
+++ b/crates/chat-prompts/src/chat/mod.rs
@@ -18,6 +18,7 @@ pub mod nvidia;
 pub mod octopus;
 pub mod openchat;
 pub mod phi;
+pub mod qwen;
 pub mod solar;
 pub mod vicuna;
 pub mod wizard;
@@ -45,6 +46,7 @@ use nvidia::{NemotronChatPrompt, NemotronToolPrompt};
 use octopus::*;
 use openchat::*;
 use phi::*;
+use qwen::Qwen2vlPrompt;
 use solar::*;
 use vicuna::*;
 use wizard::*;
@@ -111,6 +113,7 @@ pub enum ChatPrompt {
     MoxinChatPrompt,
     FalconChatPrompt,
     MegrezPrompt,
+    Qwen2vlPrompt,
 }
 impl From<PromptTemplateType> for ChatPrompt {
     fn from(ty: PromptTemplateType) -> Self {
@@ -191,6 +194,7 @@ impl From<PromptTemplateType> for ChatPrompt {
             PromptTemplateType::MoxinChat => ChatPrompt::MoxinChatPrompt(MoxinChatPrompt),
             PromptTemplateType::Falcon3 => ChatPrompt::FalconChatPrompt(FalconChatPrompt),
             PromptTemplateType::Megrez => ChatPrompt::MegrezPrompt(MegrezPrompt),
+            PromptTemplateType::Qwen2vl => ChatPrompt::Qwen2vlPrompt(Qwen2vlPrompt),
             PromptTemplateType::Embedding => {
                 panic!("Embedding prompt template is not used for building chat prompts")
             }

--- a/crates/chat-prompts/src/chat/phi.rs
+++ b/crates/chat-prompts/src/chat/phi.rs
@@ -174,7 +174,7 @@ impl BuildChatPrompt for Phi3InstructPrompt {
     }
 }
 
-/// Generate chat prompt for the `microsoft/phi-2` model.
+/// Generate chat prompt for the `microsoft/phi-3` model.
 #[derive(Debug, Default, Clone)]
 pub struct Phi3ChatPrompt;
 impl Phi3ChatPrompt {
@@ -271,6 +271,110 @@ impl BuildChatPrompt for Phi3ChatPrompt {
         }
 
         prompt.push_str("\n<|assistant|>");
+
+        Ok(prompt)
+    }
+}
+
+/// Generate chat prompt for the `microsoft/phi-4` model.
+#[derive(Debug, Default, Clone)]
+pub struct Phi4ChatPrompt;
+impl Phi4ChatPrompt {
+    /// Create a system prompt from a chat completion request message.
+    fn create_system_prompt(&self, message: &ChatCompletionSystemMessage) -> String {
+        let content = message.content();
+        match content.is_empty() {
+            true => {
+                String::from("<|im_start|>system<|im_sep|>\nYou are a helpful assistant. Answer questions as concisely and accurately as possible.<|im_end|>")
+            }
+            false => format!("<|im_start|>system<|im_sep|>\n{content}<|im_end|>"),
+        }
+    }
+
+    /// Create a user prompt from a chat completion request message.
+    fn append_user_message(
+        &self,
+        chat_history: impl AsRef<str>,
+        system_prompt: impl AsRef<str>,
+        message: &ChatCompletionUserMessage,
+    ) -> String {
+        let content = match message.content() {
+            ChatCompletionUserMessageContent::Text(text) => text.to_string(),
+            ChatCompletionUserMessageContent::Parts(parts) => {
+                let mut content = String::new();
+                for part in parts {
+                    if let ContentPart::Text(text_content) = part {
+                        content.push_str(text_content.text());
+                        content.push('\n');
+                    }
+                }
+                content
+            }
+        };
+
+        match chat_history.as_ref().is_empty() {
+            true => format!(
+                "{system_prompt}\n<|im_start|>user<|im_sep|>\n{user_message}<|im_end|>",
+                system_prompt = system_prompt.as_ref().trim(),
+                user_message = content.trim(),
+            ),
+            false => format!(
+                "{chat_history}\n<|im_start|>user<|im_sep|>\n{user_message}<|im_end|>",
+                chat_history = chat_history.as_ref().trim(),
+                user_message = content.trim(),
+            ),
+        }
+    }
+
+    /// create an assistant prompt from a chat completion request message.
+    fn append_assistant_message(
+        &self,
+        chat_history: impl AsRef<str>,
+        message: &ChatCompletionAssistantMessage,
+    ) -> Result<String> {
+        let content = match message.content() {
+            Some(content) => content.to_string(),
+            // Note that the content is optional if `tool_calls` is specified.
+            None => match message.tool_calls().is_some() {
+                true => String::new(),
+                false => return Err(PromptError::NoAssistantMessage),
+            },
+        };
+
+        Ok(format!(
+            "{chat_history}\n<|im_start|>assistant<|im_sep|>\n{assistant_message}<|im_end|>",
+            chat_history = chat_history.as_ref().trim(),
+            assistant_message = content.trim(),
+        ))
+    }
+}
+impl BuildChatPrompt for Phi4ChatPrompt {
+    fn build(&self, messages: &mut Vec<ChatCompletionRequestMessage>) -> Result<String> {
+        if messages.is_empty() {
+            return Err(crate::error::PromptError::NoMessages);
+        }
+
+        // system prompt
+        let system_prompt = match messages[0] {
+            ChatCompletionRequestMessage::System(ref message) => self.create_system_prompt(message),
+            _ => String::from("<|im_start|>system<|im_sep|>\nYou are a helpful assistant. Answer questions as concisely and accurately as possible.<|im_end|>"),
+        };
+
+        // append user/assistant messages
+        let mut prompt = String::new();
+        for message in messages {
+            match message {
+                ChatCompletionRequestMessage::User(message) => {
+                    prompt = self.append_user_message(&prompt, &system_prompt, message);
+                }
+                ChatCompletionRequestMessage::Assistant(message) => {
+                    prompt = self.append_assistant_message(&prompt, message)?;
+                }
+                _ => continue,
+            }
+        }
+
+        prompt.push_str("\n<|im_start|>assistant<|im_sep|>");
 
         Ok(prompt)
     }

--- a/crates/chat-prompts/src/chat/qwen.rs
+++ b/crates/chat-prompts/src/chat/qwen.rs
@@ -1,0 +1,199 @@
+use super::BuildChatPrompt;
+use crate::error::{PromptError, Result};
+use base64::{engine::general_purpose, Engine as _};
+use endpoints::chat::{
+    ChatCompletionAssistantMessage, ChatCompletionRequestMessage, ChatCompletionSystemMessage,
+    ChatCompletionUserMessage, ChatCompletionUserMessageContent, ContentPart,
+};
+use image::io::Reader as ImageReader;
+use std::io::Cursor;
+
+/// Qwen2-vl Prompt Template
+#[derive(Debug, Default, Clone)]
+pub struct Qwen2vlPrompt;
+impl Qwen2vlPrompt {
+    /// Create a system prompt from a chat completion request message.
+    fn create_system_prompt(&self, message: &ChatCompletionSystemMessage) -> String {
+        let content = message.content();
+        match content.is_empty() {
+            true => String::from("<|im_start|>system\nAnswer as concisely as possible.<|im_end|>"),
+            false => format!(
+                "<|im_start|>system\n{system_prompt}<|im_end|>",
+                system_prompt = content
+            ),
+        }
+    }
+
+    /// Create a user prompt from a chat completion request message.
+    fn append_user_message(
+        &self,
+        chat_history: impl AsRef<str>,
+        system_prompt: impl AsRef<str>,
+        message: &ChatCompletionUserMessage,
+    ) -> Result<String> {
+        let prompt = match message.content() {
+            ChatCompletionUserMessageContent::Text(content) => {
+                match chat_history.as_ref().is_empty() {
+                    true => match system_prompt.as_ref().is_empty() {
+                        true => {
+                            format!(
+                                "<|im_start|>user\n{user_message}<|im_end|>",
+                                user_message = content.trim(),
+                            )
+                        }
+                        false => {
+                            format!(
+                                "{system_prompt}\n<|im_start|>user\n{user_message}<|im_end|>",
+                                system_prompt = system_prompt.as_ref().trim(),
+                                user_message = content.trim(),
+                            )
+                        }
+                    },
+                    false => format!(
+                        "{chat_history}\n<|im_start|>user\n{user_message}<|im_end|>",
+                        chat_history = chat_history.as_ref().trim(),
+                        user_message = content.trim(),
+                    ),
+                }
+            }
+            ChatCompletionUserMessageContent::Parts(parts) => {
+                let mut content = String::new();
+                let mut image_contents = vec![];
+                for part in parts {
+                    match part {
+                        ContentPart::Text(text_content) => {
+                            content.push_str(text_content.text());
+                            content.push('\n');
+                        }
+                        ContentPart::Image(part) => {
+                            let image_content = match part.image().is_url() {
+                                true => String::from("<image>"),
+                                false => {
+                                    let base64_str = part.image().url.as_str();
+                                    let format = is_image_format(base64_str)?;
+                                    format!(
+                                        r#"<img src="data:image/{};base64,{}">"#,
+                                        format, base64_str
+                                    )
+                                }
+                            };
+                            image_contents.push(image_content);
+                        }
+                    }
+                }
+
+                let mut image_embeddings = String::new();
+                for image_content in image_contents {
+                    let image_embedding = format!(
+                        "<|vision_start|>{image_content}<|vision_end|>",
+                        image_content = image_content.trim(),
+                    );
+                    image_embeddings.push_str(&image_embedding);
+                }
+
+                match chat_history.as_ref().is_empty() {
+                    true => format!(
+                        "{system_prompt}\n<|im_start|>user\n{image_embeddings}{user_message}<|im_end|>",
+                        system_prompt = system_prompt.as_ref().trim(),
+                        image_embeddings = image_embeddings.trim(),
+                        user_message = content.trim(),
+                    ),
+                    false => format!(
+                        "{chat_history}\n<|im_start|>user\n{image_embeddings}{user_message}<|im_end|>",
+                        chat_history = chat_history.as_ref().trim(),
+                        image_embeddings = image_embeddings.trim(),
+                        user_message = content.trim(),
+                    ),
+                }
+            }
+        };
+
+        Ok(prompt)
+    }
+
+    /// create an assistant prompt from a chat completion request message.
+    fn append_assistant_message(
+        &self,
+        chat_history: impl AsRef<str>,
+        message: &ChatCompletionAssistantMessage,
+    ) -> Result<String> {
+        let content = match message.content() {
+            Some(content) => content.to_string(),
+            // Note that the content is optional if `tool_calls` is specified.
+            None => match message.tool_calls().is_some() {
+                true => String::new(),
+                false => return Err(PromptError::NoAssistantMessage),
+            },
+        };
+
+        Ok(format!(
+            "{chat_history}\nASSISTANT: {assistant_message}",
+            chat_history = chat_history.as_ref().trim(),
+            assistant_message = content.trim(),
+        ))
+    }
+}
+impl BuildChatPrompt for Qwen2vlPrompt {
+    fn build(&self, messages: &mut Vec<ChatCompletionRequestMessage>) -> Result<String> {
+        if messages.is_empty() {
+            return Err(crate::error::PromptError::NoMessages);
+        }
+
+        // system prompt
+        let system_prompt = match messages[0] {
+            ChatCompletionRequestMessage::System(ref message) => self.create_system_prompt(message),
+            _ => String::from("<|im_start|>system\nAnswer as concisely as possible.<|im_end|>"),
+        };
+
+        // append user/assistant messages
+        let mut prompt = String::new();
+        for message in messages {
+            match message {
+                ChatCompletionRequestMessage::User(message) => {
+                    prompt = self.append_user_message(&prompt, &system_prompt, message)?;
+                }
+                ChatCompletionRequestMessage::Assistant(message) => {
+                    prompt = self.append_assistant_message(&prompt, message)?;
+                }
+                _ => continue,
+            }
+        }
+
+        prompt.push_str("\n<|im_start|>assistant");
+
+        Ok(prompt)
+    }
+}
+
+fn is_image_format(base64_str: &str) -> Result<String> {
+    let image_data = match general_purpose::STANDARD.decode(base64_str) {
+        Ok(data) => data,
+        Err(_) => {
+            return Err(PromptError::Operation(
+                "Failed to decode base64 string.".to_string(),
+            ))
+        }
+    };
+
+    let format = ImageReader::new(Cursor::new(image_data))
+        .with_guessed_format()
+        .unwrap()
+        .format();
+
+    let image_format = match format {
+        Some(image::ImageFormat::Png) => "png".to_string(),
+        Some(image::ImageFormat::Jpeg) => "jpeg".to_string(),
+        Some(image::ImageFormat::Tga) => "tga".to_string(),
+        Some(image::ImageFormat::Bmp) => "bmp".to_string(),
+        Some(image::ImageFormat::Gif) => "gif".to_string(),
+        Some(image::ImageFormat::Hdr) => "hdr".to_string(),
+        Some(image::ImageFormat::Pnm) => "pnm".to_string(),
+        _ => {
+            return Err(PromptError::Operation(
+                "Unsupported image format.".to_string(),
+            ))
+        }
+    };
+
+    Ok(image_format)
+}

--- a/crates/chat-prompts/src/chat/qwen.rs
+++ b/crates/chat-prompts/src/chat/qwen.rs
@@ -1,12 +1,12 @@
 use super::BuildChatPrompt;
-use crate::error::{PromptError, Result};
-use base64::{engine::general_purpose, Engine as _};
+use crate::{
+    error::{PromptError, Result},
+    utils::get_image_format,
+};
 use endpoints::chat::{
     ChatCompletionAssistantMessage, ChatCompletionRequestMessage, ChatCompletionSystemMessage,
     ChatCompletionUserMessage, ChatCompletionUserMessageContent, ContentPart,
 };
-use image::io::Reader as ImageReader;
-use std::io::Cursor;
 
 /// Qwen2-vl Prompt Template
 #[derive(Debug, Default, Clone)]
@@ -70,7 +70,7 @@ impl Qwen2vlPrompt {
                                 true => String::from("<image>"),
                                 false => {
                                     let base64_str = part.image().url.as_str();
-                                    let format = is_image_format(base64_str)?;
+                                    let format = get_image_format(base64_str)?;
                                     format!(
                                         r#"<img src="data:image/{};base64,{}">"#,
                                         format, base64_str
@@ -163,37 +163,4 @@ impl BuildChatPrompt for Qwen2vlPrompt {
 
         Ok(prompt)
     }
-}
-
-fn is_image_format(base64_str: &str) -> Result<String> {
-    let image_data = match general_purpose::STANDARD.decode(base64_str) {
-        Ok(data) => data,
-        Err(_) => {
-            return Err(PromptError::Operation(
-                "Failed to decode base64 string.".to_string(),
-            ))
-        }
-    };
-
-    let format = ImageReader::new(Cursor::new(image_data))
-        .with_guessed_format()
-        .unwrap()
-        .format();
-
-    let image_format = match format {
-        Some(image::ImageFormat::Png) => "png".to_string(),
-        Some(image::ImageFormat::Jpeg) => "jpeg".to_string(),
-        Some(image::ImageFormat::Tga) => "tga".to_string(),
-        Some(image::ImageFormat::Bmp) => "bmp".to_string(),
-        Some(image::ImageFormat::Gif) => "gif".to_string(),
-        Some(image::ImageFormat::Hdr) => "hdr".to_string(),
-        Some(image::ImageFormat::Pnm) => "pnm".to_string(),
-        _ => {
-            return Err(PromptError::Operation(
-                "Unsupported image format.".to_string(),
-            ))
-        }
-    };
-
-    Ok(image_format)
 }

--- a/crates/chat-prompts/src/chat/vicuna.rs
+++ b/crates/chat-prompts/src/chat/vicuna.rs
@@ -1,12 +1,12 @@
 use super::BuildChatPrompt;
-use crate::error::{PromptError, Result};
-use base64::{engine::general_purpose, Engine as _};
+use crate::{
+    error::{PromptError, Result},
+    utils::get_image_format,
+};
 use endpoints::chat::{
     ChatCompletionAssistantMessage, ChatCompletionRequestMessage, ChatCompletionSystemMessage,
     ChatCompletionUserMessage, ChatCompletionUserMessageContent, ContentPart,
 };
-use image::io::Reader as ImageReader;
-use std::io::Cursor;
 
 /// Vicuna-1.0 Prompt Template
 #[derive(Debug, Default, Clone)]
@@ -242,7 +242,7 @@ impl VicunaLlavaPrompt {
                                 true => String::from("<image>"),
                                 false => {
                                     let base64_str = part.image().url.as_str();
-                                    let format = is_image_format(base64_str)?;
+                                    let format = get_image_format(base64_str)?;
                                     format!(
                                         r#"<img src="data:image/{};base64,{}">"#,
                                         format, base64_str
@@ -327,37 +327,4 @@ impl BuildChatPrompt for VicunaLlavaPrompt {
 
         Ok(prompt)
     }
-}
-
-fn is_image_format(base64_str: &str) -> Result<String> {
-    let image_data = match general_purpose::STANDARD.decode(base64_str) {
-        Ok(data) => data,
-        Err(_) => {
-            return Err(PromptError::Operation(
-                "Failed to decode base64 string.".to_string(),
-            ))
-        }
-    };
-
-    let format = ImageReader::new(Cursor::new(image_data))
-        .with_guessed_format()
-        .unwrap()
-        .format();
-
-    let image_format = match format {
-        Some(image::ImageFormat::Png) => "png".to_string(),
-        Some(image::ImageFormat::Jpeg) => "jpeg".to_string(),
-        Some(image::ImageFormat::Tga) => "tga".to_string(),
-        Some(image::ImageFormat::Bmp) => "bmp".to_string(),
-        Some(image::ImageFormat::Gif) => "gif".to_string(),
-        Some(image::ImageFormat::Hdr) => "hdr".to_string(),
-        Some(image::ImageFormat::Pnm) => "pnm".to_string(),
-        _ => {
-            return Err(PromptError::Operation(
-                "Unsupported image format.".to_string(),
-            ))
-        }
-    };
-
-    Ok(image_format)
 }

--- a/crates/chat-prompts/src/lib.rs
+++ b/crates/chat-prompts/src/lib.rs
@@ -95,6 +95,8 @@ pub enum PromptTemplateType {
     MiniCPMV,
     #[value(name = "moxin-chat")]
     MoxinChat,
+    #[value(name = "falcon3")]
+    Falcon3,
     #[value(name = "embedding")]
     Embedding,
     #[value(name = "none")]
@@ -128,7 +130,8 @@ impl PromptTemplateType {
             | PromptTemplateType::NemotronChat
             | PromptTemplateType::NemotronTool
             | PromptTemplateType::MiniCPMV
-            | PromptTemplateType::MoxinChat => true,
+            | PromptTemplateType::MoxinChat
+            | PromptTemplateType::Falcon3 => true,
             PromptTemplateType::MistralInstruct
             | PromptTemplateType::MistralTool
             | PromptTemplateType::MistralLite
@@ -196,6 +199,7 @@ impl FromStr for PromptTemplateType {
             "functionary-31" => Ok(PromptTemplateType::FunctionaryV31),
             "minicpmv" => Ok(PromptTemplateType::MiniCPMV),
             "moxin-chat" => Ok(PromptTemplateType::MoxinChat),
+            "falcon3" => Ok(PromptTemplateType::Falcon3),
             "embedding" => Ok(PromptTemplateType::Embedding),
             "none" => Ok(PromptTemplateType::Null),
             _ => Err(error::PromptError::UnknownPromptTemplateType(
@@ -248,6 +252,7 @@ impl std::fmt::Display for PromptTemplateType {
             PromptTemplateType::FunctionaryV31 => write!(f, "functionary-31"),
             PromptTemplateType::MiniCPMV => write!(f, "minicpmv"),
             PromptTemplateType::MoxinChat => write!(f, "moxin-chat"),
+            PromptTemplateType::Falcon3 => write!(f, "falcon3"),
             PromptTemplateType::Embedding => write!(f, "embedding"),
             PromptTemplateType::Null => write!(f, "none"),
         }

--- a/crates/chat-prompts/src/lib.rs
+++ b/crates/chat-prompts/src/lib.rs
@@ -63,6 +63,8 @@ pub enum PromptTemplateType {
     DeepseekChat2,
     #[value(name = "deepseek-chat-25")]
     DeepseekChat25,
+    #[value(name = "deepseek-chat-3")]
+    DeepseekChat3,
     #[value(name = "solar-instruct")]
     SolarInstruct,
     #[value(name = "phi-2-chat")]
@@ -123,6 +125,7 @@ impl PromptTemplateType {
             | PromptTemplateType::IntelNeural
             | PromptTemplateType::DeepseekCoder
             | PromptTemplateType::DeepseekChat2
+            | PromptTemplateType::DeepseekChat3
             | PromptTemplateType::Octopus
             | PromptTemplateType::Phi3Chat
             | PromptTemplateType::Glm4Chat
@@ -186,6 +189,7 @@ impl FromStr for PromptTemplateType {
             "deepseek-coder" => Ok(PromptTemplateType::DeepseekCoder),
             "deepseek-chat-2" => Ok(PromptTemplateType::DeepseekChat2),
             "deepseek-chat-25" => Ok(PromptTemplateType::DeepseekChat25),
+            "deepseek-chat-3" => Ok(PromptTemplateType::DeepseekChat3),
             "solar-instruct" => Ok(PromptTemplateType::SolarInstruct),
             "phi-2-chat" => Ok(PromptTemplateType::Phi2Chat),
             "phi-2-instruct" => Ok(PromptTemplateType::Phi2Instruct),
@@ -239,6 +243,7 @@ impl std::fmt::Display for PromptTemplateType {
             PromptTemplateType::DeepseekCoder => write!(f, "deepseek-coder"),
             PromptTemplateType::DeepseekChat2 => write!(f, "deepseek-chat-2"),
             PromptTemplateType::DeepseekChat25 => write!(f, "deepseek-chat-25"),
+            PromptTemplateType::DeepseekChat3 => write!(f, "deepseek-chat-3"),
             PromptTemplateType::SolarInstruct => write!(f, "solar-instruct"),
             PromptTemplateType::Phi2Chat => write!(f, "phi-2-chat"),
             PromptTemplateType::Phi2Instruct => write!(f, "phi-2-instruct"),

--- a/crates/chat-prompts/src/lib.rs
+++ b/crates/chat-prompts/src/lib.rs
@@ -76,6 +76,8 @@ pub enum PromptTemplateType {
     Phi3Chat,
     #[value(name = "phi-3-instruct")]
     Phi3Instruct,
+    #[value(name = "phi-4-chat")]
+    Phi4Chat,
     #[value(name = "gemma-instruct")]
     GemmaInstruct,
     #[value(name = "octopus")]
@@ -131,6 +133,7 @@ impl PromptTemplateType {
             | PromptTemplateType::DeepseekChat3
             | PromptTemplateType::Octopus
             | PromptTemplateType::Phi3Chat
+            | PromptTemplateType::Phi4Chat
             | PromptTemplateType::Glm4Chat
             | PromptTemplateType::GroqLlama3Tool
             | PromptTemplateType::BreezeInstruct
@@ -199,6 +202,7 @@ impl FromStr for PromptTemplateType {
             "phi-2-instruct" => Ok(PromptTemplateType::Phi2Instruct),
             "phi-3-chat" => Ok(PromptTemplateType::Phi3Chat),
             "phi-3-instruct" => Ok(PromptTemplateType::Phi3Instruct),
+            "phi-4-chat" => Ok(PromptTemplateType::Phi4Chat),
             "gemma-instruct" => Ok(PromptTemplateType::GemmaInstruct),
             "octopus" => Ok(PromptTemplateType::Octopus),
             "glm-4-chat" => Ok(PromptTemplateType::Glm4Chat),
@@ -254,6 +258,7 @@ impl std::fmt::Display for PromptTemplateType {
             PromptTemplateType::Phi2Instruct => write!(f, "phi-2-instruct"),
             PromptTemplateType::Phi3Chat => write!(f, "phi-3-chat"),
             PromptTemplateType::Phi3Instruct => write!(f, "phi-3-instruct"),
+            PromptTemplateType::Phi4Chat => write!(f, "phi-4-chat"),
             PromptTemplateType::CodeLlamaSuper => write!(f, "codellama-super-instruct"),
             PromptTemplateType::GemmaInstruct => write!(f, "gemma-instruct"),
             PromptTemplateType::Octopus => write!(f, "octopus"),

--- a/crates/chat-prompts/src/lib.rs
+++ b/crates/chat-prompts/src/lib.rs
@@ -97,6 +97,8 @@ pub enum PromptTemplateType {
     MoxinChat,
     #[value(name = "falcon3")]
     Falcon3,
+    #[value(name = "megrez")]
+    Megrez,
     #[value(name = "embedding")]
     Embedding,
     #[value(name = "none")]
@@ -131,7 +133,8 @@ impl PromptTemplateType {
             | PromptTemplateType::NemotronTool
             | PromptTemplateType::MiniCPMV
             | PromptTemplateType::MoxinChat
-            | PromptTemplateType::Falcon3 => true,
+            | PromptTemplateType::Falcon3
+            | PromptTemplateType::Megrez => true,
             PromptTemplateType::MistralInstruct
             | PromptTemplateType::MistralTool
             | PromptTemplateType::MistralLite
@@ -200,6 +203,7 @@ impl FromStr for PromptTemplateType {
             "minicpmv" => Ok(PromptTemplateType::MiniCPMV),
             "moxin-chat" => Ok(PromptTemplateType::MoxinChat),
             "falcon3" => Ok(PromptTemplateType::Falcon3),
+            "megrez" => Ok(PromptTemplateType::Megrez),
             "embedding" => Ok(PromptTemplateType::Embedding),
             "none" => Ok(PromptTemplateType::Null),
             _ => Err(error::PromptError::UnknownPromptTemplateType(
@@ -253,6 +257,7 @@ impl std::fmt::Display for PromptTemplateType {
             PromptTemplateType::MiniCPMV => write!(f, "minicpmv"),
             PromptTemplateType::MoxinChat => write!(f, "moxin-chat"),
             PromptTemplateType::Falcon3 => write!(f, "falcon3"),
+            PromptTemplateType::Megrez => write!(f, "megrez"),
             PromptTemplateType::Embedding => write!(f, "embedding"),
             PromptTemplateType::Null => write!(f, "none"),
         }

--- a/crates/chat-prompts/src/lib.rs
+++ b/crates/chat-prompts/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod chat;
 pub mod error;
+pub mod utils;
 
 use clap::ValueEnum;
 use endpoints::chat::ChatCompletionRequestMessage;

--- a/crates/chat-prompts/src/lib.rs
+++ b/crates/chat-prompts/src/lib.rs
@@ -101,6 +101,8 @@ pub enum PromptTemplateType {
     Falcon3,
     #[value(name = "megrez")]
     Megrez,
+    #[value(name = "qwen2-vision")]
+    Qwen2vl,
     #[value(name = "embedding")]
     Embedding,
     #[value(name = "none")]
@@ -137,7 +139,8 @@ impl PromptTemplateType {
             | PromptTemplateType::MiniCPMV
             | PromptTemplateType::MoxinChat
             | PromptTemplateType::Falcon3
-            | PromptTemplateType::Megrez => true,
+            | PromptTemplateType::Megrez
+            | PromptTemplateType::Qwen2vl => true,
             PromptTemplateType::MistralInstruct
             | PromptTemplateType::MistralTool
             | PromptTemplateType::MistralLite
@@ -208,6 +211,7 @@ impl FromStr for PromptTemplateType {
             "moxin-chat" => Ok(PromptTemplateType::MoxinChat),
             "falcon3" => Ok(PromptTemplateType::Falcon3),
             "megrez" => Ok(PromptTemplateType::Megrez),
+            "qwen2-vision" => Ok(PromptTemplateType::Qwen2vl),
             "embedding" => Ok(PromptTemplateType::Embedding),
             "none" => Ok(PromptTemplateType::Null),
             _ => Err(error::PromptError::UnknownPromptTemplateType(
@@ -263,6 +267,7 @@ impl std::fmt::Display for PromptTemplateType {
             PromptTemplateType::MoxinChat => write!(f, "moxin-chat"),
             PromptTemplateType::Falcon3 => write!(f, "falcon3"),
             PromptTemplateType::Megrez => write!(f, "megrez"),
+            PromptTemplateType::Qwen2vl => write!(f, "qwen2-vision"),
             PromptTemplateType::Embedding => write!(f, "embedding"),
             PromptTemplateType::Null => write!(f, "none"),
         }

--- a/crates/chat-prompts/src/utils.rs
+++ b/crates/chat-prompts/src/utils.rs
@@ -1,0 +1,38 @@
+use crate::error::{PromptError, Result};
+use base64::{engine::general_purpose, Engine as _};
+use image::io::Reader as ImageReader;
+use std::io::Cursor;
+
+/// Get the image format from a base64-encoded image string.
+pub fn get_image_format(base64_str: &str) -> Result<String> {
+    let image_data = match general_purpose::STANDARD.decode(base64_str) {
+        Ok(data) => data,
+        Err(_) => {
+            return Err(PromptError::Operation(
+                "Failed to decode base64 string.".to_string(),
+            ))
+        }
+    };
+
+    let format = ImageReader::new(Cursor::new(image_data))
+        .with_guessed_format()
+        .unwrap()
+        .format();
+
+    let image_format = match format {
+        Some(image::ImageFormat::Png) => "png".to_string(),
+        Some(image::ImageFormat::Jpeg) => "jpeg".to_string(),
+        Some(image::ImageFormat::Tga) => "tga".to_string(),
+        Some(image::ImageFormat::Bmp) => "bmp".to_string(),
+        Some(image::ImageFormat::Gif) => "gif".to_string(),
+        Some(image::ImageFormat::Hdr) => "hdr".to_string(),
+        Some(image::ImageFormat::Pnm) => "pnm".to_string(),
+        _ => {
+            return Err(PromptError::Operation(
+                "Unsupported image format.".to_string(),
+            ))
+        }
+    };
+
+    Ok(image_format)
+}

--- a/crates/endpoints/Cargo.toml
+++ b/crates/endpoints/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endpoints"
-version = "0.23.2"
+version = "0.24.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/endpoints/src/chat.rs
+++ b/crates/endpoints/src/chat.rs
@@ -246,6 +246,11 @@ impl ChatCompletionRequestBuilder {
     /// # Argument
     ///
     /// * `max_tokens` - The maximum number of tokens to generate in the chat completion. `-1` means infinity. `-2` means until context filled. Defaults to `-1`.
+    #[deprecated(
+        since = "0.24.0",
+        note = "Please use `with_max_completion_tokens` instead."
+    )]
+    #[allow(deprecated)]
     pub fn with_max_tokens(mut self, max_tokens: i32) -> Self {
         self.req.max_tokens = Some(max_tokens);
         self
@@ -414,11 +419,12 @@ pub struct ChatCompletionRequest {
     /// Defaults to None
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stop: Option<Vec<String>>,
-    /// **Deprecated** Use `max_completion_tokens` instead.
+    /// **Deprecated since 0.24.0.** Use `max_completion_tokens` instead.
     ///
     /// The maximum number of tokens to generate.
     /// `-1` means infinity. `-2` means until context filled. Defaults to `-1`.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[deprecated(since = "0.24.0", note = "Please use `max_completion_tokens` instead.")]
     pub max_tokens: Option<i32>,
     /// An upper bound for the number of tokens that can be generated for a completion. `-1` means infinity. `-2` means until context filled. Defaults to `-1`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -442,11 +448,18 @@ pub struct ChatCompletionRequest {
     pub user: Option<String>,
 
     //* OpenAI specific parameters
-    /// **Deprecated since 0.10.0.** Use `tools` instead.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[deprecated(
+        since = "0.10.0",
+        note = "Please use `tools` and `tool_choice` instead."
+    )]
+    #[allow(deprecated)]
     pub functions: Option<Vec<ChatCompletionRequestFunction>>,
-    /// **Deprecated since 0.10.0.** Use `tool_choice` instead.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[deprecated(
+        since = "0.10.0",
+        note = "Please use `tools` and `tool_choice` instead."
+    )]
     pub function_call: Option<String>,
 
     /// Format that the model must output
@@ -491,6 +504,7 @@ pub struct ChatCompletionRequest {
     #[serde(rename = "vdb_api_key", skip_serializing_if = "Option::is_none")]
     pub vdb_api_key: Option<String>,
 }
+#[allow(deprecated)]
 impl<'de> Deserialize<'de> for ChatCompletionRequest {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -697,6 +711,7 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
         )
     }
 }
+#[allow(deprecated)]
 impl Default for ChatCompletionRequest {
     fn default() -> Self {
         Self {
@@ -2661,7 +2676,6 @@ impl std::fmt::Display for ChatCompletionRole {
     }
 }
 
-/// **Deprecated since 0.10.0.** Use [Tool] instead.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ChatCompletionRequestFunction {
     name: String,

--- a/crates/endpoints/src/chat.rs
+++ b/crates/endpoints/src/chat.rs
@@ -25,7 +25,8 @@
 //! messages.push(user_message);
 //!
 //! // create a chat completion request
-//! let request = ChatCompletionRequestBuilder::new("model-id", messages)
+//! let request = ChatCompletionRequestBuilder::new(messages)
+//!     .with_model("model-id")
 //!     .with_tool_choice(ToolChoice::None)
 //!     .build();
 //!
@@ -118,7 +119,8 @@
 //! };
 //!
 //! // create a chat completion request
-//! let request = ChatCompletionRequestBuilder::new("model-id", messages)
+//! let request = ChatCompletionRequestBuilder::new(messages)
+//!     .with_model("model-id")
 //!     .with_sampling(ChatCompletionRequestSampling::Temperature(0.8))
 //!     .with_n_choices(3)
 //!     .enable_stream(true)

--- a/crates/endpoints/src/chat.rs
+++ b/crates/endpoints/src/chat.rs
@@ -25,7 +25,7 @@
 //! messages.push(user_message);
 //!
 //! // create a chat completion request
-//! let request = ChatCompletionRequestBuilder::new(messages)
+//! let request = ChatCompletionRequestBuilder::new(&messages)
 //!     .with_model("model-id")
 //!     .with_tool_choice(ToolChoice::None)
 //!     .build();
@@ -119,7 +119,7 @@
 //! };
 //!
 //! // create a chat completion request
-//! let request = ChatCompletionRequestBuilder::new(messages)
+//! let request = ChatCompletionRequestBuilder::new(&messages)
 //!     .with_model("model-id")
 //!     .with_sampling(ChatCompletionRequestSampling::Temperature(0.8))
 //!     .with_n_choices(3)
@@ -166,10 +166,10 @@ impl ChatCompletionRequestBuilder {
     /// # Arguments
     ///
     /// * `messages` - A list of messages comprising the conversation so far.
-    pub fn new(messages: Vec<ChatCompletionRequestMessage>) -> Self {
+    pub fn new(messages: &[ChatCompletionRequestMessage]) -> Self {
         Self {
             req: ChatCompletionRequest {
-                messages,
+                messages: messages.to_vec(),
                 ..Default::default()
             },
         }
@@ -726,7 +726,7 @@ fn test_chat_serialize_chat_request() {
             ChatCompletionAssistantMessage::new(Some("Hello, world!".to_string()), None, None),
         );
         messages.push(assistant_message);
-        let request = ChatCompletionRequestBuilder::new(messages)
+        let request = ChatCompletionRequestBuilder::new(&messages)
             .with_model("model-id")
             .with_sampling(ChatCompletionRequestSampling::Temperature(0.8))
             .with_n_choices(3)
@@ -763,7 +763,7 @@ fn test_chat_serialize_chat_request() {
             ChatCompletionRequestMessage::new_user_message(user_message_content, None);
         messages.push(user_message);
 
-        let request = ChatCompletionRequestBuilder::new(messages)
+        let request = ChatCompletionRequestBuilder::new(&messages)
             .with_model("model-id")
             .with_tool_choice(ToolChoice::None)
             .build();
@@ -847,7 +847,7 @@ fn test_chat_serialize_chat_request() {
             },
         };
 
-        let request = ChatCompletionRequestBuilder::new(messages)
+        let request = ChatCompletionRequestBuilder::new(&messages)
             .with_model("model-id")
             .with_sampling(ChatCompletionRequestSampling::Temperature(0.8))
             .with_n_choices(3)
@@ -946,7 +946,7 @@ fn test_chat_serialize_chat_request() {
             },
         };
 
-        let request = ChatCompletionRequestBuilder::new(messages)
+        let request = ChatCompletionRequestBuilder::new(&messages)
             .with_model("model-id")
             .with_sampling(ChatCompletionRequestSampling::Temperature(0.8))
             .with_n_choices(3)
@@ -1041,7 +1041,8 @@ fn test_chat_serialize_chat_request() {
             },
         };
 
-        let request = ChatCompletionRequestBuilder::new("model-id", messages)
+        let request = ChatCompletionRequestBuilder::new(&messages)
+            .with_model("model-id")
             .with_sampling(ChatCompletionRequestSampling::Temperature(0.8))
             .with_n_choices(3)
             .enable_stream(true)

--- a/crates/endpoints/src/chat.rs
+++ b/crates/endpoints/src/chat.rs
@@ -479,11 +479,11 @@ pub struct ChatCompletionRequest {
         skip_serializing_if = "Option::is_none"
     )]
     pub vdb_collection_name: Option<Vec<String>>,
-    /// Max number of retrieved results. The number of the values must be the same as the number of `qdrant_collection_name`.
+    /// Max number of retrieved results. The number of the values must be the same as the number of `vdb_collection_name`.
     #[cfg(feature = "rag")]
     #[serde(rename = "limit", skip_serializing_if = "Option::is_none")]
     pub limit: Option<Vec<u64>>,
-    /// The score threshold for the retrieved results. The number of the values must be the same as the number of `qdrant_collection_name`.
+    /// The score threshold for the retrieved results. The number of the values must be the same as the number of `vdb_collection_name`.
     #[cfg(feature = "rag")]
     #[serde(rename = "score_threshold", skip_serializing_if = "Option::is_none")]
     pub score_threshold: Option<Vec<f32>>,
@@ -1312,7 +1312,7 @@ fn test_chat_serialize_response_format() {
     assert_eq!(json, r#"{"type":"json_object"}"#);
 }
 
-/// Options for streaming response. Only set this when you set stream: `true``.
+/// Options for streaming response. Only set this when you set stream: `true`.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct StreamOptions {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/endpoints/src/chat.rs
+++ b/crates/endpoints/src/chat.rs
@@ -34,7 +34,7 @@
 //! let json = serde_json::to_string(&request).unwrap();
 //! assert_eq!(
 //!     json,
-//!     r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":[{"type":"text","text":"what is in the picture?"},{"type":"image_url","image_url":{"url":"https://example.com/image.png"}}]}],"temperature":1.0,"top_p":1.0,"n":1,"stream":false,"max_tokens":1024,"presence_penalty":0.0,"frequency_penalty":0.0,"tool_choice":"none"}"#
+//!     r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":[{"type":"text","text":"what is in the picture?"},{"type":"image_url","image_url":{"url":"https://example.com/image.png"}}]}],"temperature":0.8,"top_p":0.9,"n":1,"stream":false,"max_tokens":1024,"presence_penalty":0.0,"frequency_penalty":0.0,"tool_choice":"none"}"#
 //! );
 //! ```
 //!
@@ -376,19 +376,19 @@ pub struct ChatCompletionRequest {
     /// Adjust the randomness of the generated text. Between 0.0 and 2.0. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.
     ///
     /// We generally recommend altering this or top_p but not both.
-    /// Defaults to 1.0.
+    /// Defaults to `0.8`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f64>,
-    /// Limit the next token selection to a subset of tokens with a cumulative probability above a threshold P. The value should be between 0.0 and 1.0.
+    /// An alternative to sampling with temperature. Limit the next token selection to a subset of tokens with a cumulative probability above a threshold `p`. The value should be between 0.0 and 1.0.
     ///
-    /// Top-p sampling, also known as nucleus sampling, is another text generation method that selects the next token from a subset of tokens that together have a cumulative probability of at least p. This method provides a balance between diversity and quality by considering both the probabilities of tokens and the number of tokens to sample from. A higher value for top_p (e.g., 0.95) will lead to more diverse text, while a lower value (e.g., 0.5) will generate more focused and conservative text.
+    /// Top-p sampling, also known as nucleus sampling, is another text generation method that selects the next token from a subset of tokens that together have a cumulative probability of at least `p`. This method provides a balance between diversity and quality by considering both the probabilities of tokens and the number of tokens to sample from. A higher value for top_p (e.g., 0.95) will lead to more diverse text, while a lower value (e.g., 0.5) will generate more focused and conservative text.
     ///
     /// We generally recommend altering this or temperature but not both.
-    /// Defaults to 1.0.
+    /// Defaults to `0.9`. To disable top-p sampling, set it to `1.0`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub top_p: Option<f64>,
     /// How many chat completion choices to generate for each input message.
-    /// Defaults to 1.
+    /// Defaults to `1`.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "n")]
     pub n_choice: Option<u64>,
@@ -677,8 +677,8 @@ impl Default for ChatCompletionRequest {
         Self {
             model: None,
             messages: vec![],
-            temperature: Some(1.0),
-            top_p: Some(1.0),
+            temperature: Some(0.8),
+            top_p: Some(0.9),
             n_choice: Some(1),
             stream: Some(false),
             stream_options: None,
@@ -770,7 +770,7 @@ fn test_chat_serialize_chat_request() {
         let json = serde_json::to_string(&request).unwrap();
         assert_eq!(
             json,
-            r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":[{"type":"text","text":"what is in the picture?"},{"type":"image_url","image_url":{"url":"https://example.com/image.png"}}]}],"temperature":1.0,"top_p":1.0,"n":1,"stream":false,"max_tokens":1024,"presence_penalty":0.0,"frequency_penalty":0.0,"tool_choice":"none"}"#
+            r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":[{"type":"text","text":"what is in the picture?"},{"type":"image_url","image_url":{"url":"https://example.com/image.png"}}]}],"temperature":0.8,"top_p":0.9,"n":1,"stream":false,"max_tokens":1024,"presence_penalty":0.0,"frequency_penalty":0.0,"tool_choice":"none"}"#
         );
     }
 

--- a/crates/llama-core/Cargo.toml
+++ b/crates/llama-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-core"
-version = "0.25.3"
+version = "0.26.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/llama-core/src/chat.rs
+++ b/crates/llama-core/src/chat.rs
@@ -2017,6 +2017,13 @@ fn post_process(
         } else {
             s.to_owned()
         }
+    } else if *template_ty == PromptTemplateType::Falcon3 {
+        let s = output.as_ref().trim();
+        if s.ends_with("<|endoftext|>") {
+            s.trim_end_matches("<|endoftext|>").trim().to_owned()
+        } else {
+            s.to_owned()
+        }
     } else if *template_ty == PromptTemplateType::Megrez {
         let s = output.as_ref().trim();
         if s.ends_with("<|turn_end|>") {

--- a/crates/llama-core/src/chat.rs
+++ b/crates/llama-core/src/chat.rs
@@ -2051,6 +2051,13 @@ fn post_process(
         } else {
             s.to_owned()
         }
+    } else if *template_ty == PromptTemplateType::Phi4Chat {
+        let s = output.as_ref().trim();
+        if s.ends_with("<|im_end|>") {
+            s.trim_end_matches("<|im_end|>").trim().to_owned()
+        } else {
+            s.to_owned()
+        }
     } else if *template_ty == PromptTemplateType::FunctionaryV31 {
         let mut s = output.as_ref().trim();
         if s.ends_with("<|eot_id|>") {

--- a/crates/llama-core/src/chat.rs
+++ b/crates/llama-core/src/chat.rs
@@ -2017,6 +2017,13 @@ fn post_process(
         } else {
             s.to_owned()
         }
+    } else if *template_ty == PromptTemplateType::Megrez {
+        let s = output.as_ref().trim();
+        if s.ends_with("<|turn_end|>") {
+            s.trim_end_matches("<|turn_end|>").trim().to_owned()
+        } else {
+            s.to_owned()
+        }
     } else {
         output.as_ref().trim().to_owned()
     };

--- a/crates/llama-core/src/chat.rs
+++ b/crates/llama-core/src/chat.rs
@@ -2356,6 +2356,7 @@ async fn download_image(image_url: impl AsRef<str>) -> Result<String, LlamaCoreE
         let err_msg = format!("Failed to create archive document {}. {}", &fname, e);
 
         // log
+        #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
 
         LlamaCoreError::Operation(err_msg)

--- a/crates/llama-core/src/chat.rs
+++ b/crates/llama-core/src/chat.rs
@@ -2244,7 +2244,7 @@ fn build_prompt(
                             }
                         } else if token_info.prompt_tokens > ctx_size {
                             let err_msg = format!(
-                                    "The number of prompt tokens is greater than the context size: {} > {}",
+                                    "The number of prompt tokens ({}) is greater than the context size ({}). Please increase the context size, or simplify the input message.",
                                     token_info.prompt_tokens, ctx_size
                                 );
 
@@ -2278,7 +2278,7 @@ fn build_prompt(
                             chat_request.messages.remove(0);
                         } else if token_info.prompt_tokens > ctx_size {
                             let err_msg = format!(
-                                    "The number of prompt tokens is greater than the context size: {} > {}",
+                                    "The number of prompt tokens ({}) is greater than the context size ({}). Please increase the context size, or simplify the input message.",
                                     token_info.prompt_tokens, ctx_size
                                 );
 

--- a/crates/llama-core/src/metadata/ggml.rs
+++ b/crates/llama-core/src/metadata/ggml.rs
@@ -91,6 +91,11 @@ impl GgmlMetadataBuilder {
         self
     }
 
+    pub fn with_split_mode(mut self, mode: String) -> Self {
+        self.metadata.split_mode = mode;
+        self
+    }
+
     pub fn with_ctx_size(mut self, size: u64) -> Self {
         self.metadata.ctx_size = size;
         self
@@ -184,12 +189,20 @@ pub struct GgmlMetadata {
     #[serde(rename = "main-gpu")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub main_gpu: Option<u64>,
-    /// How split tensors should be distributed accross GPUs. If None the model is not split; otherwise, a comma-separated list of non-negative values, e.g., "3,2" presents 60% of the data to GPU 0 and 40% to GPU 1.
+    /// How split tensors should be distributed accross GPUs. If None the model is not split; otherwise, a comma-separated list of non-negative values, e.g., "3,2" presents 60% of the data to GPU 0 and 40% to GPU 1. Defaults to None.
     #[serde(rename = "tensor-split")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tensor_split: Option<String>,
+    /// Whether to use memory-mapped files for the model. Defaults to `true`.
     #[serde(skip_serializing_if = "Option::is_none", rename = "use-mmap")]
     pub use_mmap: Option<bool>,
+    /// How to split the model across multiple GPUs. Possible values:
+    /// - `none`: use one GPU only
+    /// - `layer`: split layers and KV across GPUs (default)
+    /// - `row`: split rows across GPUs
+    #[serde(rename = "split-mode")]
+    pub split_mode: String,
+
     // * Context parameters (used by the llama context):
     #[serde(rename = "ctx-size")]
     pub ctx_size: u64,
@@ -235,6 +248,7 @@ impl Default for GgmlMetadata {
             main_gpu: None,
             tensor_split: None,
             use_mmap: Some(true),
+            split_mode: "layer".to_string(),
             ctx_size: 512,
             batch_size: 512,
             threads: 2,

--- a/crates/llama-core/src/metadata/ggml.rs
+++ b/crates/llama-core/src/metadata/ggml.rs
@@ -46,7 +46,7 @@ impl GgmlMetadataBuilder {
         self
     }
 
-    pub fn with_n_predict(mut self, n: u64) -> Self {
+    pub fn with_n_predict(mut self, n: i32) -> Self {
         self.metadata.n_predict = n;
         self
     }
@@ -171,8 +171,10 @@ pub struct GgmlMetadata {
     // pub stream_stdout: bool,
     #[serde(rename = "embedding")]
     pub embeddings: bool,
+    /// Number of tokens to predict, -1 = infinity, -2 = until context filled. Defaults to -1.
     #[serde(rename = "n-predict")]
-    pub n_predict: u64,
+    pub n_predict: i32,
+    /// Halt generation at PROMPT, return control in interactive mode.
     #[serde(skip_serializing_if = "Option::is_none", rename = "reverse-prompt")]
     pub reverse_prompt: Option<String>,
     /// path to the multimodal projector file for llava
@@ -240,7 +242,7 @@ impl Default for GgmlMetadata {
             prompt_template: PromptTemplateType::Llama2Chat,
             log_enable: false,
             embeddings: false,
-            n_predict: 1024,
+            n_predict: -1,
             reverse_prompt: None,
             mmproj: None,
             image: None,

--- a/llama-api-server/Cargo.toml
+++ b/llama-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-api-server"
-version = "0.15.2"
+version = "0.16.0"
 edition = "2021"
 
 [dependencies]

--- a/llama-api-server/src/main.rs
+++ b/llama-api-server/src/main.rs
@@ -68,9 +68,9 @@ struct Cli {
     /// Halt generation at PROMPT, return control.
     #[arg(short, long)]
     reverse_prompt: Option<String>,
-    /// Number of tokens to predict
-    #[arg(short, long, default_value = "1024")]
-    n_predict: u64,
+    /// Number of tokens to predict, -1 = infinity, -2 = until context filled.
+    #[arg(short, long, default_value = "-1")]
+    n_predict: i32,
     /// Number of layers to run on the GPU
     #[arg(short = 'g', long, default_value = "100")]
     n_gpu_layers: u64,
@@ -150,8 +150,8 @@ struct CliConfig {
     prompt_template: Vec<PromptTemplateType>,
     /// Halt generation at PROMPT, return control.
     reverse_prompt: Option<String>,
-    /// Number of tokens to predict
-    n_predict: u64,
+    /// Number of tokens to predict, -1 = infinity, -2 = until context filled.
+    n_predict: i32,
     /// Number of layers to run on the GPU
     n_gpu_layers: u64,
     /// Split the model across multiple GPUs. Possible values:
@@ -534,8 +534,6 @@ async fn main() -> Result<(), ServerError> {
     wasi_logger::Logger::install().expect("failed to install wasi_logger::Logger");
     log::set_max_level(log_level.into());
 
-    info!(target: "stdout", "log_level: {}", log_level);
-
     if let Ok(api_key) = std::env::var("API_KEY") {
         // define a const variable for the API key
         if let Err(e) = LLAMA_API_KEY.set(api_key) {
@@ -549,6 +547,8 @@ async fn main() -> Result<(), ServerError> {
 
     // parse the command line arguments
     let mut cli = Cli::parse();
+
+    info!(target: "stdout", "log_level: {}", log_level);
 
     // log the version of the server
     info!(target: "stdout", "server version: {}", env!("CARGO_PKG_VERSION"));
@@ -1167,7 +1167,7 @@ pub(crate) struct ModelConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prompt_template: Option<PromptTemplateType>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub n_predict: Option<u64>,
+    pub n_predict: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reverse_prompt: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/llama-api-server/src/main.rs
+++ b/llama-api-server/src/main.rs
@@ -432,7 +432,7 @@ impl<'de> Deserialize<'de> for CliConfig {
 
                 let reverse_prompt = reverse_prompt.unwrap_or_default();
 
-                let n_predict = n_predict.unwrap_or(1024);
+                let n_predict = n_predict.unwrap_or(-1);
 
                 let n_gpu_layers = n_gpu_layers.unwrap_or(100);
 

--- a/llama-chat/Cargo.toml
+++ b/llama-chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-chat"
-version = "0.15.2"
+version = "0.16.0"
 edition = "2021"
 
 [dependencies]

--- a/llama-chat/src/main.rs
+++ b/llama-chat/src/main.rs
@@ -250,7 +250,8 @@ async fn main() -> anyhow::Result<()> {
     };
 
     // create a chat request
-    let mut chat_request = ChatCompletionRequestBuilder::new(&cli.model_name, vec![])
+    let mut chat_request = ChatCompletionRequestBuilder::new(vec![])
+        .with_model(cli.model_name)
         .with_presence_penalty(cli.presence_penalty)
         .with_frequency_penalty(cli.frequency_penalty)
         .with_sampling(sampling)

--- a/llama-chat/src/main.rs
+++ b/llama-chat/src/main.rs
@@ -23,9 +23,9 @@ struct Cli {
     /// Size of the prompt context
     #[arg(short, long, default_value = "512")]
     ctx_size: u64,
-    /// Number of tokens to predict
-    #[arg(short, long, default_value = "1024")]
-    n_predict: u64,
+    /// Number of tokens to predict, -1 = infinity, -2 = until context filled.
+    #[arg(short, long, default_value = "-1")]
+    n_predict: i32,
     /// Number of layers to run on the GPU
     #[arg(short = 'g', long, default_value = "100")]
     n_gpu_layers: u64,

--- a/llama-chat/src/main.rs
+++ b/llama-chat/src/main.rs
@@ -250,7 +250,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     // create a chat request
-    let mut chat_request = ChatCompletionRequestBuilder::new(vec![])
+    let mut chat_request = ChatCompletionRequestBuilder::new(&[])
         .with_model(cli.model_name)
         .with_presence_penalty(cli.presence_penalty)
         .with_frequency_penalty(cli.frequency_penalty)

--- a/llama-simple/Cargo.toml
+++ b/llama-simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-simple"
-version = "0.15.2"
+version = "0.16.0"
 edition = "2021"
 
 [dependencies]

--- a/tests/assets/config.yaml
+++ b/tests/assets/config.yaml
@@ -23,6 +23,8 @@ reverse-prompt: null
 n-predict: 1024
 # Number of layers to run on GPU
 n-gpu-layers: 100
+# Split mode. Possible values: `none`, `layer` (default), `row`.
+split-mode: "layer"
 # Main GPU to use
 main-gpu: null
 # GPU tensor split ratio (e.g., "3,2")


### PR DESCRIPTION
Major changes:

- `llama-api-server`
  - (New) Add the `--split-mode` CLI option
  - (BREAKING) Update the `--n-predict` CLI option
    - Update the type to `i32`
    - Update the default value to `-1`. Keep it consistent with the `--n-predict` CLI option of `llama.cpp`

- `llama-core` crate
  - (NEW) Support `split_mode` in `GgmlMetadata`
  - (BREAKING) Update the type of the `n_predict` field of `GgmlMetadata` to `i32`

- `chat-prompts` crate
  - (NEW) Extend template types: `Phi4Chat`, `DeepseekChat3`, `Qwen2vl`, `Megrez`, and `Falcon3`

- `endpoints` crate
  - (NEW) Add the `with_model` method in `ChatCompletionRequestBuilder`
  - (NEW) Support `max_completion_tokens` in `ChatCompletionRequest`.
  - (BREAKING) Improve the arguments of the `ChatCompletionRequestBuilder::new` method
  - (BREAKING) Update the default value of the `top_p` field of `ChatCompletionRequest` to `0.9`. Keep it consistent with the `--top_p` CLI option of `llama.cpp`.
  - (BREAKING) Update the default value of the `temperature` field of `ChatCompletionRequest` to `0.8`. Keep it consistent with the `--temp` CLI option of `llama.cpp`.
  - (Deprecated) Annotate the `max_tokens` field of `ChatCompletionRequest` deprecated

- Support new GGUF models
  - [Phi-4](https://huggingface.co/second-state/phi-4-GGUF)
  - [DeepSeek-V3](https://huggingface.co/mradermacher/DeepSeek-V3-GGUF)
  - [Qwen2-VL](https://huggingface.co/collections/second-state/qwen2-vl-gguf-models-675ff2389a291a38da0a0fcf)
  - [Falcon3-7B-Instruct](https://huggingface.co/second-state/Falcon3-7B-Instruct-GGUF)
  - [Falcon3-10B-Instruct](https://huggingface.co/second-state/Falcon3-10B-Instruct-GGUF)
  - [Megrez-3B-Instruct](https://huggingface.co/second-state/Megrez-3B-Instruct-GGUF)