### PR TITLE
Release 0.17.1

### DIFF
--- a/.github/workflows/test_api_server.yml
+++ b/.github/workflows/test_api_server.yml
@@ -205,7 +205,7 @@ jobs:
           curl -LO https://huggingface.co/second-state/OuteTTS-0.2-500M-GGUF/resolve/main/OuteTTS-0.2-500M-Q5_K_M.gguf
           curl -LO https://huggingface.co/second-state/OuteTTS-0.2-500M-GGUF/resolve/main/wavtokenizer-large-75-ggml-f16.gguf
           nohup $HOME/.wasmedge/bin/wasmedge --dir .:. --nn-preload default:GGML:AUTO:Llama-3.2-1B-Instruct-Q5_K_M.gguf --nn-preload embedding:GGML:AUTO:nomic-embed-text-v1.5-f16.gguf --nn-preload tts:GGML:AUTO:OuteTTS-0.2-500M-Q5_K_M.gguf llama-api-server.wasm config --file llama_server_config.toml --chat --embedding --tts > ./start-llamaedge.log 2>&1 &
-          sleep 15
+          sleep 20
           cat start-llamaedge.log
 
       - name: Run test_config.hurl
@@ -294,23 +294,23 @@ jobs:
         run: |
           pkill -f wasmedge
 
-      # - name: Start llama-api-server with config file
-      #   run: |
-      #     cp ./tests/assets/llama_server_config.toml ./llama_server_config.toml
-      #     curl -LO https://huggingface.co/second-state/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q5_K_M.gguf
-      #     curl -LO https://huggingface.co/second-state/OuteTTS-0.2-500M-GGUF/resolve/main/OuteTTS-0.2-500M-Q5_K_M.gguf
-      #     curl -LO https://huggingface.co/second-state/OuteTTS-0.2-500M-GGUF/resolve/main/wavtokenizer-large-75-ggml-f16.gguf
-      #     nohup $HOME/.wasmedge/bin/wasmedge --dir .:. --nn-preload default:GGML:AUTO:Llama-3.2-1B-Instruct-Q5_K_M.gguf --nn-preload embedding:GGML:AUTO:nomic-embed-text-v1.5-f16.gguf --nn-preload tts:GGML:AUTO:OuteTTS-0.2-500M-Q5_K_M.gguf llama-api-server.wasm config --file llama_server_config.toml --chat --embedding --tts > ./start-llamaedge.log 2>&1 &
-      #     sleep 15
-      #     cat start-llamaedge.log
+      - name: Start llama-api-server with config file
+        run: |
+          cp ./tests/assets/llama_server_config.toml ./llama_server_config.toml
+          curl -LO https://huggingface.co/second-state/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q5_K_M.gguf
+          curl -LO https://huggingface.co/second-state/OuteTTS-0.2-500M-GGUF/resolve/main/OuteTTS-0.2-500M-Q5_K_M.gguf
+          curl -LO https://huggingface.co/second-state/OuteTTS-0.2-500M-GGUF/resolve/main/wavtokenizer-large-75-ggml-f16.gguf
+          nohup $HOME/.wasmedge/bin/wasmedge --dir .:. --nn-preload default:GGML:AUTO:Llama-3.2-1B-Instruct-Q5_K_M.gguf --nn-preload embedding:GGML:AUTO:nomic-embed-text-v1.5-f16.gguf --nn-preload tts:GGML:AUTO:OuteTTS-0.2-500M-Q5_K_M.gguf llama-api-server.wasm config --file llama_server_config.toml --chat --embedding --tts > ./start-llamaedge.log 2>&1 &
+          sleep 20
+          cat start-llamaedge.log
 
-      # - name: Run test_config.hurl
-      #   run: |
-      #     hurl --test --jobs 1 ./tests/test_config.hurl
+      - name: Run test_config.hurl
+        run: |
+          hurl --test --jobs 1 ./tests/test_config.hurl
 
-      # - name: Stop llama-api-server for testing config
-      #   run: |
-      #     pkill -f wasmedge
+      - name: Stop llama-api-server for testing config
+        run: |
+          pkill -f wasmedge
 
   test-api-server-macos-15:
     runs-on: macos-15
@@ -390,20 +390,20 @@ jobs:
         run: |
           pkill -f wasmedge
 
-      # - name: Start llama-api-server with config file
-      #   run: |
-      #     cp ./tests/assets/llama_server_config.toml ./llama_server_config.toml
-      #     curl -LO https://huggingface.co/second-state/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q5_K_M.gguf
-      #     curl -LO https://huggingface.co/second-state/OuteTTS-0.2-500M-GGUF/resolve/main/OuteTTS-0.2-500M-Q5_K_M.gguf
-      #     curl -LO https://huggingface.co/second-state/OuteTTS-0.2-500M-GGUF/resolve/main/wavtokenizer-large-75-ggml-f16.gguf
-      #     nohup $HOME/.wasmedge/bin/wasmedge --dir .:. --nn-preload default:GGML:AUTO:Llama-3.2-1B-Instruct-Q5_K_M.gguf --nn-preload embedding:GGML:AUTO:nomic-embed-text-v1.5-f16.gguf --nn-preload tts:GGML:AUTO:OuteTTS-0.2-500M-Q5_K_M.gguf llama-api-server.wasm config --file llama_server_config.toml --chat --embedding --tts > ./start-llamaedge.log 2>&1 &
-      #     sleep 15
-      #     cat start-llamaedge.log
+      - name: Start llama-api-server with config file
+        run: |
+          cp ./tests/assets/llama_server_config.toml ./llama_server_config.toml
+          curl -LO https://huggingface.co/second-state/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q5_K_M.gguf
+          curl -LO https://huggingface.co/second-state/OuteTTS-0.2-500M-GGUF/resolve/main/OuteTTS-0.2-500M-Q5_K_M.gguf
+          curl -LO https://huggingface.co/second-state/OuteTTS-0.2-500M-GGUF/resolve/main/wavtokenizer-large-75-ggml-f16.gguf
+          nohup $HOME/.wasmedge/bin/wasmedge --dir .:. --nn-preload default:GGML:AUTO:Llama-3.2-1B-Instruct-Q5_K_M.gguf --nn-preload embedding:GGML:AUTO:nomic-embed-text-v1.5-f16.gguf --nn-preload tts:GGML:AUTO:OuteTTS-0.2-500M-Q5_K_M.gguf llama-api-server.wasm config --file llama_server_config.toml --chat --embedding --tts > ./start-llamaedge.log 2>&1 &
+          sleep 20
+          cat start-llamaedge.log
 
-      # - name: Run test_config.hurl
-      #   run: |
-      #     hurl --test --jobs 1 ./tests/test_config.hurl
+      - name: Run test_config.hurl
+        run: |
+          hurl --test --jobs 1 ./tests/test_config.hurl
 
-      # - name: Stop llama-api-server for testing config
-      #   run: |
-      #     pkill -f wasmedge
+      - name: Stop llama-api-server for testing config
+        run: |
+          pkill -f wasmedge

--- a/.github/workflows/test_api_server.yml
+++ b/.github/workflows/test_api_server.yml
@@ -294,23 +294,23 @@ jobs:
         run: |
           pkill -f wasmedge
 
-      - name: Start llama-api-server with config file
-        run: |
-          cp ./tests/assets/llama_server_config.toml ./llama_server_config.toml
-          curl -LO https://huggingface.co/second-state/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q5_K_M.gguf
-          curl -LO https://huggingface.co/second-state/OuteTTS-0.2-500M-GGUF/resolve/main/OuteTTS-0.2-500M-Q5_K_M.gguf
-          curl -LO https://huggingface.co/second-state/OuteTTS-0.2-500M-GGUF/resolve/main/wavtokenizer-large-75-ggml-f16.gguf
-          nohup $HOME/.wasmedge/bin/wasmedge --dir .:. --nn-preload default:GGML:AUTO:Llama-3.2-1B-Instruct-Q5_K_M.gguf --nn-preload embedding:GGML:AUTO:nomic-embed-text-v1.5-f16.gguf --nn-preload tts:GGML:AUTO:OuteTTS-0.2-500M-Q5_K_M.gguf llama-api-server.wasm config --file llama_server_config.toml --chat --embedding --tts > ./start-llamaedge.log 2>&1 &
-          sleep 20
-          cat start-llamaedge.log
+      # - name: Start llama-api-server with config file
+      #   run: |
+      #     cp ./tests/assets/llama_server_config.toml ./llama_server_config.toml
+      #     curl -LO https://huggingface.co/second-state/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q5_K_M.gguf
+      #     curl -LO https://huggingface.co/second-state/OuteTTS-0.2-500M-GGUF/resolve/main/OuteTTS-0.2-500M-Q5_K_M.gguf
+      #     curl -LO https://huggingface.co/second-state/OuteTTS-0.2-500M-GGUF/resolve/main/wavtokenizer-large-75-ggml-f16.gguf
+      #     nohup $HOME/.wasmedge/bin/wasmedge --dir .:. --nn-preload default:GGML:AUTO:Llama-3.2-1B-Instruct-Q5_K_M.gguf --nn-preload embedding:GGML:AUTO:nomic-embed-text-v1.5-f16.gguf --nn-preload tts:GGML:AUTO:OuteTTS-0.2-500M-Q5_K_M.gguf llama-api-server.wasm config --file llama_server_config.toml --chat --embedding --tts > ./start-llamaedge.log 2>&1 &
+      #     sleep 20
+      #     cat start-llamaedge.log
 
-      - name: Run test_config.hurl
-        run: |
-          hurl --test --jobs 1 ./tests/test_config.hurl
+      # - name: Run test_config.hurl
+      #   run: |
+      #     hurl --test --jobs 1 ./tests/test_config.hurl
 
-      - name: Stop llama-api-server for testing config
-        run: |
-          pkill -f wasmedge
+      # - name: Stop llama-api-server for testing config
+      #   run: |
+      #     pkill -f wasmedge
 
   test-api-server-macos-15:
     runs-on: macos-15
@@ -390,20 +390,20 @@ jobs:
         run: |
           pkill -f wasmedge
 
-      - name: Start llama-api-server with config file
-        run: |
-          cp ./tests/assets/llama_server_config.toml ./llama_server_config.toml
-          curl -LO https://huggingface.co/second-state/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q5_K_M.gguf
-          curl -LO https://huggingface.co/second-state/OuteTTS-0.2-500M-GGUF/resolve/main/OuteTTS-0.2-500M-Q5_K_M.gguf
-          curl -LO https://huggingface.co/second-state/OuteTTS-0.2-500M-GGUF/resolve/main/wavtokenizer-large-75-ggml-f16.gguf
-          nohup $HOME/.wasmedge/bin/wasmedge --dir .:. --nn-preload default:GGML:AUTO:Llama-3.2-1B-Instruct-Q5_K_M.gguf --nn-preload embedding:GGML:AUTO:nomic-embed-text-v1.5-f16.gguf --nn-preload tts:GGML:AUTO:OuteTTS-0.2-500M-Q5_K_M.gguf llama-api-server.wasm config --file llama_server_config.toml --chat --embedding --tts > ./start-llamaedge.log 2>&1 &
-          sleep 20
-          cat start-llamaedge.log
+      # - name: Start llama-api-server with config file
+      #   run: |
+      #     cp ./tests/assets/llama_server_config.toml ./llama_server_config.toml
+      #     curl -LO https://huggingface.co/second-state/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q5_K_M.gguf
+      #     curl -LO https://huggingface.co/second-state/OuteTTS-0.2-500M-GGUF/resolve/main/OuteTTS-0.2-500M-Q5_K_M.gguf
+      #     curl -LO https://huggingface.co/second-state/OuteTTS-0.2-500M-GGUF/resolve/main/wavtokenizer-large-75-ggml-f16.gguf
+      #     nohup $HOME/.wasmedge/bin/wasmedge --dir .:. --nn-preload default:GGML:AUTO:Llama-3.2-1B-Instruct-Q5_K_M.gguf --nn-preload embedding:GGML:AUTO:nomic-embed-text-v1.5-f16.gguf --nn-preload tts:GGML:AUTO:OuteTTS-0.2-500M-Q5_K_M.gguf llama-api-server.wasm config --file llama_server_config.toml --chat --embedding --tts > ./start-llamaedge.log 2>&1 &
+      #     sleep 20
+      #     cat start-llamaedge.log
 
-      - name: Run test_config.hurl
-        run: |
-          hurl --test --jobs 1 ./tests/test_config.hurl
+      # - name: Run test_config.hurl
+      #   run: |
+      #     hurl --test --jobs 1 ./tests/test_config.hurl
 
-      - name: Stop llama-api-server for testing config
-        run: |
-          pkill -f wasmedge
+      # - name: Stop llama-api-server for testing config
+      #   run: |
+      #     pkill -f wasmedge

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 [workspace.dependencies]
 serde            = { version = "1.0", features = ["derive"] }
 serde_json       = "1.0"
-endpoints        = { path = "crates/endpoints", version = "^0.25" }
+endpoints        = { path = "crates/endpoints", version = "^0.26" }
 chat-prompts     = { path = "crates/chat-prompts", version = "^0.27" }
 thiserror        = "1"
 uuid             = { version = "1.4", features = ["v4", "fast-rng", "macro-diagnostics"] }
@@ -21,7 +21,7 @@ log              = { version = "0.4.21", features = ["std", "kv", "kv_serde"] }
 wasi-logger      = { version = "0.1.2", features = ["kv"] }
 either           = "1.12.0"
 base64           = "=0.22.1"
-llama-core       = { path = "crates/llama-core", features = ["logging"], version = "^0.31" }
+llama-core       = { path = "crates/llama-core", features = ["logging"], version = "^0.32" }
 tokio            = { version = "^1.36", features = ["sync", "macros", "io-util", "fs", "net", "rt", "time"] }
 anyhow           = "1"
 once_cell        = "1.18"

--- a/crates/chat-prompts/Cargo.toml
+++ b/crates/chat-prompts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "chat-prompts"
-version       = "0.27.0"
+version       = "0.27.1"
 edition       = "2021"
 readme        = "README.md"
 repository    = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/chat-prompts/src/chat/chatml.rs
+++ b/crates/chat-prompts/src/chat/chatml.rs
@@ -15,10 +15,7 @@ impl ChatMLPrompt {
         let content = message.content();
         match content.is_empty() {
             true => String::from("<|im_start|>system\nAnswer as concisely as possible.<|im_end|>"),
-            false => format!(
-                "<|im_start|>system\n{system_prompt}<|im_end|>",
-                system_prompt = content
-            ),
+            false => format!("<|im_start|>system\n{content}<|im_end|>"),
         }
     }
 
@@ -148,10 +145,7 @@ impl ChatMLToolPrompt {
         let content = message.content();
         match content.is_empty() {
             true => String::from("<|im_start|>system\nAnswer as concisely as possible.<|im_end|>"),
-            false => format!(
-                "<|im_start|>system\n{system_prompt}<|im_end|>",
-                system_prompt = content
-            ),
+            false => format!("<|im_start|>system\n{content}<|im_end|>",),
         }
     }
 
@@ -165,13 +159,13 @@ impl ChatMLToolPrompt {
             true => match tools {
                 Some(tools) => {
                     let available_tools = serde_json::to_string(tools).unwrap();
-                    let tools = format!("<tools> {} </tools>", available_tools);
+                    let tools = format!("<tools> {available_tools} </tools>");
 
                     let begin = r#"<|im_start|>system\nYou are a function calling AI model. You are provided with function signatures within <tools></tools> XML tags. You may call one or more functions to assist with the user query. Don't make assumptions about what values to plug into functions. Here are the available tools:"#;
 
                     let end = r#"Use the following pydantic model json schema for each tool call you will make: {"properties": {"arguments": {"title": "Arguments", "type": "object"}, "name": {"title": "Name", "type": "string"}}, "required": ["arguments", "name"], "title": "FunctionCall", "type": "object"} For each function call return a json object with function name and arguments within <tool_call></tool_call> XML tags as follows:\n<tool_call>\n{"arguments": <args-dict>, "name": <function-name>}\n</tool_call><|im_end|>"#;
 
-                    format!("{} {} {}", begin, tools, end)
+                    format!("{begin} {tools} {end}")
                 }
                 None => {
                     String::from("<|im_start|>system\nAnswer as concisely as possible.<|im_end|>")
@@ -180,22 +174,18 @@ impl ChatMLToolPrompt {
             false => match tools {
                 Some(tools) => {
                     let available_tools = serde_json::to_string(tools).unwrap();
-                    let tools = format!("<tools> {} </tools>", available_tools);
+                    let tools = format!("<tools> {available_tools} </tools>");
 
                     let begin = format!(
-                            "<|im_start|>system\n{system_prompt}\nYou are provided with function signatures within <tools></tools> XML tags. You may call one or more functions to assist with the user query. Don't make assumptions about what values to plug into functions. Here are the available tools:",
-                            system_prompt = content
+                            "<|im_start|>system\n{content}\nYou are provided with function signatures within <tools></tools> XML tags. You may call one or more functions to assist with the user query. Don't make assumptions about what values to plug into functions. Here are the available tools:",
                         );
 
                     let end = r#"Use the following pydantic model json schema for each tool call you will make: {"properties": {"arguments": {"title": "Arguments", "type": "object"}, "name": {"title": "Name", "type": "string"}}, "required": ["arguments", "name"], "title": "FunctionCall", "type": "object"} For each function call return a json object with function name and arguments within <tool_call></tool_call> XML tags as follows:\n<tool_call>\n{"arguments": <args-dict>, "name": <function-name>}\n</tool_call><|im_end|>"#;
 
-                    format!("{} {} {}", begin, tools, end)
+                    format!("{begin} {tools} {end}")
                 }
                 None => {
-                    format!(
-                        "<|im_start|>system\n{system_prompt}<|im_end|>",
-                        system_prompt = content
-                    )
+                    format!("<|im_start|>system\n{content}<|im_end|>")
                 }
             },
         }
@@ -332,13 +322,13 @@ impl BuildChatPrompt for ChatMLToolPrompt {
             _ => match tools {
                 Some(tools) => {
                     let available_tools = serde_json::to_string(tools).unwrap();
-                    let tools = format!("<tools> {} </tools>", available_tools);
+                    let tools = format!("<tools> {available_tools} </tools>");
 
                     let begin = r#"<|im_start|>system\nYou are a function calling AI model. You are provided with function signatures within <tools></tools> XML tags. You may call one or more functions to assist with the user query. Don't make assumptions about what values to plug into functions. Here are the available tools:"#;
 
                     let end = r#"Use the following pydantic model json schema for each tool call you will make: {"properties": {"arguments": {"title": "Arguments", "type": "object"}, "name": {"title": "Name", "type": "string"}}, "required": ["arguments", "name"], "title": "FunctionCall", "type": "object"} For each function call return a json object with function name and arguments within <tool_call></tool_call> XML tags as follows:\n<tool_call>\n{"arguments": <args-dict>, "name": <function-name>}\n</tool_call><|im_end|>"#;
 
-                    format!("{} {} {}", begin, tools, end)
+                    format!("{begin} {tools} {end}")
                 }
                 None => {
                     String::from("<|im_start|>system\nAnswer as concisely as possible.<|im_end|>")
@@ -377,10 +367,7 @@ impl InternLM2ToolPrompt {
         let content = message.content();
         match content.is_empty() {
             true => String::from("<|im_start|>system\nAnswer as concisely as possible.<|im_end|>"),
-            false => format!(
-                "<|im_start|>system\n{system_prompt}<|im_end|>",
-                system_prompt = content
-            ),
+            false => format!("<|im_start|>system\n{content}<|im_end|>"),
         }
     }
 
@@ -396,9 +383,9 @@ impl InternLM2ToolPrompt {
                     let begin = "<|im_start|>system\nYou are InternLM2-Chat, a harmless AI assistant.<|im_end|>";
 
                     let available_tools = serde_json::to_string_pretty(tools).unwrap();
-                    let tools = format!("<|im_start|>system name=<|plugin|>\n{}\n<|im_end|>", available_tools);
+                    let tools = format!("<|im_start|>system name=<|plugin|>\n{available_tools}\n<|im_end|>");
 
-                    format!("{}\n{}", begin, tools)
+                    format!("{begin}\n{tools}")
                 }
                 None => {
                     String::from("<|im_start|>system\nYou are InternLM2-Chat, a harmless AI assistant.<|im_end|>")
@@ -406,15 +393,15 @@ impl InternLM2ToolPrompt {
             },
             false => match tools {
                 Some(tools) => {
-                    let begin = format!("<|im_start|>system\n{}<|im_end|>", content);
+                    let begin = format!("<|im_start|>system\n{content}<|im_end|>");
 
                     let available_tools = serde_json::to_string_pretty(tools).unwrap();
-                    let tools = format!("<|im_start|>system name=<|plugin|>\n{}\n<|im_end|>", available_tools);
+                    let tools = format!("<|im_start|>system name=<|plugin|>\n{available_tools}\n<|im_end|>");
 
-                    format!("{}\n{}", begin, tools)
+                    format!("{begin}\n{tools}")
                 }
                 None => {
-                    format!("<|im_start|>system\n{}<|im_end|>", content)
+                    format!("<|im_start|>system\n{content}<|im_end|>")
                 }
             },
         }
@@ -553,9 +540,9 @@ impl BuildChatPrompt for InternLM2ToolPrompt {
                     let begin = "<|im_start|>system\nYou are InternLM2-Chat, a harmless AI assistant.<|im_end|>";
 
                     let available_tools = serde_json::to_string_pretty(tools).unwrap();
-                    let tools = format!("<|im_start|>system name=<|plugin|>\n{}\n<|im_end|>", available_tools);
+                    let tools = format!("<|im_start|>system name=<|plugin|>\n{available_tools}\n<|im_end|>");
 
-                    format!("{}\n{}", begin, tools)
+                    format!("{begin}\n{tools}")
                 }
                 None => {
                     String::from("<|im_start|>system\nYou are InternLM2-Chat, a harmless AI assistant.<|im_end|>")
@@ -595,10 +582,7 @@ impl ChatMLThinkPrompt {
         let content = message.content();
         match content.is_empty() {
             true => String::from("<|im_start|>system\nAnswer as concisely as possible.<|im_end|>"),
-            false => format!(
-                "<|im_start|>system\n{system_prompt}<|im_end|>",
-                system_prompt = content
-            ),
+            false => format!("<|im_start|>system\n{content}<|im_end|>"),
         }
     }
 

--- a/crates/chat-prompts/src/chat/deepseek.rs
+++ b/crates/chat-prompts/src/chat/deepseek.rs
@@ -205,7 +205,7 @@ impl DeepseekChat2Prompt {
         let content = message.content();
         match content.is_empty() {
             true => String::from("<|begin▁of▁sentence|>You are an AI programming assistant, utilizing the DeepSeek Coder model, developed by DeepSeek Company, and you only answer questions related to computer science. For politically sensitive questions, security and privacy issues, and other non-computer science questions, you will refuse to answer."),
-            false => format!("<|begin▁of▁sentence|>{system_message}", system_message=content),
+            false => format!("<|begin▁of▁sentence|>{content}"),
         }
     }
 
@@ -314,10 +314,7 @@ impl DeepseekChat25Prompt {
         let content = message.content();
         match content.is_empty() {
             true => String::from("<|begin▁of▁sentence|>"),
-            false => format!(
-                "<|begin▁of▁sentence|>{system_message}",
-                system_message = content
-            ),
+            false => format!("<|begin▁of▁sentence|>{content}"),
         }
     }
 

--- a/crates/chat-prompts/src/chat/exaone.rs
+++ b/crates/chat-prompts/src/chat/exaone.rs
@@ -15,8 +15,7 @@ impl ExaoneDeepChatPrompt {
         match content.is_empty() {
             true => String::from("[|system|]You are a helpful AI assistant. Answer questions as concisely and accurately as possible.[|endofturn|]"),
             false => format!(
-                "[|system|]{system_prompt}[|endofturn|]",
-                system_prompt = content
+                "[|system|]{content}[|endofturn|]"
             ),
         }
     }
@@ -132,8 +131,7 @@ impl ExaoneChatPrompt {
         match content.is_empty() {
             true => String::from("[|system|]You are a helpful AI assistant. Answer questions as concisely and accurately as possible.[|endofturn|]"),
             false => format!(
-                "[|system|]{system_prompt}[|endofturn|]",
-                system_prompt = content
+                "[|system|]{content}[|endofturn|]"
             ),
         }
     }

--- a/crates/chat-prompts/src/chat/functionary.rs
+++ b/crates/chat-prompts/src/chat/functionary.rs
@@ -51,7 +51,7 @@ Respond in this format:
 >>>${recipient}
 ${content}"###;
 
-                format!("{}\n{}<|eot_id|>", begin, tools)
+                format!("{begin}\n{tools}<|eot_id|>")
             }
             _ => String::from("<|start_header_id|>system<|end_header_id|>\n\nAnswer as concisely as possible.<|eot_id|>"),
         }
@@ -178,7 +178,7 @@ impl FunctionaryV31ToolPrompt {
                 let mut available_tools = String::new();
                 for tool in tools {
                     let tool_s = serde_json::to_string(&tool.function).unwrap();
-                    println!("tool_s: {}", tool_s);
+                    println!("tool_s: {tool_s}");
 
                     available_tools.push_str(&format!("Use the function '{func_name}' to '{desc}'\n{tool_info}\n\n", func_name = &tool.function.name, desc = &tool.function.description.clone().unwrap_or_default(), tool_info = tool_s));
                 }
@@ -214,7 +214,7 @@ Reminder:
 
 <|eot_id|>"###;
 
-                format!("{}\n\n{}\n\n\n{}", begin, tools, end)
+                format!("{begin}\n\n{tools}\n\n\n{end}")
             }
             _ => String::from("<|start_header_id|>system<|end_header_id|>\n\nAnswer as concisely as possible.<|eot_id|>"),
         }

--- a/crates/chat-prompts/src/chat/groq.rs
+++ b/crates/chat-prompts/src/chat/groq.rs
@@ -25,17 +25,15 @@ impl GroqLlama3ToolPrompt {
                     }
                 }
 
-                let tools = format!(
-                    "Here are the available tools:\n<tools> {} </tools>",
-                    available_tools
-                );
+                let tools =
+                    format!("Here are the available tools:\n<tools> {available_tools} </tools>",);
 
                 let format = r#"{"name": <function-name>,"arguments": <args-dict>}"#;
-                let begin = format!("<|start_header_id|>system<|end_header_id|>\n\nYou are a function calling AI model. You are provided with function signatures within <tools></tools> XML tags. You may call one or more functions to assist with the user query. Don't make assumptions about what values to plug into functions. For each function call return a json object with function name and arguments within <tool_call></tool_call> XML tags as follows:\n<tool_call>\n{}\n</tool_call>", format);
+                let begin = format!("<|start_header_id|>system<|end_header_id|>\n\nYou are a function calling AI model. You are provided with function signatures within <tools></tools> XML tags. You may call one or more functions to assist with the user query. Don't make assumptions about what values to plug into functions. For each function call return a json object with function name and arguments within <tool_call></tool_call> XML tags as follows:\n<tool_call>\n{format}\n</tool_call>");
 
                 let end = r#"<|eot_id|>"#;
 
-                Ok(format!("{}\n\n{}{}", begin, tools, end))
+                Ok(format!("{begin}\n\n{tools}{end}"))
             }
             None => Err(PromptError::NoAvailableTools),
         }

--- a/crates/chat-prompts/src/chat/llama.rs
+++ b/crates/chat-prompts/src/chat/llama.rs
@@ -130,7 +130,7 @@ impl CodeLlamaInstructPrompt {
         match content.is_empty() {
             true => String::from("<<SYS>>\nWrite code to solve the following coding problem that obeys the constraints and passes the example test cases. Please wrap your code answer using ```: <</SYS>>"),
             false => format!(
-                "<<SYS>>\n{system_prompt} <</SYS>>", system_prompt=content
+                "<<SYS>>\n{content} <</SYS>>"
             )
         }
     }
@@ -342,7 +342,7 @@ impl Llama3ChatPrompt {
         match content.is_empty() {
             true => String::from("<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\nYou are a helpful, respectful and honest assistant. Always answer as short as possible, while being safe.<|eot_id|>"),
             false =>format!(
-                "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n{system_prompt}<|eot_id|>", system_prompt=content
+                "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n{content}<|eot_id|>"
             )
         }
     }
@@ -450,7 +450,7 @@ impl Llama3ToolPrompt {
         match content.is_empty() {
             true => String::from("<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\nYou are a helpful, respectful and honest assistant. Always answer as short as possible, while being safe.<|eot_id|>"),
             false =>format!(
-                "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n{system_prompt}<|eot_id|>", system_prompt=content
+                "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n{content}<|eot_id|>"
             )
         }
     }
@@ -461,7 +461,7 @@ impl Llama3ToolPrompt {
         match content.is_empty() {
             true => String::from("<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\nYou are a helpful assistant with tool calling capabilities. When you receive a tool call response, use the output to format an answer to the orginal use question.<|eot_id|>"),
             false =>format!(
-                "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n{system_prompt}<|eot_id|>", system_prompt=content
+                "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n{content}<|eot_id|>"
             )
         }
     }
@@ -684,7 +684,7 @@ impl Llama4ChatPromptOld {
         match content.is_empty() {
             true => String::from("<|begin_of_text|><|header_start|>system<|header_end|>\n\nYou are a helpful, respectful and honest assistant. Always answer as short as possible, while being safe.<|eot|>"),
             false =>format!(
-                "<|begin_of_text|><|header_start|>system<|header_end|>\n\n{system_prompt}<|eot|>", system_prompt=content
+                "<|begin_of_text|><|header_start|>system<|header_end|>\n\n{content}<|eot|>"
             )
         }
     }
@@ -864,7 +864,7 @@ impl Llama4ChatPrompt {
         match content.is_empty() {
             true => String::from("<|begin_of_text|><|header_start|>system<|header_end|>\n\nYou are a helpful, respectful and honest assistant. Always answer as short as possible, while being safe.<|eot|>"),
             false =>format!(
-                "<|begin_of_text|><|header_start|>system<|header_end|>\n\n{system_prompt}<|eot|>", system_prompt=content
+                "<|begin_of_text|><|header_start|>system<|header_end|>\n\n{content}<|eot|>"
             )
         }
     }

--- a/crates/chat-prompts/src/chat/megrez.rs
+++ b/crates/chat-prompts/src/chat/megrez.rs
@@ -15,8 +15,7 @@ impl MegrezPrompt {
         match content.is_empty() {
             true => String::from("<|role_start|>system<|role_end|>You are a helpful assistant. Answer questions as concisely and accurately as possible.<|turn_end|>"),
             false => format!(
-                "<|role_start|>system<|role_end|>{system_prompt}<|turn_end|>",
-                system_prompt = content
+                "<|role_start|>system<|role_end|>{content}<|turn_end|>"
             ),
         }
     }

--- a/crates/chat-prompts/src/chat/minicpm.rs
+++ b/crates/chat-prompts/src/chat/minicpm.rs
@@ -17,10 +17,7 @@ impl MiniCPMVPrompt {
         let content = message.content();
         match content.is_empty() {
             true => String::from("<|im_start|>system\nAnswer as concisely as possible.<|im_end|>"),
-            false => format!(
-                "<|im_start|>system\n{system_prompt}<|im_end|>",
-                system_prompt = content
-            ),
+            false => format!("<|im_start|>system\n{content}<|im_end|>"),
         }
     }
 
@@ -62,8 +59,7 @@ impl MiniCPMVPrompt {
                                     let base64_str = part.image().url.as_str();
                                     let format = is_image_format(base64_str)?;
                                     format!(
-                                        r#"<img src="data:image/{};base64,{}">"#,
-                                        format, base64_str
+                                        r#"<img src="data:image/{format};base64,{base64_str}">"#
                                     )
                                 }
                             };

--- a/crates/chat-prompts/src/chat/mistral.rs
+++ b/crates/chat-prompts/src/chat/mistral.rs
@@ -387,8 +387,7 @@ impl MistralSmallChatPrompt {
         match content.is_empty() {
             true => String::from("<s>[SYSTEM_PROMPT]You are Mistral Small 3, a Large Language Model (LLM) created by Mistral AI, a French startup headquartered in Paris.\nYour knowledge base was last updated on 2023-10-01. The current date is 2025-01-30.\nWhen you're not sure about some information, you say that you don't have the information and don't make up anything.\nIf the user's question is not clear, ambiguous, or does not provide enough context for you to accurately answer the question, you do not try to answer it right away and you rather ask the user to clarify their request (e.g. \"What are some good restaurants around me?\" => \"Where are you?\" or \"When is the next flight to Tokyo\" => \"Where do you travel from?\")[/SYSTEM_PROMPT]"),
             false => format!(
-                "<s>[SYSTEM_PROMPT]{system_prompt}[/SYSTEM_PROMPT]",
-                system_prompt = content
+                "<s>[SYSTEM_PROMPT]{content}[/SYSTEM_PROMPT]"
             ),
         }
     }

--- a/crates/chat-prompts/src/chat/moxin.rs
+++ b/crates/chat-prompts/src/chat/moxin.rs
@@ -16,7 +16,7 @@ impl MoxinChatPrompt {
             true => String::from(
                 "<s> [INST] You are an AI assistant. Answer questions as concisely and accurately as possible.",
             ),
-            false => format!("<s> [INST] {system_prompt}", system_prompt = content),
+            false => format!("<s> [INST] {content}"),
         }
     }
 

--- a/crates/chat-prompts/src/chat/nvidia.rs
+++ b/crates/chat-prompts/src/chat/nvidia.rs
@@ -16,7 +16,7 @@ impl NemotronChatPrompt {
         match content.is_empty() {
             true => String::from("<extra_id_0>System\nYou are a helpful, respectful and honest assistant. Always answer as short as possible, while being safe."),
             false =>format!(
-                "<extra_id_0>System\n{system_prompt}", system_prompt=content
+                "<extra_id_0>System\n{content}"
             )
         }
     }
@@ -121,10 +121,7 @@ impl NemotronToolPrompt {
         let content = message.content();
         match content.is_empty() {
             true => String::from("<|im_start|>system\nAnswer as concisely as possible.<|im_end|>"),
-            false => format!(
-                "<|im_start|>system\n{system_prompt}<|im_end|>",
-                system_prompt = content
-            ),
+            false => format!("<|im_start|>system\n{content}<|im_end|>"),
         }
     }
 
@@ -138,11 +135,11 @@ impl NemotronToolPrompt {
             true => match tools {
                 Some(tools) => {
                     let available_tools = serde_json::to_string(tools).unwrap();
-                    let tools = format!("<tool> {} </tool>", available_tools);
+                    let tools = format!("<tool> {available_tools} </tool>");
 
                     let begin = r#"<extra_id_0>System\nYou are a helpful, respectful and honest assistant. Always answer as short as possible, while being safe."#;
 
-                    format!("{}\n\n{}", begin, tools)
+                    format!("{begin}\n\n{tools}")
                 }
                 None => {
                     String::from("<extra_id_0>System\nYou are a helpful, respectful and honest assistant. Always answer as short as possible, while being safe.")
@@ -151,17 +148,17 @@ impl NemotronToolPrompt {
             false => match tools {
                 Some(tools) => {
                     let available_tools = serde_json::to_string(tools).unwrap();
-                    let tools = format!("<tool> {} </tool>", available_tools);
+                    let tools = format!("<tool> {available_tools} </tool>");
 
                     let begin = format!(
-                        "<extra_id_0>System\n{system_prompt}", system_prompt=content
+                        "<extra_id_0>System\n{content}"
                     );
 
-                    format!("{}\n\n{}", begin, tools)
+                    format!("{begin}\n\n{tools}")
                 }
                 None => {
                     format!(
-                        "<extra_id_0>System\n{system_prompt}", system_prompt=content
+                        "<extra_id_0>System\n{content}"
                     )
                 }
             },
@@ -292,7 +289,7 @@ impl BuildChatPrompt for NemotronToolPrompt {
                     for tool in tools {
                         let available_tool = serde_json::to_string(&tool.function).unwrap();
 
-                        let tool = format!("<tool> {} </tool>\n", available_tool);
+                        let tool = format!("<tool> {available_tool} </tool>\n");
 
                         tools_s.push_str(&tool);
                     }

--- a/crates/chat-prompts/src/chat/qwen.rs
+++ b/crates/chat-prompts/src/chat/qwen.rs
@@ -14,13 +14,10 @@ pub struct Qwen2vlPrompt;
 impl Qwen2vlPrompt {
     /// Create a system prompt from a chat completion request message.
     fn create_system_prompt(&self, message: &ChatCompletionSystemMessage) -> String {
-        let content = message.content();
-        match content.is_empty() {
+        let system_prompt = message.content();
+        match system_prompt.is_empty() {
             true => String::from("<|im_start|>system\nAnswer as concisely as possible.<|im_end|>"),
-            false => format!(
-                "<|im_start|>system\n{system_prompt}<|im_end|>",
-                system_prompt = content
-            ),
+            false => format!("<|im_start|>system\n{system_prompt}<|im_end|>"),
         }
     }
 
@@ -72,8 +69,7 @@ impl Qwen2vlPrompt {
                                     let base64_str = part.image().url.as_str();
                                     let format = get_image_format(base64_str)?;
                                     format!(
-                                        r#"<img src="data:image/{};base64,{}">"#,
-                                        format, base64_str
+                                        r#"<img src="data:image/{format};base64,{base64_str}">"#
                                     )
                                 }
                             };

--- a/crates/chat-prompts/src/chat/vicuna.rs
+++ b/crates/chat-prompts/src/chat/vicuna.rs
@@ -244,8 +244,7 @@ impl VicunaLlavaPrompt {
                                     let base64_str = part.image().url.as_str();
                                     let format = get_image_format(base64_str)?;
                                     format!(
-                                        r#"<img src="data:image/{};base64,{}">"#,
-                                        format, base64_str
+                                        r#"<img src="data:image/{format};base64,{base64_str}">"#
                                     )
                                 }
                             };

--- a/crates/endpoints/Cargo.toml
+++ b/crates/endpoints/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "endpoints"
-version       = "0.25.1"
+version       = "0.26.0"
 edition       = "2021"
 readme        = "README.md"
 repository    = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/endpoints/src/audio/speech.rs
+++ b/crates/endpoints/src/audio/speech.rs
@@ -131,7 +131,7 @@ impl<'de> Deserialize<'de> for SpeechRequest {
                             let _ = map.next_value::<IgnoredAny>()?;
 
                             #[cfg(feature = "logging")]
-                            warn!(target: "stdout", "Not supported field: {}", key);
+                            warn!(target: "stdout", "Not supported field: {key}");
                         }
                     }
                 }

--- a/crates/endpoints/src/audio/transcription.rs
+++ b/crates/endpoints/src/audio/transcription.rs
@@ -186,7 +186,7 @@ impl<'de> Deserialize<'de> for TranscriptionRequest {
                             let _ = map.next_value::<IgnoredAny>()?;
 
                             #[cfg(feature = "logging")]
-                            warn!(target: "stdout", "Not supported field: {}", key);
+                            warn!(target: "stdout", "Not supported field: {key}");
                         }
                     }
                 }
@@ -322,7 +322,7 @@ fn test_serialize_transcription_request() {
 #[test]
 fn test_deserialize_transcription_request() {
     let json = r#"{"file":{"id":"file-abc123","bytes":1000,"created_at":1717027200,"filename":"audio.mp3","object":"file","purpose":"assistants"},"model":"whisper-1","language":"en","prompt":"","response_format":"json","temperature":0.0,"timestamp_granularities":["segment"],"detect_language":true,"offset_time":0,"duration":0,"max_context":-1,"max_len":0,"split_on_word":false}"#;
-    let obj: TranscriptionRequest = serde_json::from_str(&json).unwrap();
+    let obj: TranscriptionRequest = serde_json::from_str(json).unwrap();
     assert_eq!(obj.detect_language, Some(true));
     assert_eq!(obj.language, Some("auto".to_string()));
 }

--- a/crates/endpoints/src/audio/translation.rs
+++ b/crates/endpoints/src/audio/translation.rs
@@ -173,7 +173,7 @@ impl<'de> Deserialize<'de> for TranslationRequest {
                             let _ = map.next_value::<IgnoredAny>()?;
 
                             #[cfg(feature = "logging")]
-                            warn!(target: "stdout", "Not supported field: {}", key);
+                            warn!(target: "stdout", "Not supported field: {key}");
                         }
                     }
                 }
@@ -262,7 +262,7 @@ impl<'de> Deserialize<'de> for TranslationRequest {
 #[test]
 fn test_deserialize_translation_request() {
     let json = r#"{"file":{"id":"file-abc123","bytes":1000,"created_at":1717027200,"filename":"audio.mp3","object":"file","purpose":"assistants"},"model":"whisper-1","language":"en","prompt":"","response_format":"json","temperature":0.0,"detect_language":true,"offset_time":0,"duration":0,"max_context":-1,"max_len":0,"split_on_word":false}"#;
-    let obj: TranslationRequest = serde_json::from_str(&json).unwrap();
+    let obj: TranslationRequest = serde_json::from_str(json).unwrap();
     assert_eq!(obj.detect_language, Some(true));
     assert_eq!(obj.language, Some("auto".to_string()));
     assert!(obj.prompt.is_none());

--- a/crates/endpoints/src/chat.rs
+++ b/crates/endpoints/src/chat.rs
@@ -2414,6 +2414,18 @@ pub struct ToolCall {
     /// The function that the model called.
     pub function: Function,
 }
+impl From<ToolCallForChunk> for ToolCall {
+    fn from(value: ToolCallForChunk) -> Self {
+        Self {
+            id: value.id,
+            ty: value.ty,
+            function: Function {
+                name: value.function.name,
+                arguments: value.function.arguments,
+            },
+        }
+    }
+}
 
 #[test]
 fn test_deserialize_tool_call() {
@@ -3170,6 +3182,17 @@ fn test_deserialize_chat_completion_chunk() {
         assert_eq!(chunk.model, "default");
         assert_eq!(chunk.system_fingerprint, "fp_44709d6fcb");
         assert_eq!(chunk.object, "chat.completion.chunk");
+    }
+
+    {
+        let json_str = r#"{"id":"chatcmpl-5b20a5a9-80e0-4cc4-9d33-7ab504dac9ca","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":0,"id":"call_abc123","type":"function","function":{"name":"get_current_weather","arguments":"{\"location\":\"Beijing\",\"unit\":\"celsius\"}"}}],"role":"assistant"},"logprobs":null,"finish_reason":null}],"created":1744028716,"model":"Llama-3-Groq-8B","system_fingerprint":"fp_44709d6fcb","object":"chat.completion.chunk"}"#;
+
+        let chunk: ChatCompletionChunk = serde_json::from_str(json_str).unwrap();
+        assert_eq!(chunk.id, "chatcmpl-5b20a5a9-80e0-4cc4-9d33-7ab504dac9ca");
+        assert_eq!(chunk.choices.len(), 1);
+        assert_eq!(chunk.choices[0].index, 0);
+        assert_eq!(chunk.choices[0].delta.content, None);
+        assert_eq!(chunk.choices[0].delta.tool_calls.len(), 1);
     }
 }
 

--- a/crates/endpoints/src/chat.rs
+++ b/crates/endpoints/src/chat.rs
@@ -41,117 +41,6 @@
 //! }
 //! ```
 //!
-//! **Example 2** Create a chat completion request with available tools.
-//! ```
-//! #[cfg(not(feature = "index"))]
-//! {
-//!   use endpoints::chat::*;
-//!
-//!   let mut messages = Vec::new();
-//!
-//!   // create a system message
-//!   let system_message = ChatCompletionRequestMessage::System(
-//!       ChatCompletionSystemMessage::new("Hello, world!", None),
-//!   );
-//!   messages.push(system_message);
-//!
-//!   // create a user message
-//!   let user_message = ChatCompletionRequestMessage::User(ChatCompletionUserMessage::new(
-//!       ChatCompletionUserMessageContent::Text("Hello, world!".to_string()),
-//!       None,
-//!   ));
-//!   messages.push(user_message);
-//!   let assistant_message = ChatCompletionRequestMessage::Assistant(
-//!       ChatCompletionAssistantMessage::new(Some("Hello, world!".to_string()), None, None),
-//!   );
-//!   messages.push(assistant_message);
-//!
-//!   // create a tool
-//!   let params = ToolFunctionParameters {
-//!       schema_type: JSONSchemaType::Object,
-//!       properties: Some(
-//!           vec![
-//!               (
-//!                   "location".to_string(),
-//!                   Box::new(JSONSchemaDefine {
-//!                       schema_type: Some(JSONSchemaType::String),
-//!                       description: Some(
-//!                           "The city and state, e.g. San Francisco, CA".to_string(),
-//!                       ),
-//!                       enum_values: None,
-//!                       properties: None,
-//!                       required: None,
-//!                       items: None,
-//!                       default: None,
-//!                       maximum: None,
-//!                       minimum: None,
-//!                       title: None,
-//!                       examples: None,
-//!                   }),
-//!               ),
-//!               (
-//!                   "unit".to_string(),
-//!                   Box::new(JSONSchemaDefine {
-//!                       schema_type: Some(JSONSchemaType::String),
-//!                       description: None,
-//!                       enum_values: Some(vec![
-//!                           "celsius".to_string(),
-//!                           "fahrenheit".to_string(),
-//!                       ]),
-//!                       properties: None,
-//!                       required: None,
-//!                       items: None,
-//!                       default: None,
-//!                       maximum: None,
-//!                       minimum: None,
-//!                       title: None,
-//!                       examples: None,
-//!                   }),
-//!               ),
-//!           ]
-//!           .into_iter()
-//!           .collect(),
-//!       ),
-//!       required: Some(vec!["location".to_string()]),
-//!   };
-//!   let tool = Tool {
-//!       ty: "function".to_string(),
-//!       function: ToolFunction {
-//!           name: "my_function".to_string(),
-//!           description: None,
-//!           parameters: Some(params),
-//!       },
-//!   };
-//!
-//!   // create a chat completion request
-//!   let request = ChatCompletionRequestBuilder::new(&messages)
-//!       .with_model("model-id")
-//!       .with_sampling(ChatCompletionRequestSampling::Temperature(0.8))
-//!       .with_n_choices(3)
-//!       .enable_stream(true)
-//!       .include_usage()
-//!       .with_stop(vec!["stop1".to_string(), "stop2".to_string()])
-//!       .with_max_completion_tokens(100)
-//!       .with_presence_penalty(0.5)
-//!       .with_frequency_penalty(0.5)
-//!       .with_reponse_format(ChatResponseFormat::default())
-//!       .with_tools(vec![tool])
-//!       .with_tool_choice(ToolChoice::Tool(ToolChoiceTool {
-//!           ty: "function".to_string(),
-//!           function: ToolChoiceToolFunction {
-//!               name: "my_function".to_string(),
-//!           },
-//!       }))
-//!       .build();
-//!
-//!   // serialize the request to JSON string
-//!   let json = serde_json::to_string(&request).unwrap();
-//!   assert_eq!(
-//!       json,
-//!       r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":"Hello, world!"},{"role":"assistant","content":"Hello, world!"}],"temperature":0.8,"top_p":1.0,"n":3,"stream":true,"stream_options":{"include_usage":true},"stop":["stop1","stop2"],"max_tokens":-1,"max_completion_tokens":100,"presence_penalty":0.5,"frequency_penalty":0.5,"response_format":{"type":"text"},"tools":[{"type":"function","function":{"name":"my_function","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"tool_choice":{"type":"function","function":{"name":"my_function"}}}"#
-//!   );
-//! }
-//! ```
 
 use crate::common::{FinishReason, Usage};
 use indexmap::IndexMap;
@@ -931,60 +820,53 @@ fn test_chat_serialize_chat_request() {
         );
         messages.push(assistant_message);
 
-        let params = ToolFunctionParameters {
-            schema_type: JSONSchemaType::Object,
-            properties: Some(
-                vec![
-                    (
-                        "location".to_string(),
-                        Box::new(JSONSchemaDefine {
-                            schema_type: Some(JSONSchemaType::String),
-                            description: Some(
-                                "The city and state, e.g. San Francisco, CA".to_string(),
-                            ),
-                            enum_values: None,
-                            properties: None,
-                            required: None,
-                            items: None,
-                            default: None,
-                            maximum: None,
-                            minimum: None,
-                            title: None,
-                            examples: None,
-                        }),
-                    ),
-                    (
-                        "unit".to_string(),
-                        Box::new(JSONSchemaDefine {
-                            schema_type: Some(JSONSchemaType::String),
-                            description: None,
-                            enum_values: Some(vec![
-                                "celsius".to_string(),
-                                "fahrenheit".to_string(),
-                            ]),
-                            properties: None,
-                            required: None,
-                            items: None,
-                            default: None,
-                            maximum: None,
-                            minimum: None,
-                            title: None,
-                            examples: None,
-                        }),
-                    ),
-                ]
-                .into_iter()
-                .collect(),
-            ),
-            required: Some(vec!["location".to_string()]),
-        };
+        let json_str = r###"{
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "definitions": {
+                        "TemperatureUnit": {
+                            "enum": [
+                                "celsius",
+                                "fahrenheit"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "properties": {
+                        "api_key": {
+                            "description": "the OpenWeatherMap API key to use. If not provided, the server will use the OPENWEATHERMAP_API_KEY environment variable.",
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "location": {
+                            "description": "the city to get the weather for, e.g., 'Beijing', 'New York', 'Tokyo'",
+                            "type": "string"
+                        },
+                        "unit": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/TemperatureUnit"
+                                }
+                            ],
+                            "description": "the unit to use for the temperature, e.g., 'celsius', 'fahrenheit'"
+                        }
+                    },
+                    "required": [
+                        "location",
+                        "unit"
+                    ],
+                    "title": "GetWeatherRequest",
+                    "type": "object"
+                }"###;
+        let json_schema: JsonObject = serde_json::from_str(json_str).unwrap();
 
         let tool = Tool {
             ty: "function".to_string(),
             function: ToolFunction {
                 name: "my_function".to_string(),
                 description: None,
-                parameters: Some(params),
+                parameters: Some(json_schema),
             },
         };
 
@@ -1010,7 +892,7 @@ fn test_chat_serialize_chat_request() {
         let json = serde_json::to_string(&request).unwrap();
         assert_eq!(
             json,
-            r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":"Hello, world!"},{"role":"assistant","content":"Hello, world!"}],"temperature":0.8,"top_p":1.0,"n":3,"stream":true,"stream_options":{"include_usage":true},"stop":["stop1","stop2"],"max_tokens":-1,"max_completion_tokens":100,"presence_penalty":0.5,"frequency_penalty":0.5,"response_format":{"type":"text"},"tools":[{"type":"function","function":{"name":"my_function","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"tool_choice":{"type":"function","function":{"name":"my_function"}}}"#
+            r###"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":"Hello, world!"},{"role":"assistant","content":"Hello, world!"}],"temperature":0.8,"top_p":1.0,"n":3,"stream":true,"stream_options":{"include_usage":true},"stop":["stop1","stop2"],"max_tokens":-1,"max_completion_tokens":100,"presence_penalty":0.5,"frequency_penalty":0.5,"response_format":{"type":"text"},"tools":[{"type":"function","function":{"name":"my_function","parameters":{"$schema":"http://json-schema.org/draft-07/schema#","definitions":{"TemperatureUnit":{"enum":["celsius","fahrenheit"],"type":"string"}},"properties":{"api_key":{"description":"the OpenWeatherMap API key to use. If not provided, the server will use the OPENWEATHERMAP_API_KEY environment variable.","type":["string","null"]},"location":{"description":"the city to get the weather for, e.g., 'Beijing', 'New York', 'Tokyo'","type":"string"},"unit":{"allOf":[{"$ref":"#/definitions/TemperatureUnit"}],"description":"the unit to use for the temperature, e.g., 'celsius', 'fahrenheit'"}},"required":["location","unit"],"title":"GetWeatherRequest","type":"object"}}}],"tool_choice":{"type":"function","function":{"name":"my_function"}}}"###
         );
     }
 
@@ -1031,60 +913,12 @@ fn test_chat_serialize_chat_request() {
         );
         messages.push(assistant_message);
 
-        let params = ToolFunctionParameters {
-            schema_type: JSONSchemaType::Object,
-            properties: Some(
-                vec![
-                    (
-                        "location".to_string(),
-                        Box::new(JSONSchemaDefine {
-                            schema_type: Some(JSONSchemaType::String),
-                            description: Some(
-                                "The city and state, e.g. San Francisco, CA".to_string(),
-                            ),
-                            enum_values: None,
-                            properties: None,
-                            required: None,
-                            items: None,
-                            default: None,
-                            maximum: None,
-                            minimum: None,
-                            title: None,
-                            examples: None,
-                        }),
-                    ),
-                    (
-                        "unit".to_string(),
-                        Box::new(JSONSchemaDefine {
-                            schema_type: Some(JSONSchemaType::String),
-                            description: None,
-                            enum_values: Some(vec![
-                                "celsius".to_string(),
-                                "fahrenheit".to_string(),
-                            ]),
-                            properties: None,
-                            required: None,
-                            items: None,
-                            default: None,
-                            maximum: None,
-                            minimum: None,
-                            title: None,
-                            examples: None,
-                        }),
-                    ),
-                ]
-                .into_iter()
-                .collect(),
-            ),
-            required: Some(vec!["location".to_string()]),
-        };
-
         let tool = Tool {
             ty: "function".to_string(),
             function: ToolFunction {
                 name: "my_function".to_string(),
                 description: None,
-                parameters: Some(params),
+                parameters: None,
             },
         };
 
@@ -1105,7 +939,7 @@ fn test_chat_serialize_chat_request() {
         let json = serde_json::to_string(&request).unwrap();
         assert_eq!(
             json,
-            r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":"Hello, world!"},{"role":"assistant","content":"Hello, world!"}],"temperature":0.8,"top_p":1.0,"n":3,"stream":true,"stream_options":{"include_usage":true},"stop":["stop1","stop2"],"max_tokens":-1,"max_completion_tokens":100,"presence_penalty":0.5,"frequency_penalty":0.5,"response_format":{"type":"text"},"tools":[{"type":"function","function":{"name":"my_function","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"tool_choice":"auto"}"#
+            r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":"Hello, world!"},{"role":"assistant","content":"Hello, world!"}],"temperature":0.8,"top_p":1.0,"n":3,"stream":true,"stream_options":{"include_usage":true},"stop":["stop1","stop2"],"max_tokens":-1,"max_completion_tokens":100,"presence_penalty":0.5,"frequency_penalty":0.5,"response_format":{"type":"text"},"tools":[{"type":"function","function":{"name":"my_function"}}],"tool_choice":"auto"}"#
         );
     }
 
@@ -1126,53 +960,28 @@ fn test_chat_serialize_chat_request() {
         );
         messages.push(assistant_message);
 
-        let params = ToolFunctionParameters {
-            schema_type: JSONSchemaType::Object,
-            properties: Some(
-                vec![
-                    (
-                        "location".to_string(),
-                        Box::new(JSONSchemaDefine {
-                            schema_type: Some(JSONSchemaType::String),
-                            description: Some(
-                                "The city and state, e.g. San Francisco, CA".to_string(),
-                            ),
-                            enum_values: None,
-                            properties: None,
-                            required: None,
-                            items: None,
-                            default: None,
-                            maximum: None,
-                            minimum: None,
-                            title: None,
-                            examples: None,
-                        }),
-                    ),
-                    (
-                        "unit".to_string(),
-                        Box::new(JSONSchemaDefine {
-                            schema_type: Some(JSONSchemaType::String),
-                            description: None,
-                            enum_values: Some(vec![
-                                "celsius".to_string(),
-                                "fahrenheit".to_string(),
-                            ]),
-                            properties: None,
-                            required: None,
-                            items: None,
-                            default: None,
-                            maximum: None,
-                            minimum: None,
-                            title: None,
-                            examples: None,
-                        }),
-                    ),
-                ]
-                .into_iter()
-                .collect(),
-            ),
-            required: Some(vec!["location".to_string()]),
-        };
+        let params_json = r###"{
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "properties": {
+                        "a": {
+                            "description": "the left hand side number",
+                            "format": "int32",
+                            "type": "integer"
+                        },
+                        "b": {
+                            "description": "the right hand side number",
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    },
+                    "required": [
+                        "a",
+                        "b"
+                    ],
+                    "title": "SumRequest",
+                    "type": "object"
+                }"###;
+        let params: JsonObject = serde_json::from_str(params_json).unwrap();
 
         let tool = Tool {
             ty: "function".to_string(),
@@ -1208,7 +1017,7 @@ fn test_chat_serialize_chat_request() {
         let json = serde_json::to_string(&request).unwrap();
         assert_eq!(
             json,
-            r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":"Hello, world!"},{"role":"assistant","content":"Hello, world!"}],"temperature":0.8,"top_p":1.0,"n":3,"stream":true,"stream_options":{"include_usage":true},"stop":["stop1","stop2"],"max_tokens":-1,"max_completion_tokens":100,"presence_penalty":0.5,"frequency_penalty":0.5,"response_format":{"type":"text"},"tools":[{"type":"function","function":{"name":"my_function","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"tool_choice":"auto","context_window":3,"vdb_server_url":"http://localhost:6333","vdb_collection_name":["collection1","collection2"],"limit":[10,20],"score_threshold":[0.5,0.6]}"#
+            r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":"Hello, world!"},{"role":"assistant","content":"Hello, world!"}],"temperature":0.8,"top_p":1.0,"n":3,"stream":true,"stream_options":{"include_usage":true},"stop":["stop1","stop2"],"max_tokens":-1,"max_completion_tokens":100,"presence_penalty":0.5,"frequency_penalty":0.5,"response_format":{"type":"text"},"tools":[{"type":"function","function":{"name":"my_function","parameters":{"$schema":"http://json-schema.org/draft-07/schema#","properties":{"a":{"description":"the left hand side number","format":"int32","type":"integer"},"b":{"description":"the right hand side number","format":"int32","type":"integer"}},"required":["a","b"],"title":"SumRequest","type":"object"}}}],"tool_choice":"auto","context_window":3,"vdb_server_url":"http://localhost:6333","vdb_collection_name":["collection1","collection2"],"limit":[10,20],"score_threshold":[0.5,0.6]}"#
         );
     }
 
@@ -1229,53 +1038,28 @@ fn test_chat_serialize_chat_request() {
         );
         messages.push(assistant_message);
 
-        let params = ToolFunctionParameters {
-            schema_type: JSONSchemaType::Object,
-            properties: Some(
-                vec![
-                    (
-                        "location".to_string(),
-                        Box::new(JSONSchemaDefine {
-                            schema_type: Some(JSONSchemaType::String),
-                            description: Some(
-                                "The city and state, e.g. San Francisco, CA".to_string(),
-                            ),
-                            enum_values: None,
-                            properties: None,
-                            required: None,
-                            items: None,
-                            default: None,
-                            maximum: None,
-                            minimum: None,
-                            title: None,
-                            examples: None,
-                        }),
-                    ),
-                    (
-                        "unit".to_string(),
-                        Box::new(JSONSchemaDefine {
-                            schema_type: Some(JSONSchemaType::String),
-                            description: None,
-                            enum_values: Some(vec![
-                                "celsius".to_string(),
-                                "fahrenheit".to_string(),
-                            ]),
-                            properties: None,
-                            required: None,
-                            items: None,
-                            default: None,
-                            maximum: None,
-                            minimum: None,
-                            title: None,
-                            examples: None,
-                        }),
-                    ),
-                ]
-                .into_iter()
-                .collect(),
-            ),
-            required: Some(vec!["location".to_string()]),
-        };
+        let params_json = r###"{
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "properties": {
+                        "a": {
+                            "description": "the left hand side number",
+                            "format": "int32",
+                            "type": "integer"
+                        },
+                        "b": {
+                            "description": "the right hand side number",
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    },
+                    "required": [
+                        "a",
+                        "b"
+                    ],
+                    "title": "SumRequest",
+                    "type": "object"
+                }"###;
+        let params: JsonObject = serde_json::from_str(params_json).unwrap();
 
         let tool = Tool {
             ty: "function".to_string(),
@@ -1314,7 +1098,7 @@ fn test_chat_serialize_chat_request() {
         let json = serde_json::to_string(&request).unwrap();
         assert_eq!(
             json,
-            r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":"Hello, world!"},{"role":"assistant","content":"Hello, world!"}],"temperature":0.8,"top_p":1.0,"n":3,"stream":true,"stream_options":{"include_usage":true},"stop":["stop1","stop2"],"max_tokens":-1,"max_completion_tokens":100,"presence_penalty":0.5,"frequency_penalty":0.5,"response_format":{"type":"text"},"tools":[{"type":"function","function":{"name":"my_function","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"tool_choice":"auto","context_window":3,"vdb_server_url":"http://localhost:6333","vdb_collection_name":["collection1","collection2"],"limit":[10,20],"score_threshold":[0.5,0.6],"kw_search_url":"http://localhost:9069","kw_index_name":"index-name","kw_top_k":5}"#
+            r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":"Hello, world!"},{"role":"assistant","content":"Hello, world!"}],"temperature":0.8,"top_p":1.0,"n":3,"stream":true,"stream_options":{"include_usage":true},"stop":["stop1","stop2"],"max_tokens":-1,"max_completion_tokens":100,"presence_penalty":0.5,"frequency_penalty":0.5,"response_format":{"type":"text"},"tools":[{"type":"function","function":{"name":"my_function","parameters":{"$schema":"http://json-schema.org/draft-07/schema#","properties":{"a":{"description":"the left hand side number","format":"int32","type":"integer"},"b":{"description":"the right hand side number","format":"int32","type":"integer"}},"required":["a","b"],"title":"SumRequest","type":"object"}}}],"tool_choice":"auto","context_window":3,"vdb_server_url":"http://localhost:6333","vdb_collection_name":["collection1","collection2"],"limit":[10,20],"score_threshold":[0.5,0.6],"kw_search_url":"http://localhost:9069","kw_index_name":"index-name","kw_top_k":5}"#
         );
     }
 }
@@ -1409,39 +1193,6 @@ fn test_chat_deserialize_chat_request() {
     }
 
     {
-        let json = r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":"Hello, world!"},{"role":"assistant","content":"Hello, world!"}],"temperature":0.8,"top_p":1.0,"n":3,"stream":true,"stop":["stop1","stop2"],"max_completion_tokens":100,"presence_penalty":0.5,"frequency_penalty":0.5,"response_format":{"type":"text"},"tools":[{"type":"function","function":{"name":"my_function","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"tool_choice":{"type":"function","function":{"name":"my_function"}}}"#;
-
-        let request: ChatCompletionRequest = serde_json::from_str(json).unwrap();
-        let tools = request.tools.unwrap();
-        let tool = &tools[0];
-        assert_eq!(tool.ty, "function");
-        assert_eq!(tool.function.name, "my_function");
-        assert!(tool.function.description.is_none());
-        assert!(tool.function.parameters.is_some());
-        let params = tool.function.parameters.as_ref().unwrap();
-        assert_eq!(params.schema_type, JSONSchemaType::Object);
-        let properties = params.properties.as_ref().unwrap();
-        assert_eq!(properties.len(), 2);
-        assert!(properties.contains_key("unit"));
-        assert!(properties.contains_key("location"));
-        let unit = properties.get("unit").unwrap();
-        assert_eq!(unit.schema_type, Some(JSONSchemaType::String));
-        assert_eq!(
-            unit.enum_values,
-            Some(vec!["celsius".to_string(), "fahrenheit".to_string()])
-        );
-        let location = properties.get("location").unwrap();
-        assert_eq!(location.schema_type, Some(JSONSchemaType::String));
-        assert_eq!(
-            location.description,
-            Some("The city and state, e.g. San Francisco, CA".to_string())
-        );
-        let required = params.required.as_ref().unwrap();
-        assert_eq!(required.len(), 1);
-        assert_eq!(required[0], "location");
-    }
-
-    {
         let json = r#"{"model":"model-id","messages":[{"role":"system","content":"Hello, world!"},{"role":"user","content":"Hello, world!"},{"role":"assistant","content":"Hello, world!"}],"temperature":0.8,"top_p":1.0,"n":3,"stream":true,"stream_options":{"include_usage":true},"stop":["stop1","stop2"],"max_completion_tokens":100,"presence_penalty":0.5,"frequency_penalty":0.5,"response_format":{"type":"text"},"tools":[{"type":"function","function":{"name":"my_function","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}]}"#;
 
         let request: ChatCompletionRequest = serde_json::from_str(json).unwrap();
@@ -1458,30 +1209,85 @@ fn test_chat_deserialize_chat_request() {
     }
 
     {
-        let json = r#"{"messages":[{"content":"Send an email to John Doe with the subject 'Hello' and the body 'Hello, John!'. His email is jhon@example.com","role":"user"}],"model":"llama","tool_choice":"auto","tools":[{"function":{"description":"Action to fetch all emails from Gmail.","name":"GMAIL_FETCH_EMAILS","parameters":{"properties":{"include_spam_trash":{"default":false,"description":"Include messages from SPAM and TRASH in the results.","title":"Include Spam Trash","type":"boolean"},"label_ids":{"default":null,"description":"Filter messages by their label IDs. Labels identify the status or category of messages. Some of the in-built labels include 'INBOX', 'SPAM', 'TRASH', 'UNREAD', 'STARRED', 'IMPORTANT', 'CATEGORY_PERSONAL', 'CATEGORY_SOCIAL', 'CATEGORY_PROMOTIONS', 'CATEGORY_UPDATES', and 'CATEGORY_FORUMS'. The 'label_ids' for custom labels can be found in the response of the 'listLabels' action. Note: The label_ids is a list of label IDs to filter the messages by.","items":{"type":"string"},"title":"Label Ids","type":"array"},"max_results":{"default":10,"description":"Maximum number of messages to return.","maximum":500,"minimum":1,"title":"Max Results","type":"integer"},"page_token":{"default":null,"description":"Page token to retrieve a specific page of results in the list. The page token is returned in the response of this action if there are more results to be fetched. If not provided, the first page of results is returned.","title":"Page Token","type":"string"},"query":{"default":null,"description":"Only return messages matching the specified query.","title":"Query","type":"string"},"user_id":{"default":"me","description":"The user's email address or 'me' for the authenticated user.","title":"User Id","type":"string"}},"title":"FetchEmailsRequest","type":"object"}},"type":"function"}]}"#;
+        let json_str = r###"{
+    "model": "Llama-3-Groq-8B",
+    "messages": [
+        {
+            "role": "user",
+            "content": "How is the weather of Beijing, China? In Celsius."
+        }
+    ],
+    "tools": [
+        {
+            "type": "function",
+            "function": {
+                "name": "sum",
+                "description": "Calculate the sum of two numbers",
+                "parameters": {
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "properties": {
+                        "a": {
+                            "description": "the left hand side number",
+                            "format": "int32",
+                            "type": "integer"
+                        },
+                        "b": {
+                            "description": "the right hand side number",
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    },
+                    "required": [
+                        "a",
+                        "b"
+                    ],
+                    "title": "SumRequest",
+                    "type": "object"
+                }
+            }
+        }
+    ],
+    "tool_choice": "required",
+    "stream": false
+}"###;
 
-        let request: ChatCompletionRequest = serde_json::from_str(json).unwrap();
+        let request: ChatCompletionRequest = serde_json::from_str(json_str).unwrap();
         assert!(request.model.is_some());
         let tools = request.tools.unwrap();
         assert!(tools.len() == 1);
         let tool = &tools[0];
         assert_eq!(tool.ty, "function");
-        assert_eq!(tool.function.name, "GMAIL_FETCH_EMAILS");
+        assert_eq!(tool.function.name, "sum");
         assert!(tool.function.parameters.is_some());
         let params = tool.function.parameters.as_ref().unwrap();
-        assert!(params.properties.is_some());
-        let properties = params.properties.as_ref().unwrap();
-        assert!(properties.len() == 6);
-        assert!(properties.contains_key("max_results"));
-        let max_results = properties.get("max_results").unwrap();
-        assert!(max_results.description.is_some());
+        assert!(params.contains_key("properties"));
+        let properties = params.get("properties").unwrap();
+        let properties = properties.as_object().unwrap();
+        assert!(properties.len() == 2);
+        assert!(properties.contains_key("a"));
+        assert!(properties.contains_key("b"));
+        let a = properties.get("a").unwrap();
+        let a = a.as_object().unwrap();
+        assert!(a.contains_key("description"));
         assert_eq!(
-            max_results.description.as_ref().unwrap(),
-            "Maximum number of messages to return."
+            a.get("description").unwrap().as_str().unwrap(),
+            "the left hand side number"
         );
-        assert!(max_results.schema_type.is_some());
-        assert_eq!(max_results.schema_type, Some(JSONSchemaType::Integer));
-        println!("{:?}", max_results);
+        assert!(a.contains_key("format"));
+        assert_eq!(a.get("format").unwrap().as_str().unwrap(), "int32");
+        assert!(a.contains_key("type"));
+        assert_eq!(a.get("type").unwrap().as_str().unwrap(), "integer");
+        let b = properties.get("b").unwrap();
+        let b = b.as_object().unwrap();
+        assert!(b.contains_key("description"));
+        assert_eq!(
+            b.get("description").unwrap().as_str().unwrap(),
+            "the right hand side number"
+        );
+        assert!(b.contains_key("format"));
+        assert_eq!(b.get("format").unwrap().as_str().unwrap(), "int32");
+        assert!(b.contains_key("type"));
+        assert_eq!(b.get("type").unwrap().as_str().unwrap(), "integer");
     }
 
     #[cfg(feature = "rag")]
@@ -1680,174 +1486,239 @@ fn test_chat_serialize_tool() {
     }
 
     {
-        let params = ToolFunctionParameters {
-            schema_type: JSONSchemaType::Object,
-            properties: Some(
-                vec![
-                    (
-                        "location".to_string(),
-                        Box::new(JSONSchemaDefine {
-                            schema_type: Some(JSONSchemaType::String),
-                            description: Some(
-                                "The city and state, e.g. San Francisco, CA".to_string(),
-                            ),
-                            enum_values: None,
-                            properties: None,
-                            required: None,
-                            items: None,
-                            default: None,
-                            maximum: None,
-                            minimum: None,
-                            title: None,
-                            examples: None,
-                        }),
-                    ),
-                    (
-                        "unit".to_string(),
-                        Box::new(JSONSchemaDefine {
-                            schema_type: Some(JSONSchemaType::String),
-                            description: None,
-                            enum_values: Some(vec![
-                                "celsius".to_string(),
-                                "fahrenheit".to_string(),
-                            ]),
-                            properties: None,
-                            required: None,
-                            items: None,
-                            default: None,
-                            maximum: None,
-                            minimum: None,
-                            title: None,
-                            examples: None,
-                        }),
-                    ),
-                ]
-                .into_iter()
-                .collect(),
-            ),
-            required: Some(vec!["location".to_string()]),
-        };
+        let input_schema_str = r###"{
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "properties": {
+                        "a": {
+                            "description": "the left hand side number",
+                            "format": "int32",
+                            "type": "integer"
+                        },
+                        "b": {
+                            "description": "the right hand side number",
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    },
+                    "required": [
+                        "a",
+                        "b"
+                    ],
+                    "title": "SumRequest",
+                    "type": "object"
+                }"###;
+        let input_schema: JsonObject = serde_json::from_str(input_schema_str).unwrap();
 
         let tool = Tool {
             ty: "function".to_string(),
             function: ToolFunction {
-                name: "my_function".to_string(),
-                description: None,
-                parameters: Some(params),
+                name: "sum".to_string(),
+                description: Some("Calculate the sum of two numbers".to_string()),
+                parameters: Some(input_schema),
             },
         };
         let json = serde_json::to_string(&tool).unwrap();
         assert_eq!(
             json,
-            r#"{"type":"function","function":{"name":"my_function","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}"#
+            r###"{"type":"function","function":{"name":"sum","description":"Calculate the sum of two numbers","parameters":{"$schema":"http://json-schema.org/draft-07/schema#","properties":{"a":{"description":"the left hand side number","format":"int32","type":"integer"},"b":{"description":"the right hand side number","format":"int32","type":"integer"}},"required":["a","b"],"title":"SumRequest","type":"object"}}}"###
         );
     }
 
     {
-        let tool_1 = Tool {
-            ty: "function".to_string(),
-            function: ToolFunction {
-                name: "my_function_1".to_string(),
-                description: None,
-                parameters: None,
-            },
-        };
+        let tool1_json_str = r###"{
+            "type": "function",
+            "function": {
+                "name": "get_current_weather",
+                "description": "Get the current weather in a given location",
+                "parameters": {
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "definitions": {
+                        "TemperatureUnit": {
+                            "enum": [
+                                "celsius",
+                                "fahrenheit"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "properties": {
+                        "api_key": {
+                            "description": "the OpenWeatherMap API key to use. If not provided, the server will use the OPENWEATHERMAP_API_KEY environment variable.",
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "location": {
+                            "description": "the city to get the weather for, e.g., 'Beijing', 'New York', 'Tokyo'",
+                            "type": "string"
+                        },
+                        "unit": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/TemperatureUnit"
+                                }
+                            ],
+                            "description": "the unit to use for the temperature, e.g., 'celsius', 'fahrenheit'"
+                        }
+                    },
+                    "required": [
+                        "location",
+                        "unit"
+                    ],
+                    "title": "GetWeatherRequest",
+                    "type": "object"
+                }
+            }
+        }"###;
+        let tool_1: Tool = serde_json::from_str(tool1_json_str).unwrap();
 
-        let params = ToolFunctionParameters {
-            schema_type: JSONSchemaType::Object,
-            properties: Some(
-                vec![
-                    (
-                        "location".to_string(),
-                        Box::new(JSONSchemaDefine {
-                            schema_type: Some(JSONSchemaType::String),
-                            description: Some(
-                                "The city and state, e.g. San Francisco, CA".to_string(),
-                            ),
-                            enum_values: None,
-                            properties: None,
-                            required: None,
-                            items: None,
-                            default: None,
-                            maximum: None,
-                            minimum: None,
-                            title: None,
-                            examples: None,
-                        }),
-                    ),
-                    (
-                        "unit".to_string(),
-                        Box::new(JSONSchemaDefine {
-                            schema_type: Some(JSONSchemaType::String),
-                            description: None,
-                            enum_values: Some(vec![
-                                "celsius".to_string(),
-                                "fahrenheit".to_string(),
-                            ]),
-                            properties: None,
-                            required: None,
-                            items: None,
-                            default: None,
-                            maximum: None,
-                            minimum: None,
-                            title: None,
-                            examples: None,
-                        }),
-                    ),
-                ]
-                .into_iter()
-                .collect(),
-            ),
-            required: Some(vec!["location".to_string()]),
-        };
-
-        let tool_2 = Tool {
-            ty: "function".to_string(),
-            function: ToolFunction {
-                name: "my_function_2".to_string(),
-                description: None,
-                parameters: Some(params),
-            },
-        };
+        let tool2_json_str = r###"{
+            "type": "function",
+            "function": {
+                "name": "sum",
+                "description": "Calculate the sum of two numbers",
+                "parameters": {
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "properties": {
+                        "a": {
+                            "description": "the left hand side number",
+                            "format": "int32",
+                            "type": "integer"
+                        },
+                        "b": {
+                            "description": "the right hand side number",
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    },
+                    "required": [
+                        "a",
+                        "b"
+                    ],
+                    "title": "SumRequest",
+                    "type": "object"
+                }
+            }
+        }"###;
+        let tool_2: Tool = serde_json::from_str(tool2_json_str).unwrap();
 
         let tools = vec![tool_1, tool_2];
-        let json = serde_json::to_string(&tools).unwrap();
+        let json_str = serde_json::to_string(&tools).unwrap();
         assert_eq!(
-            json,
-            r#"[{"type":"function","function":{"name":"my_function_1"}},{"type":"function","function":{"name":"my_function_2","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}]"#
+            json_str,
+            r###"[{"type":"function","function":{"name":"get_current_weather","description":"Get the current weather in a given location","parameters":{"$schema":"http://json-schema.org/draft-07/schema#","definitions":{"TemperatureUnit":{"enum":["celsius","fahrenheit"],"type":"string"}},"properties":{"api_key":{"description":"the OpenWeatherMap API key to use. If not provided, the server will use the OPENWEATHERMAP_API_KEY environment variable.","type":["string","null"]},"location":{"description":"the city to get the weather for, e.g., 'Beijing', 'New York', 'Tokyo'","type":"string"},"unit":{"allOf":[{"$ref":"#/definitions/TemperatureUnit"}],"description":"the unit to use for the temperature, e.g., 'celsius', 'fahrenheit'"}},"required":["location","unit"],"title":"GetWeatherRequest","type":"object"}}},{"type":"function","function":{"name":"sum","description":"Calculate the sum of two numbers","parameters":{"$schema":"http://json-schema.org/draft-07/schema#","properties":{"a":{"description":"the left hand side number","format":"int32","type":"integer"},"b":{"description":"the right hand side number","format":"int32","type":"integer"}},"required":["a","b"],"title":"SumRequest","type":"object"}}}]"###
         );
     }
 }
 
 #[test]
 fn test_chat_deserialize_tool() {
-    let json = r#"{"type":"function","function":{"name":"my_function","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}"#;
+    use std::any::{Any, TypeId};
+
+    let json = r###"{
+    "type": "function",
+    "function": {
+        "name": "get_current_weather",
+        "description": "Get the current weather in a given location",
+        "parameters": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "definitions": {
+                "TemperatureUnit": {
+                    "enum": [
+                        "celsius",
+                        "fahrenheit"
+                    ],
+                    "type": "string"
+                }
+            },
+            "properties": {
+                "api_key": {
+                    "description": "the OpenWeatherMap API key to use. If not provided, the server will use the OPENWEATHERMAP_API_KEY environment variable.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "location": {
+                    "description": "the city to get the weather for, e.g., 'Beijing', 'New York', 'Tokyo'",
+                    "type": "string"
+                },
+                "unit": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/TemperatureUnit"
+                        }
+                    ],
+                    "description": "the unit to use for the temperature, e.g., 'celsius', 'fahrenheit'"
+                }
+            },
+            "required": [
+                "location",
+                "unit"
+            ],
+            "title": "GetWeatherRequest",
+            "type": "object"
+        }
+    }
+}"###;
     let tool: Tool = serde_json::from_str(json).unwrap();
     assert_eq!(tool.ty, "function");
-    assert_eq!(tool.function.name, "my_function");
-    assert!(tool.function.description.is_none());
+    assert_eq!(tool.function.name, "get_current_weather");
+    assert!(tool.function.description.is_some());
     assert!(tool.function.parameters.is_some());
     let params = tool.function.parameters.as_ref().unwrap();
-    assert_eq!(params.schema_type, JSONSchemaType::Object);
-    let properties = params.properties.as_ref().unwrap();
-    assert_eq!(properties.len(), 2);
+    assert_eq!(params.type_id(), TypeId::of::<JsonObject>());
+    assert!(params.contains_key("$schema"));
+    assert!(params.contains_key("definitions"));
+    let definitions = params.get("definitions").unwrap();
+    let definitions = definitions.as_object().unwrap();
+    assert_eq!(definitions.len(), 1);
+    assert!(definitions.contains_key("TemperatureUnit"));
+    let temperature_unit = definitions.get("TemperatureUnit").unwrap();
+    let temperature_unit = temperature_unit.as_object().unwrap();
+    assert_eq!(temperature_unit.len(), 2);
+    assert!(temperature_unit.contains_key("enum"));
+    let enum_values = temperature_unit.get("enum").unwrap();
+    let enum_values = enum_values.as_array().unwrap();
+    assert_eq!(enum_values.len(), 2);
+    assert_eq!(enum_values[0].as_str().unwrap(), "celsius");
+    assert_eq!(enum_values[1].as_str().unwrap(), "fahrenheit");
+    assert!(params.contains_key("properties"));
+    let properties = params.get("properties").unwrap();
+    let properties = properties.as_object().unwrap();
+    assert_eq!(properties.len(), 3);
     assert!(properties.contains_key("unit"));
     assert!(properties.contains_key("location"));
+    assert!(properties.contains_key("api_key"));
     let unit = properties.get("unit").unwrap();
-    assert_eq!(unit.schema_type, Some(JSONSchemaType::String));
+    let unit = unit.as_object().unwrap();
+    assert!(unit.contains_key("allOf"));
+    let all_of = unit.get("allOf").unwrap();
+    let all_of = all_of.as_array().unwrap();
+    assert_eq!(all_of.len(), 1);
+    let all_of_0 = all_of[0].as_object().unwrap();
+    assert!(all_of_0.contains_key("$ref"));
     assert_eq!(
-        unit.enum_values,
-        Some(vec!["celsius".to_string(), "fahrenheit".to_string()])
+        all_of_0.get("$ref").unwrap().as_str().unwrap(),
+        "#/definitions/TemperatureUnit"
     );
     let location = properties.get("location").unwrap();
-    assert_eq!(location.schema_type, Some(JSONSchemaType::String));
+    let location = location.as_object().unwrap();
+    assert_eq!(location.len(), 2);
+    assert!(location.contains_key("description"));
     assert_eq!(
-        location.description,
-        Some("The city and state, e.g. San Francisco, CA".to_string())
+        location.get("description").unwrap().as_str().unwrap(),
+        "the city to get the weather for, e.g., 'Beijing', 'New York', 'Tokyo'"
     );
-    let required = params.required.as_ref().unwrap();
-    assert_eq!(required.len(), 1);
-    assert_eq!(required[0], "location");
+    assert!(location.contains_key("type"));
+    assert_eq!(location.get("type").unwrap().as_str().unwrap(), "string");
+    assert!(params.contains_key("required"));
+    let required = params.get("required").unwrap();
+    let required = required.as_array().unwrap();
+    assert_eq!(required.len(), 2);
+    assert_eq!(required[0].as_str().unwrap(), "location");
+    assert_eq!(required[1].as_str().unwrap(), "unit");
 }
 
 /// Function the model may generate JSON inputs for.
@@ -1858,66 +1729,66 @@ pub struct ToolFunction {
     /// A description of what the function does, used by the model to choose when and how to call the function.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    // The parameters the functions accepts, described as a JSON Schema object.
+    /// The parameters the functions accepts, described as a JSON Schema object.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub parameters: Option<ToolFunctionParameters>,
+    pub parameters: Option<JsonObject>,
 }
+
+pub type JsonObject<F = Value> = serde_json::Map<String, F>;
 
 #[test]
 fn test_chat_serialize_tool_function() {
-    let params = ToolFunctionParameters {
-        schema_type: JSONSchemaType::Object,
-        properties: Some(
-            vec![
-                (
-                    "location".to_string(),
-                    Box::new(JSONSchemaDefine {
-                        schema_type: Some(JSONSchemaType::String),
-                        description: Some("The city and state, e.g. San Francisco, CA".to_string()),
-                        enum_values: None,
-                        properties: None,
-                        required: None,
-                        items: None,
-                        default: None,
-                        maximum: None,
-                        minimum: None,
-                        title: None,
-                        examples: None,
-                    }),
-                ),
-                (
-                    "unit".to_string(),
-                    Box::new(JSONSchemaDefine {
-                        schema_type: Some(JSONSchemaType::String),
-                        description: None,
-                        enum_values: Some(vec!["celsius".to_string(), "fahrenheit".to_string()]),
-                        properties: None,
-                        required: None,
-                        items: None,
-                        default: None,
-                        maximum: None,
-                        minimum: None,
-                        title: None,
-                        examples: None,
-                    }),
-                ),
+    let parameters_str = r###"{
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "definitions": {
+          "TemperatureUnit": {
+            "enum": [
+              "celsius",
+              "fahrenheit"
+            ],
+            "type": "string"
+          }
+        },
+        "properties": {
+          "api_key": {
+            "description": "the OpenWeatherMap API key to use. If not provided, the server will use the OPENWEATHERMAP_API_KEY environment variable.",
+            "type": [
+              "string",
+              "null"
             ]
-            .into_iter()
-            .collect(),
-        ),
-        required: Some(vec!["location".to_string()]),
-    };
+          },
+          "location": {
+            "description": "the city to get the weather for, e.g., 'Beijing', 'New York', 'Tokyo'",
+            "type": "string"
+          },
+          "unit": {
+            "allOf": [
+              {
+                "$ref": "#/definitions/TemperatureUnit"
+              }
+            ],
+            "description": "the unit to use for the temperature, e.g., 'celsius', 'fahrenheit'"
+          }
+        },
+        "required": [
+          "location",
+          "unit"
+        ],
+        "title": "GetWeatherRequest",
+        "type": "object"
+      }"###;
+    let parameters: JsonObject = serde_json::from_str(parameters_str).unwrap();
 
     let func = ToolFunction {
-        name: "my_function".to_string(),
+        name: "get_current_weather".to_string(),
         description: Some("Get the current weather in a given location".to_string()),
-        parameters: Some(params),
+        parameters: Some(parameters),
     };
 
-    let json = serde_json::to_string(&func).unwrap();
+    let json_str = serde_json::to_string(&func).unwrap();
     assert_eq!(
-        json,
-        r#"{"name":"my_function","description":"Get the current weather in a given location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}"#
+        json_str,
+        r###"{"name":"get_current_weather","description":"Get the current weather in a given location","parameters":{"$schema":"http://json-schema.org/draft-07/schema#","definitions":{"TemperatureUnit":{"enum":["celsius","fahrenheit"],"type":"string"}},"properties":{"api_key":{"description":"the OpenWeatherMap API key to use. If not provided, the server will use the OPENWEATHERMAP_API_KEY environment variable.","type":["string","null"]},"location":{"description":"the city to get the weather for, e.g., 'Beijing', 'New York', 'Tokyo'","type":"string"},"unit":{"allOf":[{"$ref":"#/definitions/TemperatureUnit"}],"description":"the unit to use for the temperature, e.g., 'celsius', 'fahrenheit'"}},"required":["location","unit"],"title":"GetWeatherRequest","type":"object"}}"###
     );
 }
 

--- a/crates/endpoints/src/chat.rs
+++ b/crates/endpoints/src/chat.rs
@@ -2443,7 +2443,7 @@ impl ChatCompletionAssistantMessage {
     ) -> Self {
         match tool_calls.is_some() {
             true => Self {
-                content: None,
+                content,
                 name,
                 tool_calls,
             },

--- a/crates/endpoints/src/chat.rs
+++ b/crates/endpoints/src/chat.rs
@@ -735,6 +735,39 @@ impl Default for ChatCompletionRequest {
         }
     }
 }
+impl ChatCompletionRequest {
+    /// Return the reference to the latest user message from the chat history.
+    pub fn latest_user_message(&self) -> Option<&ChatCompletionUserMessage> {
+        self.messages
+            .iter()
+            .rev()
+            .find_map(|message| match message {
+                ChatCompletionRequestMessage::User(user_message) => Some(user_message),
+                _ => None,
+            })
+    }
+
+    /// Return the mutable reference to the latest user message from the chat history.
+    pub fn latest_user_message_mut(&mut self) -> Option<&mut ChatCompletionUserMessage> {
+        self.messages
+            .iter_mut()
+            .rev()
+            .find_map(|message| match message {
+                ChatCompletionRequestMessage::User(user_message) => Some(user_message),
+                _ => None,
+            })
+    }
+
+    /// Return the type of the latest message from the chat history.
+    pub fn latest_message_type(&self) -> Option<String> {
+        self.messages.last().map(|message| match message {
+            ChatCompletionRequestMessage::User(_) => "user".to_string(),
+            ChatCompletionRequestMessage::Assistant(_) => "assistant".to_string(),
+            ChatCompletionRequestMessage::System(_) => "system".to_string(),
+            ChatCompletionRequestMessage::Tool(_) => "tool".to_string(),
+        })
+    }
+}
 
 #[test]
 fn test_chat_serialize_chat_request() {
@@ -1465,6 +1498,14 @@ pub struct Tool {
     pub ty: String,
     /// Function the model may generate JSON inputs for.
     pub function: ToolFunction,
+}
+impl Tool {
+    pub fn new(function: ToolFunction) -> Self {
+        Self {
+            ty: "function".to_string(),
+            function,
+        }
+    }
 }
 
 #[test]

--- a/crates/endpoints/src/chat.rs
+++ b/crates/endpoints/src/chat.rs
@@ -522,7 +522,7 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
 
                 while let Some(key) = map.next_key::<String>()? {
                     #[cfg(feature = "logging")]
-                    debug!(target: "stdout", "key: {}", key);
+                    debug!(target: "stdout", "key: {key}");
 
                     match key.as_str() {
                         "model" => model = map.next_value()?,
@@ -569,7 +569,7 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
                             let _ = map.next_value::<IgnoredAny>()?;
 
                             #[cfg(feature = "logging")]
-                            warn!(target: "stdout", "Not supported field: {}", key);
+                            warn!(target: "stdout", "Not supported field: {key}");
                         }
                     }
                 }
@@ -1148,8 +1148,8 @@ fn test_chat_serialize_chat_request() {
             .with_rag_vdb_settings(
                 "http://localhost:6333",
                 &["collection1".to_string(), "collection2".to_string()],
-                &[10, 20],
-                &[0.5, 0.6],
+                [10, 20],
+                [0.5, 0.6],
                 None,
             )
             .with_kw_search_url("http://localhost:9069")
@@ -3105,7 +3105,7 @@ impl<'de> Deserialize<'de> for ChatCompletionObjectMessage {
                             let _ = map.next_value::<IgnoredAny>()?;
 
                             #[cfg(feature = "logging")]
-                            warn!(target: "stdout", "Not supported field: {}", key);
+                            warn!(target: "stdout", "Not supported field: {key}");
                         }
                     }
                 }
@@ -3321,7 +3321,7 @@ impl<'de> Deserialize<'de> for ChatCompletionChunkChoiceDelta {
                             let _ = map.next_value::<IgnoredAny>()?;
 
                             #[cfg(feature = "logging")]
-                            warn!(target: "stdout", "Not supported field: {}", key);
+                            warn!(target: "stdout", "Not supported field: {key}");
                         }
                     }
                 }

--- a/crates/endpoints/src/images.rs
+++ b/crates/endpoints/src/images.rs
@@ -369,7 +369,7 @@ impl<'de> Deserialize<'de> for ImageCreateRequest {
                             let _ = map.next_value::<IgnoredAny>()?;
 
                             #[cfg(feature = "logging")]
-                            warn!(target: "stdout", "Not supported field: {}", key);
+                            warn!(target: "stdout", "Not supported field: {key}");
                         }
                     }
                 }
@@ -1029,7 +1029,7 @@ impl<'de> Deserialize<'de> for ImageEditRequest {
                             let _ = map.next_value::<IgnoredAny>()?;
 
                             #[cfg(feature = "logging")]
-                            warn!(target: "stdout", "Not supported field: {}", key);
+                            warn!(target: "stdout", "Not supported field: {key}");
                         }
                     }
                 }
@@ -1375,7 +1375,7 @@ impl<'de> Deserialize<'de> for ImageVariationRequest {
                             let _ = map.next_value::<IgnoredAny>()?;
 
                             #[cfg(feature = "logging")]
-                            warn!(target: "stdout", "Not supported field: {}", key);
+                            warn!(target: "stdout", "Not supported field: {key}");
                         }
                     }
                 }
@@ -1513,8 +1513,7 @@ impl<'de> Deserialize<'de> for Scheduler {
                     "ays" => Ok(Scheduler::Ays),
                     "gits" => Ok(Scheduler::Gits),
                     _ => Err(E::custom(format!(
-                        "unknown scheduler type: {}, expected one of: discrete, karras, exponential, ays, gits",
-                        value
+                        "unknown scheduler type: {value}, expected one of: discrete, karras, exponential, ays, gits",
                     ))),
                 }
             }
@@ -2809,8 +2808,7 @@ pub mod sd_webui {
                         "PLMS" => Ok(Sampler::Plms),
                         "UniPC" => Ok(Sampler::UniPC),
                         _ => Err(E::custom(format!(
-                            "unknown sampler type: {}, expected one of: Euler, Euler a, Heun, DPM2, DPM2 a, DPM fast, DPM adaptive, DPM++ 2S a, DPM++ 2M, DPM++ 2M SDE, DPM++ 2M SDE Heun, DPM++ 3M SDE, DPM++ SDE, LCM, LMS, Restart, DDIM, DDIM CFG++, PLMS, UniPC",
-                            value
+                            "unknown sampler type: {value}, expected one of: Euler, Euler a, Heun, DPM2, DPM2 a, DPM fast, DPM adaptive, DPM++ 2S a, DPM++ 2M, DPM++ 2M SDE, DPM++ 2M SDE Heun, DPM++ 3M SDE, DPM++ SDE, LCM, LMS, Restart, DDIM, DDIM CFG++, PLMS, UniPC"
                         ))),
                     }
                 }

--- a/crates/endpoints/src/keyword_search.rs
+++ b/crates/endpoints/src/keyword_search.rs
@@ -20,8 +20,10 @@ pub struct DocumentInput {
 // Document processing result
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DocumentResult {
-    pub filename: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filename: Option<String>,
     pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
 

--- a/crates/endpoints/src/keyword_search.rs
+++ b/crates/endpoints/src/keyword_search.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 // Document indexing request for JSON input
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IndexRequest {
+    /// The name of the index to create
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// The documents to index
     pub documents: Vec<DocumentInput>,
 }
 

--- a/crates/llama-core/Cargo.toml
+++ b/crates/llama-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "llama-core"
-version       = "0.31.0"
+version       = "0.32.0"
 edition       = "2021"
 readme        = "README.md"
 repository    = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/llama-core/src/audio.rs
+++ b/crates/llama-core/src/audio.rs
@@ -49,7 +49,7 @@ async fn transcribe_audio(
     let mut graph = match graph.lock() {
         Ok(graph) => graph,
         Err(e) => {
-            let err_msg = format!("Failed to lock the graph. {}", e);
+            let err_msg = format!("Failed to lock the graph. {e}");
 
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);
@@ -215,7 +215,7 @@ async fn transcribe_audio(
                     info!(target: "stdout", "metadata updated");
                 }
                 Err(e) => {
-                    let err_msg = format!("Fail to serialize metadata to a JSON string. {}", e);
+                    let err_msg = format!("Fail to serialize metadata to a JSON string. {e}");
 
                     #[cfg(feature = "logging")]
                     error!(target: "stdout", "{}", &err_msg);
@@ -248,7 +248,7 @@ async fn transcribe_audio(
     #[cfg(feature = "logging")]
     info!(target: "stdout", "Transcribe audio to text.");
     if let Err(e) = graph.compute() {
-        let err_msg = format!("Failed to compute the graph. {}", e);
+        let err_msg = format!("Failed to compute the graph. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -263,7 +263,7 @@ async fn transcribe_audio(
     // Retrieve the output.
     let mut output_buffer = vec![0u8; MAX_BUFFER_SIZE];
     let output_size = graph.get_output(0, &mut output_buffer).map_err(|e| {
-        let err_msg = format!("Failed to get the output tensor. {}", e);
+        let err_msg = format!("Failed to get the output tensor. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -272,7 +272,7 @@ async fn transcribe_audio(
     })?;
 
     #[cfg(feature = "logging")]
-    info!(target: "stdout", "Output buffer size: {}", output_size);
+    info!(target: "stdout", "Output buffer size: {output_size}");
 
     // decode the output buffer
     #[cfg(feature = "logging")]
@@ -297,7 +297,7 @@ async fn transcribe_audio(
 fn load_audio_waveform(filename: impl AsRef<std::path::Path>) -> Result<Vec<u8>, LlamaCoreError> {
     std::fs::read(filename)
         .map_err(|e| {
-            let err_msg = format!("Failed to read the input tensor. {}", e);
+            let err_msg = format!("Failed to read the input tensor. {e}");
 
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);
@@ -357,7 +357,7 @@ async fn translate_audio(request: TranslationRequest) -> Result<TranslationObjec
     let mut graph = match graph.lock() {
         Ok(graph) => graph,
         Err(e) => {
-            let err_msg = format!("Failed to lock the graph. {}", e);
+            let err_msg = format!("Failed to lock the graph. {e}");
 
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);
@@ -512,7 +512,7 @@ async fn translate_audio(request: TranslationRequest) -> Result<TranslationObjec
                     set_tensor_data(&mut graph, 1, config.as_bytes(), [1])?;
                 }
                 Err(e) => {
-                    let err_msg = format!("Fail to serialize metadata to a JSON string. {}", e);
+                    let err_msg = format!("Fail to serialize metadata to a JSON string. {e}");
 
                     #[cfg(feature = "logging")]
                     error!(target: "stdout", "{}", &err_msg);
@@ -545,7 +545,7 @@ async fn translate_audio(request: TranslationRequest) -> Result<TranslationObjec
     #[cfg(feature = "logging")]
     info!(target: "stdout", "translate audio to text.");
     if let Err(e) = graph.compute() {
-        let err_msg = format!("Failed to compute the graph. {}", e);
+        let err_msg = format!("Failed to compute the graph. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -560,7 +560,7 @@ async fn translate_audio(request: TranslationRequest) -> Result<TranslationObjec
     // Retrieve the output.
     let mut output_buffer = vec![0u8; MAX_BUFFER_SIZE];
     let output_size = graph.get_output(0, &mut output_buffer).map_err(|e| {
-        let err_msg = format!("Failed to get the output tensor. {}", e);
+        let err_msg = format!("Failed to get the output tensor. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -569,7 +569,7 @@ async fn translate_audio(request: TranslationRequest) -> Result<TranslationObjec
     })?;
 
     #[cfg(feature = "logging")]
-    info!(target: "stdout", "output buffer size: {}", output_size);
+    info!(target: "stdout", "output buffer size: {output_size}");
 
     // decode the output buffer
     #[cfg(feature = "logging")]
@@ -615,7 +615,7 @@ pub async fn create_speech(request: SpeechRequest) -> Result<Vec<u8>, LlamaCoreE
     let mut graph = match graph.lock() {
         Ok(graph) => graph,
         Err(e) => {
-            let err_msg = format!("Failed to lock the graph. {}", e);
+            let err_msg = format!("Failed to lock the graph. {e}");
 
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);
@@ -633,7 +633,7 @@ pub async fn create_speech(request: SpeechRequest) -> Result<Vec<u8>, LlamaCoreE
     #[cfg(feature = "logging")]
     info!(target: "stdout", "create audio.");
     if let Err(e) = graph.compute() {
-        let err_msg = format!("Failed to compute the graph. {}", e);
+        let err_msg = format!("Failed to compute the graph. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -647,7 +647,7 @@ pub async fn create_speech(request: SpeechRequest) -> Result<Vec<u8>, LlamaCoreE
 
     let mut output_buffer = vec![0u8; MAX_BUFFER_SIZE];
     let output_size = graph.get_output(0, &mut output_buffer).map_err(|e| {
-        let err_msg = format!("Failed to get the output tensor. {}", e);
+        let err_msg = format!("Failed to get the output tensor. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -656,7 +656,7 @@ pub async fn create_speech(request: SpeechRequest) -> Result<Vec<u8>, LlamaCoreE
     })?;
 
     #[cfg(feature = "logging")]
-    info!(target: "stdout", "Output buffer size: {}", output_size);
+    info!(target: "stdout", "Output buffer size: {output_size}");
 
     Ok(output_buffer)
 }
@@ -688,14 +688,14 @@ fn get_model_metadata() -> Result<WhisperMetadata, LlamaCoreError> {
             let err_msg = "Fail to get the underlying value of `AUDIO_GRAPH`.";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             return Err(LlamaCoreError::Operation(err_msg.into()));
         }
     };
 
     let audio_graph = audio_graph.lock().map_err(|e| {
-        let err_msg = format!("Fail to acquire the lock of `AUDIO_GRAPH`. {}", e);
+        let err_msg = format!("Fail to acquire the lock of `AUDIO_GRAPH`. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -711,7 +711,7 @@ fn update_model_metadata(metadata: &WhisperMetadata) -> Result<(), LlamaCoreErro
     let config = match serde_json::to_string(metadata) {
         Ok(config) => config,
         Err(e) => {
-            let err_msg = format!("Fail to serialize metadata to a JSON string. {}", e);
+            let err_msg = format!("Fail to serialize metadata to a JSON string. {e}");
 
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);
@@ -726,14 +726,14 @@ fn update_model_metadata(metadata: &WhisperMetadata) -> Result<(), LlamaCoreErro
             let err_msg = "Fail to get the underlying value of `AUDIO_GRAPH`.";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             return Err(LlamaCoreError::Operation(err_msg.into()));
         }
     };
 
     let mut audio_graph = audio_graph.lock().map_err(|e| {
-        let err_msg = format!("Fail to acquire the lock of `AUDIO_GRAPH`. Reason: {}", e);
+        let err_msg = format!("Fail to acquire the lock of `AUDIO_GRAPH`. Reason: {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);

--- a/crates/llama-core/src/chat.rs
+++ b/crates/llama-core/src/chat.rs
@@ -1289,19 +1289,18 @@ fn parse_tool_calls(
 
                         let arguments = match value.get("arguments") {
                             Some(arguments) => {
-                                // if arguments.is_string() {
-                                //     arguments.as_str().unwrap().to_string()
-                                // } else if arguments.is_object() {
-                                //     let map = arguments.as_object().unwrap();
+                                if arguments.is_string() {
+                                    arguments.as_str().unwrap().to_string()
+                                } else if arguments.is_object() {
+                                    let map = arguments.as_object().unwrap();
 
-                                //     #[cfg(feature = "logging")]
-                                //     info!(target: "stdout", "func arguments: {:?}", map);
+                                    #[cfg(feature = "logging")]
+                                    info!(target: "stdout", "func arguments: {:?}", map);
 
-                                //     serde_json::to_string(map).unwrap()
-                                // } else {
-                                //     arguments.to_string()
-                                // }
-                                serde_json::to_string(arguments).unwrap()
+                                    serde_json::to_string(map).unwrap()
+                                } else {
+                                    serde_json::to_string(arguments).unwrap()
+                                }
                             }
                             None => {
                                 let err_msg = format!(
@@ -1327,10 +1326,18 @@ fn parse_tool_calls(
                         tool_calls.push(tool_call);
                     }
 
-                    let parsed = ParseResult {
-                        raw: input.to_owned(),
-                        content: None,
-                        tool_calls,
+                    let parsed = if tool_calls.is_empty() {
+                        ParseResult {
+                            raw: input.to_owned(),
+                            content: Some(input.to_owned()),
+                            tool_calls: vec![],
+                        }
+                    } else {
+                        ParseResult {
+                            raw: input.to_owned(),
+                            content: None,
+                            tool_calls,
+                        }
                     };
 
                     #[cfg(feature = "logging")]

--- a/crates/llama-core/src/chat.rs
+++ b/crates/llama-core/src/chat.rs
@@ -115,7 +115,7 @@ async fn chat_stream(
         let err_msg = "The chat completion is only supported in the chat or rag mode.";
 
         #[cfg(feature = "logging")]
-        error!(target: "stdout", "{}", err_msg);
+        error!(target: "stdout", "{err_msg}");
 
         return Err(LlamaCoreError::Operation(err_msg.to_string()));
     }
@@ -140,7 +140,7 @@ async fn chat_stream(
         None => metadata.include_usage,
     };
     #[cfg(feature = "logging")]
-    info!(target: "stdout", "include_usage: {}", include_usage);
+    info!(target: "stdout", "include_usage: {include_usage}");
 
     #[cfg(feature = "logging")]
     info!(target: "stdout", "Build the chat prompt");
@@ -152,8 +152,8 @@ async fn chat_stream(
     #[cfg(feature = "logging")]
     {
         info!(target: "stdout", "prompt:\n{}", &prompt);
-        info!(target: "stdout", "available_completion_tokens: {}", avaible_completion_tokens);
-        info!(target: "stdout", "tool_use: {}", tool_use);
+        info!(target: "stdout", "available_completion_tokens: {avaible_completion_tokens}");
+        info!(target: "stdout", "tool_use: {tool_use}");
     }
 
     #[cfg(feature = "logging")]
@@ -184,7 +184,7 @@ async fn chat_stream(
             };
 
             let mut chat_graphs = chat_graphs.lock().map_err(|e| {
-                let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
+                let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {e}");
 
                 #[cfg(feature = "logging")]
                 error!(target: "stdout", "{}", &err_msg);
@@ -247,8 +247,7 @@ fn chat_stream_for_tool(
             let output_buffer = get_output_buffer(graph, OUTPUT_TENSOR)?;
             let output = std::str::from_utf8(&output_buffer[..]).map_err(|e| {
                 let err_msg = format!(
-                    "Failed to decode the buffer of the inference result to a utf-8 string. {}",
-                    e
+                    "Failed to decode the buffer of the inference result to a utf-8 string. {e}"
                 );
 
                 #[cfg(feature = "logging")]
@@ -258,11 +257,11 @@ fn chat_stream_for_tool(
             })?;
 
             #[cfg(feature = "logging")]
-            info!(target: "stdout", "raw generation:\n{}", output);
+            info!(target: "stdout", "raw generation:\n{output}");
 
             // post-process
             let message = post_process(output, &graph.metadata.prompt_template).map_err(|e| {
-                LlamaCoreError::Operation(format!("Failed to post-process the output. {}", e))
+                LlamaCoreError::Operation(format!("Failed to post-process the output. {e}"))
             })?;
 
             #[cfg(feature = "logging")]
@@ -283,7 +282,7 @@ fn chat_stream_for_tool(
             let created = SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map_err(|e| {
-                    let err_msg = format!("Failed to get the current time. Reason: {}", e);
+                    let err_msg = format!("Failed to get the current time. Reason: {e}");
 
                     #[cfg(feature = "logging")]
                     error!(target: "stdout", "{}", &err_msg);
@@ -357,8 +356,7 @@ fn chat_stream_for_tool(
                     usage: None,
                 };
                 let chunk_str = serde_json::to_string(&chat_completion_chunk).map_err(|e| {
-                    let err_msg =
-                        format!("Failed to serialize chat completion chunk. Reason: {}", e);
+                    let err_msg = format!("Failed to serialize chat completion chunk. Reason: {e}");
 
                     #[cfg(feature = "logging")]
                     error!(target: "stdout", "{}", &err_msg);
@@ -366,7 +364,7 @@ fn chat_stream_for_tool(
                     LlamaCoreError::Operation(err_msg)
                 })?;
 
-                format!("data: {}\n\n", chunk_str)
+                format!("data: {chunk_str}\n\n")
             };
 
             // token uage chunk
@@ -381,8 +379,7 @@ fn chat_stream_for_tool(
                     usage,
                 };
                 let chunk_str = serde_json::to_string(&chat_completion_chunk).map_err(|e| {
-                    let err_msg =
-                        format!("Failed to serialize chat completion chunk. Reason: {}", e);
+                    let err_msg = format!("Failed to serialize chat completion chunk. Reason: {e}");
 
                     #[cfg(feature = "logging")]
                     error!(target: "stdout", "{}", &err_msg);
@@ -390,7 +387,7 @@ fn chat_stream_for_tool(
                     LlamaCoreError::Operation(err_msg)
                 })?;
 
-                format!("data: {}\n\n", chunk_str)
+                format!("data: {chunk_str}\n\n")
             };
 
             // ending chunk
@@ -412,8 +409,7 @@ fn chat_stream_for_tool(
             let output_buffer = get_output_buffer(graph, OUTPUT_TENSOR)?;
             let output = std::str::from_utf8(&output_buffer[..]).map_err(|e| {
                 let err_msg = format!(
-                    "Failed to decode the buffer of the inference result to a utf-8 string. {}",
-                    e
+                    "Failed to decode the buffer of the inference result to a utf-8 string. {e}"
                 );
 
                 #[cfg(feature = "logging")]
@@ -424,7 +420,7 @@ fn chat_stream_for_tool(
 
             // post-process
             let message = post_process(output, &graph.metadata.prompt_template).map_err(|e| {
-                let err_msg = format!("Failed to post-process the output. {}", e);
+                let err_msg = format!("Failed to post-process the output. {e}");
 
                 #[cfg(feature = "logging")]
                 error!(target: "stdout", "{}", &err_msg);
@@ -447,7 +443,7 @@ fn chat_stream_for_tool(
             let created = SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map_err(|e| {
-                    let err_msg = format!("Failed to get the current time. Reason: {}", e);
+                    let err_msg = format!("Failed to get the current time. Reason: {e}");
 
                     #[cfg(feature = "logging")]
                     error!(target: "stdout", "{}", &err_msg);
@@ -478,8 +474,7 @@ fn chat_stream_for_tool(
 
                 // serialize chat completion chunk
                 let chunk_str = serde_json::to_string(&chat_completion_chunk).map_err(|e| {
-                    let err_msg =
-                        format!("Failed to serialize chat completion chunk. Reason: {}", e);
+                    let err_msg = format!("Failed to serialize chat completion chunk. Reason: {e}");
 
                     #[cfg(feature = "logging")]
                     error!(target: "stdout", "{}", &err_msg);
@@ -487,7 +482,7 @@ fn chat_stream_for_tool(
                     LlamaCoreError::Operation(err_msg)
                 })?;
 
-                format!("data: {}\n\n", chunk_str)
+                format!("data: {chunk_str}\n\n")
             };
 
             // usage chunk
@@ -504,8 +499,7 @@ fn chat_stream_for_tool(
 
                 // serialize chat completion chunk
                 let chunk_str = serde_json::to_string(&chat_completion_chunk).map_err(|e| {
-                    let err_msg =
-                        format!("Failed to serialize chat completion chunk. Reason: {}", e);
+                    let err_msg = format!("Failed to serialize chat completion chunk. Reason: {e}");
 
                     #[cfg(feature = "logging")]
                     error!(target: "stdout", "{}", &err_msg);
@@ -513,7 +507,7 @@ fn chat_stream_for_tool(
                     LlamaCoreError::Operation(err_msg)
                 })?;
 
-                format!("data: {}\n\n", chunk_str)
+                format!("data: {chunk_str}\n\n")
             };
 
             // ending chunk
@@ -540,8 +534,7 @@ fn chat_stream_for_tool(
             let output_buffer = get_output_buffer(graph, OUTPUT_TENSOR)?;
             let output = std::str::from_utf8(&output_buffer[..]).map_err(|e| {
                 let err_msg = format!(
-                    "Failed to decode the buffer of the inference result to a utf-8 string. {}",
-                    e
+                    "Failed to decode the buffer of the inference result to a utf-8 string. {e}"
                 );
 
                 #[cfg(feature = "logging")]
@@ -552,7 +545,7 @@ fn chat_stream_for_tool(
 
             // post-process
             let message = post_process(output, &graph.metadata.prompt_template).map_err(|e| {
-                let err_msg = format!("Failed to post-process the output. {}", e);
+                let err_msg = format!("Failed to post-process the output. {e}");
 
                 #[cfg(feature = "logging")]
                 error!(target: "stdout", "{}", &err_msg);
@@ -575,7 +568,7 @@ fn chat_stream_for_tool(
             let created = SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map_err(|e| {
-                    let err_msg = format!("Failed to get the current time. Reason: {}", e);
+                    let err_msg = format!("Failed to get the current time. Reason: {e}");
 
                     #[cfg(feature = "logging")]
                     error!(target: "stdout", "{}", &err_msg);
@@ -606,8 +599,7 @@ fn chat_stream_for_tool(
 
                 // serialize chat completion chunk
                 let chunk_str = serde_json::to_string(&chat_completion_chunk).map_err(|e| {
-                    let err_msg =
-                        format!("Failed to serialize chat completion chunk. Reason: {}", e);
+                    let err_msg = format!("Failed to serialize chat completion chunk. Reason: {e}");
 
                     #[cfg(feature = "logging")]
                     error!(target: "stdout", "{}", &err_msg);
@@ -615,7 +607,7 @@ fn chat_stream_for_tool(
                     LlamaCoreError::Operation(err_msg)
                 })?;
 
-                format!("data: {}\n\n", chunk_str)
+                format!("data: {chunk_str}\n\n")
             };
 
             // usage chunk
@@ -632,8 +624,7 @@ fn chat_stream_for_tool(
 
                 // serialize chat completion chunk
                 let chunk_str = serde_json::to_string(&chat_completion_chunk).map_err(|e| {
-                    let err_msg =
-                        format!("Failed to serialize chat completion chunk. Reason: {}", e);
+                    let err_msg = format!("Failed to serialize chat completion chunk. Reason: {e}");
 
                     #[cfg(feature = "logging")]
                     error!(target: "stdout", "{}", &err_msg);
@@ -641,7 +632,7 @@ fn chat_stream_for_tool(
                     LlamaCoreError::Operation(err_msg)
                 })?;
 
-                format!("data: {}\n\n", chunk_str)
+                format!("data: {chunk_str}\n\n")
             };
 
             // ending chunk
@@ -659,7 +650,7 @@ fn chat_stream_for_tool(
             Ok((stream, false))
         }
         Err(e) => {
-            let err_msg = format!("Failed to compute the chat completion. Reason: {}", e);
+            let err_msg = format!("Failed to compute the chat completion. Reason: {e}");
 
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);
@@ -680,7 +671,7 @@ async fn chat_once(
         let err_msg = "The chat completion is only supported in the chat or rag mode.";
 
         #[cfg(feature = "logging")]
-        error!(target: "stdout", "{}", err_msg);
+        error!(target: "stdout", "{err_msg}");
 
         return Err(LlamaCoreError::Operation(err_msg.to_string()));
     }
@@ -710,8 +701,8 @@ async fn chat_once(
     #[cfg(feature = "logging")]
     {
         info!(target: "stdout", "prompt:\n{}", &prompt);
-        info!(target: "stdout", "available_completion_tokens: {}", avaible_completion_tokens);
-        info!(target: "stdout", "tool_use: {}", tool_use);
+        info!(target: "stdout", "available_completion_tokens: {avaible_completion_tokens}");
+        info!(target: "stdout", "tool_use: {tool_use}");
     }
 
     #[cfg(feature = "logging")]
@@ -759,7 +750,7 @@ fn compute(
     };
 
     let mut chat_graphs = chat_graphs.lock().map_err(|e| {
-        let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
+        let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -813,8 +804,7 @@ fn compute_by_graph(
             let output_buffer = get_output_buffer(graph, OUTPUT_TENSOR)?;
             let output = std::str::from_utf8(&output_buffer[..]).map_err(|e| {
                 let err_msg = format!(
-                    "Failed to decode the buffer of the inference result to a utf-8 string. {}",
-                    e
+                    "Failed to decode the buffer of the inference result to a utf-8 string. {e}"
                 );
 
                 #[cfg(feature = "logging")]
@@ -824,11 +814,11 @@ fn compute_by_graph(
             })?;
 
             #[cfg(feature = "logging")]
-            info!(target: "stdout", "raw generation: {}", output);
+            info!(target: "stdout", "raw generation: {output}");
 
             // post-process
             let message = post_process(output, &graph.metadata.prompt_template).map_err(|e| {
-                LlamaCoreError::Operation(format!("Failed to post-process the output. {}", e))
+                LlamaCoreError::Operation(format!("Failed to post-process the output. {e}"))
             })?;
 
             #[cfg(feature = "logging")]
@@ -843,7 +833,7 @@ fn compute_by_graph(
             let created = SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map_err(|e| {
-                    let err_msg = format!("Failed to get the current time. Reason: {}", e);
+                    let err_msg = format!("Failed to get the current time. Reason: {e}");
 
                     #[cfg(feature = "logging")]
                     error!(target: "stdout", "{}", &err_msg);
@@ -945,8 +935,7 @@ fn compute_by_graph(
             let output_buffer = get_output_buffer(graph, OUTPUT_TENSOR)?;
             let output = std::str::from_utf8(&output_buffer[..]).map_err(|e| {
                 let err_msg = format!(
-                    "Failed to decode the buffer of the inference result to a utf-8 string. {}",
-                    e
+                    "Failed to decode the buffer of the inference result to a utf-8 string. {e}"
                 );
 
                 #[cfg(feature = "logging")]
@@ -957,7 +946,7 @@ fn compute_by_graph(
 
             // post-process
             let message = post_process(output, &graph.metadata.prompt_template).map_err(|e| {
-                let err_msg = format!("Failed to post-process the output. {}", e);
+                let err_msg = format!("Failed to post-process the output. {e}");
 
                 #[cfg(feature = "logging")]
                 error!(target: "stdout", "{}", &err_msg);
@@ -974,7 +963,7 @@ fn compute_by_graph(
             let created = SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map_err(|e| {
-                    let err_msg = format!("Failed to get the current time. Reason: {}", e);
+                    let err_msg = format!("Failed to get the current time. Reason: {e}");
 
                     #[cfg(feature = "logging")]
                     error!(target: "stdout", "{}", &err_msg);
@@ -1018,8 +1007,7 @@ fn compute_by_graph(
             let output_buffer = get_output_buffer(graph, OUTPUT_TENSOR)?;
             let output = std::str::from_utf8(&output_buffer[..]).map_err(|e| {
                 let err_msg = format!(
-                    "Failed to decode the buffer of the inference result to a utf-8 string. {}",
-                    e
+                    "Failed to decode the buffer of the inference result to a utf-8 string. {e}"
                 );
 
                 #[cfg(feature = "logging")]
@@ -1030,7 +1018,7 @@ fn compute_by_graph(
 
             // post-process
             let message = post_process(output, &graph.metadata.prompt_template).map_err(|e| {
-                let err_msg = format!("Failed to post-process the output. {}", e);
+                let err_msg = format!("Failed to post-process the output. {e}");
 
                 #[cfg(feature = "logging")]
                 error!(target: "stdout", "{}", &err_msg);
@@ -1053,7 +1041,7 @@ fn compute_by_graph(
             let created = SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map_err(|e| {
-                    let err_msg = format!("Failed to get the current time. Reason: {}", e);
+                    let err_msg = format!("Failed to get the current time. Reason: {e}");
 
                     #[cfg(feature = "logging")]
                     error!(target: "stdout", "{}", &err_msg);
@@ -1084,7 +1072,7 @@ fn compute_by_graph(
             Ok((res, false))
         }
         Err(e) => {
-            let err_msg = format!("Failed to compute the chat completion. Reason: {}", e);
+            let err_msg = format!("Failed to compute the chat completion. Reason: {e}");
 
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);
@@ -1106,15 +1094,13 @@ fn parse_tool_calls(
                     let matched = &cap[0];
 
                     #[cfg(feature = "logging")]
-                    info!(target: "stdout", "captured: {}", matched);
+                    info!(target: "stdout", "captured: {matched}");
 
                     match serde_json::from_str::<Vec<serde_json::Value>>(matched) {
                         Ok(group) => values.extend(group),
                         Err(e) => {
-                            let err_msg = format!(
-                                "Failed to deserialize generated tool calls. Reason: {}",
-                                e
-                            );
+                            let err_msg =
+                                format!("Failed to deserialize generated tool calls. Reason: {e}");
 
                             #[cfg(feature = "logging")]
                             error!(target: "stdout", "{}", &err_msg);
@@ -1130,8 +1116,7 @@ fn parse_tool_calls(
                         Some(name) => name.to_string().replace("\"", ""),
                         None => {
                             let err_msg = format!(
-                                "Failed to get the name of the function. Tool call: {:?}",
-                                value
+                                "Failed to get the name of the function. Tool call: {value:?}"
                             );
 
                             #[cfg(feature = "logging")]
@@ -1145,8 +1130,7 @@ fn parse_tool_calls(
                         Some(arguments) => arguments.to_string(),
                         None => {
                             let err_msg = format!(
-                                "Failed to get the arguments of the function. Tool call: {:?}",
-                                value
+                                "Failed to get the arguments of the function. Tool call: {value:?}"
                             );
 
                             #[cfg(feature = "logging")]
@@ -1174,12 +1158,12 @@ fn parse_tool_calls(
                 };
 
                 #[cfg(feature = "logging")]
-                info!(target: "stdout", "parsed result: {:?}", parsed);
+                info!(target: "stdout", "parsed result: {parsed:?}");
 
                 Ok(parsed)
             }
             Err(e) => {
-                let err_msg = format!("Failed to create a regex pattern. Reason: {}", e);
+                let err_msg = format!("Failed to create a regex pattern. Reason: {e}");
 
                 #[cfg(feature = "logging")]
                 error!(target: "stdout", "{}", &err_msg);
@@ -1201,8 +1185,7 @@ fn parse_tool_calls(
                             Ok(value) => values.push(value),
                             Err(e) => {
                                 let err_msg = format!(
-                                    "Failed to deserialize generated tool calls. Reason: {}",
-                                    e
+                                    "Failed to deserialize generated tool calls. Reason: {e}"
                                 );
 
                                 #[cfg(feature = "logging")]
@@ -1219,8 +1202,7 @@ fn parse_tool_calls(
                             Some(name) => name.to_string().replace("\"", ""),
                             None => {
                                 let err_msg = format!(
-                                    "Failed to get the name of the function. Tool call: {:?}",
-                                    value
+                                    "Failed to get the name of the function. Tool call: {value:?}"
                                 );
 
                                 #[cfg(feature = "logging")]
@@ -1234,8 +1216,7 @@ fn parse_tool_calls(
                             Some(arguments) => arguments.to_string(),
                             None => {
                                 let err_msg = format!(
-                                    "Failed to get the arguments of the function. Tool call: {:?}",
-                                    value
+                                    "Failed to get the arguments of the function. Tool call: {value:?}"
                                 );
 
                                 #[cfg(feature = "logging")]
@@ -1263,12 +1244,12 @@ fn parse_tool_calls(
                     };
 
                     #[cfg(feature = "logging")]
-                    info!(target: "stdout", "parsed result: {:?}", parsed);
+                    info!(target: "stdout", "parsed result: {parsed:?}");
 
                     Ok(parsed)
                 }
                 Err(e) => {
-                    let err_msg = format!("Failed to create a regex pattern. Reason: {}", e);
+                    let err_msg = format!("Failed to create a regex pattern. Reason: {e}");
 
                     #[cfg(feature = "logging")]
                     error!(target: "stdout", "{}", &err_msg);
@@ -1279,7 +1260,7 @@ fn parse_tool_calls(
         }
         PromptTemplateType::GroqLlama3Tool => {
             #[cfg(feature = "logging")]
-            info!(target: "stdout", "raw input: {}", input);
+            info!(target: "stdout", "raw input: {input}");
 
             match regex::Regex::new(r"(?s)<tool_call>((.|\r|\n)*?)</tool_call>") {
                 Ok(re) => {
@@ -1288,14 +1269,13 @@ fn parse_tool_calls(
                         let matched = cap[1].trim();
 
                         #[cfg(feature = "logging")]
-                        info!(target: "stdout", "captured: {}", matched);
+                        info!(target: "stdout", "captured: {matched}");
 
                         match serde_json::from_str::<serde_json::Value>(matched) {
                             Ok(value) => values.push(value),
                             Err(e) => {
                                 let err_msg = format!(
-                                    "Failed to deserialize generated tool calls. Reason: {}",
-                                    e
+                                    "Failed to deserialize generated tool calls. Reason: {e}"
                                 );
 
                                 #[cfg(feature = "logging")]
@@ -1312,8 +1292,7 @@ fn parse_tool_calls(
                             Some(name) => name.to_string().replace("\"", ""),
                             None => {
                                 let err_msg = format!(
-                                    "Failed to get the name of the function. Tool call: {:?}",
-                                    value
+                                    "Failed to get the name of the function. Tool call: {value:?}"
                                 );
 
                                 #[cfg(feature = "logging")]
@@ -1331,7 +1310,7 @@ fn parse_tool_calls(
                                     let map = arguments.as_object().unwrap();
 
                                     #[cfg(feature = "logging")]
-                                    info!(target: "stdout", "func arguments: {:?}", map);
+                                    info!(target: "stdout", "func arguments: {map:?}");
 
                                     serde_json::to_string(map).unwrap()
                                 } else {
@@ -1340,8 +1319,7 @@ fn parse_tool_calls(
                             }
                             None => {
                                 let err_msg = format!(
-                                    "Failed to get the arguments of the function. Tool call: {:?}",
-                                    value
+                                    "Failed to get the arguments of the function. Tool call: {value:?}"
                                 );
 
                                 #[cfg(feature = "logging")]
@@ -1377,12 +1355,12 @@ fn parse_tool_calls(
                     };
 
                     #[cfg(feature = "logging")]
-                    info!(target: "stdout", "parsed result: {:?}", parsed);
+                    info!(target: "stdout", "parsed result: {parsed:?}");
 
                     Ok(parsed)
                 }
                 Err(e) => {
-                    let err_msg = format!("Failed to create a regex pattern. Reason: {}", e);
+                    let err_msg = format!("Failed to create a regex pattern. Reason: {e}");
 
                     #[cfg(feature = "logging")]
                     error!(target: "stdout", "{}", &err_msg);
@@ -1393,12 +1371,12 @@ fn parse_tool_calls(
         }
         PromptTemplateType::Llama3Tool => {
             #[cfg(feature = "logging")]
-            info!(target: "stdout", "raw input: {}", input);
+            info!(target: "stdout", "raw input: {input}");
 
             let re = match regex::Regex::new(r"^\{(.|\r|\n)*\}$") {
                 Ok(re) => re,
                 Err(e) => {
-                    let err_msg = format!("Failed to create a regex pattern. Reason: {}", e);
+                    let err_msg = format!("Failed to create a regex pattern. Reason: {e}");
 
                     #[cfg(feature = "logging")]
                     error!(target: "stdout", "{}", &err_msg);
@@ -1418,8 +1396,7 @@ fn parse_tool_calls(
                                 Some(name) => name.to_string().replace("\"", ""),
                                 None => {
                                     let err_msg = format!(
-                                        "Failed to get the name of the function. Tool call: {:?}",
-                                        value
+                                        "Failed to get the name of the function. Tool call: {value:?}"
                                     );
 
                                     #[cfg(feature = "logging")]
@@ -1433,8 +1410,7 @@ fn parse_tool_calls(
                                 Some(arguments) => arguments.to_string(),
                                 None => {
                                     let err_msg = format!(
-                                        "Failed to get the arguments of the function. Tool call: {:?}",
-                                        value
+                                        "Failed to get the arguments of the function. Tool call: {value:?}"
                                     );
 
                                     #[cfg(feature = "logging")]
@@ -1462,13 +1438,13 @@ fn parse_tool_calls(
                         };
 
                         #[cfg(feature = "logging")]
-                        info!(target: "stdout", "parsed result: {:?}", parsed);
+                        info!(target: "stdout", "parsed result: {parsed:?}");
 
                         Ok(parsed)
                     }
                     Err(e) => {
                         let err_msg =
-                            format!("Failed to deserialize generated tool calls. Reason: {}", e);
+                            format!("Failed to deserialize generated tool calls. Reason: {e}");
 
                         #[cfg(feature = "logging")]
                         error!(target: "stdout", "{}", &err_msg);
@@ -1484,19 +1460,19 @@ fn parse_tool_calls(
                 };
 
                 #[cfg(feature = "logging")]
-                info!(target: "stdout", "parsed result: {:?}", parsed);
+                info!(target: "stdout", "parsed result: {parsed:?}");
 
                 Ok(parsed)
             }
         }
         PromptTemplateType::InternLM2Tool => {
             #[cfg(feature = "logging")]
-            info!(target: "stdout", "raw input: {}", input);
+            info!(target: "stdout", "raw input: {input}");
 
             let blocks: Vec<&str> = input.trim().split("<|action_start|><|plugin|>").collect();
 
             #[cfg(feature = "logging")]
-            info!(target: "stdout", "blocks: {:?}", blocks);
+            info!(target: "stdout", "blocks: {blocks:?}");
 
             let mut tool_calls: Vec<ToolCall> = vec![];
             let mut content = String::new();
@@ -1507,7 +1483,7 @@ fn parse_tool_calls(
                         let value = block.trim().trim_end_matches("<|action_end|>");
 
                         #[cfg(feature = "logging")]
-                        info!(target: "stdout", "tool call: {}", value);
+                        info!(target: "stdout", "tool call: {value}");
 
                         match serde_json::from_str::<serde_json::Value>(value) {
                             Ok(value) => {
@@ -1515,8 +1491,7 @@ fn parse_tool_calls(
                                     Some(name) => name.to_string().replace("\"", ""),
                                     None => {
                                         let err_msg = format!(
-                                            "Failed to get the name of the function. Tool call: {:?}",
-                                            value
+                                            "Failed to get the name of the function. Tool call: {value:?}"
                                         );
 
                                         #[cfg(feature = "logging")]
@@ -1530,8 +1505,7 @@ fn parse_tool_calls(
                                     Some(arguments) => arguments.to_string(),
                                     None => {
                                         let err_msg = format!(
-                                            "Failed to get the arguments of the function. Tool call: {:?}",
-                                            value
+                                            "Failed to get the arguments of the function. Tool call: {value:?}"
                                         );
 
                                         #[cfg(feature = "logging")]
@@ -1553,8 +1527,7 @@ fn parse_tool_calls(
                             }
                             Err(e) => {
                                 let err_msg = format!(
-                                    "Failed to deserialize generated tool calls. Reason: {}",
-                                    e
+                                    "Failed to deserialize generated tool calls. Reason: {e}"
                                 );
 
                                 #[cfg(feature = "logging")]
@@ -1584,13 +1557,13 @@ fn parse_tool_calls(
             };
 
             #[cfg(feature = "logging")]
-            info!(target: "stdout", "parsed result: {:?}", parsed);
+            info!(target: "stdout", "parsed result: {parsed:?}");
 
             Ok(parsed)
         }
         PromptTemplateType::NemotronTool => {
             #[cfg(feature = "logging")]
-            info!(target: "stdout", "raw input: {}", input);
+            info!(target: "stdout", "raw input: {input}");
 
             match regex::Regex::new(r"(?s)<toolcall>\s*(.*?)\s*</toolcall>") {
                 Ok(re) => {
@@ -1605,14 +1578,13 @@ fn parse_tool_calls(
                         let matched = cap[1].trim();
 
                         #[cfg(feature = "logging")]
-                        info!(target: "stdout", "captured: {}", matched);
+                        info!(target: "stdout", "captured: {matched}");
 
                         match serde_json::from_str::<serde_json::Value>(matched) {
                             Ok(value) => values.push(value),
                             Err(e) => {
                                 let err_msg = format!(
-                                    "Failed to deserialize generated tool calls. Reason: {}",
-                                    e
+                                    "Failed to deserialize generated tool calls. Reason: {e}"
                                 );
 
                                 #[cfg(feature = "logging")]
@@ -1629,8 +1601,7 @@ fn parse_tool_calls(
                             Some(name) => name.to_string().replace("\"", ""),
                             None => {
                                 let err_msg = format!(
-                                    "Failed to get the name of the function. Tool call: {:?}",
-                                    value
+                                    "Failed to get the name of the function. Tool call: {value:?}"
                                 );
 
                                 #[cfg(feature = "logging")]
@@ -1644,8 +1615,7 @@ fn parse_tool_calls(
                             Some(arguments) => arguments.to_string(),
                             None => {
                                 let err_msg = format!(
-                                    "Failed to get the arguments of the function. Tool call: {:?}",
-                                    value
+                                    "Failed to get the arguments of the function. Tool call: {value:?}"
                                 );
 
                                 #[cfg(feature = "logging")]
@@ -1673,12 +1643,12 @@ fn parse_tool_calls(
                     };
 
                     #[cfg(feature = "logging")]
-                    info!(target: "stdout", "parsed result: {:?}", parsed);
+                    info!(target: "stdout", "parsed result: {parsed:?}");
 
                     Ok(parsed)
                 }
                 Err(e) => {
-                    let err_msg = format!("Failed to create a regex pattern. Reason: {}", e);
+                    let err_msg = format!("Failed to create a regex pattern. Reason: {e}");
 
                     #[cfg(feature = "logging")]
                     error!(target: "stdout", "{}", &err_msg);
@@ -1689,7 +1659,7 @@ fn parse_tool_calls(
         }
         PromptTemplateType::FunctionaryV32 => {
             #[cfg(feature = "logging")]
-            info!(target: "stdout", "raw input: {}", input);
+            info!(target: "stdout", "raw input: {input}");
 
             match regex::Regex::new(r">>>\s*(\w+)\s*\{(.*)\}<\|eot_id\|>") {
                 Ok(re) => {
@@ -1720,12 +1690,12 @@ fn parse_tool_calls(
                     };
 
                     #[cfg(feature = "logging")]
-                    info!(target: "stdout", "parsed result: {:?}", parsed);
+                    info!(target: "stdout", "parsed result: {parsed:?}");
 
                     Ok(parsed)
                 }
                 Err(e) => {
-                    let warn_msg = format!("Failed to create a regex pattern. Reason: {}", e);
+                    let warn_msg = format!("Failed to create a regex pattern. Reason: {e}");
 
                     #[cfg(feature = "logging")]
                     warn!(target: "stdout", "{}", &warn_msg);
@@ -1740,7 +1710,7 @@ fn parse_tool_calls(
         }
         PromptTemplateType::FunctionaryV31 => {
             #[cfg(feature = "logging")]
-            info!(target: "stdout", "raw input: {}", input);
+            info!(target: "stdout", "raw input: {input}");
 
             match regex::Regex::new(r"<function=(\w+)>\s*(\{.*?\})</function>") {
                 Ok(re) => {
@@ -1771,12 +1741,12 @@ fn parse_tool_calls(
                     };
 
                     #[cfg(feature = "logging")]
-                    info!(target: "stdout", "parsed result: {:?}", parsed);
+                    info!(target: "stdout", "parsed result: {parsed:?}");
 
                     Ok(parsed)
                 }
                 Err(e) => {
-                    let warn_msg = format!("Failed to create a regex pattern. Reason: {}", e);
+                    let warn_msg = format!("Failed to create a regex pattern. Reason: {e}");
 
                     #[cfg(feature = "logging")]
                     warn!(target: "stdout", "{}", &warn_msg);
@@ -1791,7 +1761,7 @@ fn parse_tool_calls(
         }
         PromptTemplateType::MistralSmallTool => {
             #[cfg(feature = "logging")]
-            info!(target: "stdout", "raw input: {}", input);
+            info!(target: "stdout", "raw input: {input}");
 
             match regex::Regex::new(r"\[TOOL_CALLS\]\s*(\[(.*?)\])") {
                 Ok(re) => {
@@ -1800,14 +1770,13 @@ fn parse_tool_calls(
                         let matched = cap[1].trim();
 
                         #[cfg(feature = "logging")]
-                        info!(target: "stdout", "captured: {}", matched);
+                        info!(target: "stdout", "captured: {matched}");
 
                         match serde_json::from_str::<Vec<serde_json::Value>>(matched) {
                             Ok(vals) => values = vals,
                             Err(e) => {
                                 let err_msg = format!(
-                                    "Failed to deserialize generated tool calls. Reason: {}",
-                                    e
+                                    "Failed to deserialize generated tool calls. Reason: {e}"
                                 );
 
                                 #[cfg(feature = "logging")]
@@ -1831,14 +1800,14 @@ fn parse_tool_calls(
                                 let func_map = value.as_object().unwrap();
                                 if func_map.contains_key("name") {
                                     let func_name = func_map.get("name").unwrap().as_str().unwrap();
-                                    println!("Function name: {:?}", func_name);
+                                    println!("Function name: {func_name:?}");
 
                                     function.name = func_name.to_string();
                                 }
                                 if func_map.contains_key("arguments") {
                                     let args = func_map.get("arguments").unwrap();
                                     let arguments = args.to_string();
-                                    println!("Arguments: {:?}", arguments);
+                                    println!("Arguments: {arguments:?}");
 
                                     function.arguments = arguments;
                                 }
@@ -1857,13 +1826,13 @@ fn parse_tool_calls(
                                 };
 
                                 let name = object_map.get("name").unwrap().as_str().unwrap();
-                                println!("name: {:?}", name);
+                                println!("name: {name:?}");
                                 function.name = name.to_string();
 
                                 if object_map.contains_key("arguments") {
                                     let args = object_map.get("arguments").unwrap();
                                     let arguments = args.to_string();
-                                    println!("Arguments: {:?}", arguments);
+                                    println!("Arguments: {arguments:?}");
 
                                     function.arguments = arguments;
                                 }
@@ -1886,12 +1855,12 @@ fn parse_tool_calls(
                     };
 
                     #[cfg(feature = "logging")]
-                    info!(target: "stdout", "parsed result: {:?}", parsed);
+                    info!(target: "stdout", "parsed result: {parsed:?}");
 
                     Ok(parsed)
                 }
                 Err(e) => {
-                    let err_msg = format!("Failed to create a regex pattern. Reason: {}", e);
+                    let err_msg = format!("Failed to create a regex pattern. Reason: {e}");
 
                     #[cfg(feature = "logging")]
                     error!(target: "stdout", "{}", &err_msg);
@@ -1902,21 +1871,21 @@ fn parse_tool_calls(
         }
         PromptTemplateType::Llama4Chat => {
             #[cfg(feature = "logging")]
-            info!(target: "stdout", "raw input: {:?}", input);
+            info!(target: "stdout", "raw input: {input:?}");
 
             let mut tool_calls: Vec<ToolCall> = vec![];
             if let Ok(value) = serde_json::from_str::<serde_json::Value>(input) {
                 match value.as_object() {
                     Some(object_map) => {
                         #[cfg(feature = "logging")]
-                        debug!(target: "stdout", "object_map: {:?}", object_map);
+                        debug!(target: "stdout", "object_map: {object_map:?}");
 
                         // parse function name
                         if object_map.contains_key("name") {
                             let name = object_map.get("name").unwrap().as_str().unwrap();
 
                             #[cfg(feature = "logging")]
-                            debug!(target: "stdout", "name: {:?}", name);
+                            debug!(target: "stdout", "name: {name:?}");
 
                             let mut function = Function {
                                 name: name.to_string(),
@@ -1941,8 +1910,7 @@ fn parse_tool_calls(
                             });
                         } else {
                             let err_msg = format!(
-                                "Failed to get the name of the function. raw input: {:?}",
-                                input
+                                "Failed to get the name of the function. raw input: {input:?}"
                             );
 
                             #[cfg(feature = "logging")]
@@ -1952,7 +1920,7 @@ fn parse_tool_calls(
                         }
                     }
                     None => {
-                        let err_msg = format!("Failed to parse the JSON string. JSON: {}", input);
+                        let err_msg = format!("Failed to parse the JSON string. JSON: {input}");
 
                         #[cfg(feature = "logging")]
                         error!(target: "stdout", "{}", &err_msg);
@@ -1969,7 +1937,7 @@ fn parse_tool_calls(
             };
 
             #[cfg(feature = "logging")]
-            info!(target: "stdout", "parsed result: {:?}", parsed);
+            info!(target: "stdout", "parsed result: {parsed:?}");
 
             Ok(parsed)
         }
@@ -2017,7 +1985,7 @@ fn check_model_metadata(
                             let img_path_str = download_image(&image.url)?;
 
                             #[cfg(feature = "logging")]
-                            info!(target: "stdout", "The image is saved to {}", img_path_str);
+                            info!(target: "stdout", "The image is saved to {img_path_str}");
 
                             // update metadata image
                             metadata.image = Some(img_path_str);
@@ -2457,7 +2425,7 @@ fn build_prompt(
             let err_msg = "The messages in the chat request are empty.";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             return Err(LlamaCoreError::Operation(err_msg.to_owned()));
         }
@@ -2472,7 +2440,7 @@ fn build_prompt(
                     role_chain.push_str(&format!("{} -> ", message.role()));
                 }
             }
-            info!(target: "stdout", "Role chain: {}", role_chain);
+            info!(target: "stdout", "Role chain: {role_chain}");
         }
 
         let (prompt, tool_use) = match chat_request.tool_choice.as_ref() {
@@ -2481,7 +2449,7 @@ fn build_prompt(
                     match chat_prompt.build_with_tools(&mut chat_request.messages, Some(&[])) {
                         Ok(prompt) => (prompt, false),
                         Err(e) => {
-                            let err_msg = format!("Fail to build chat prompts. Reason: {}", e);
+                            let err_msg = format!("Fail to build chat prompts. Reason: {e}");
 
                             #[cfg(feature = "logging")]
                             error!(target: "stdout", "{}", &err_msg);
@@ -2496,7 +2464,7 @@ fn build_prompt(
                     {
                         Ok(prompt) => (prompt, true),
                         Err(e) => {
-                            let err_msg = format!("Fail to build chat prompts. Reason: {}", e);
+                            let err_msg = format!("Fail to build chat prompts. Reason: {e}");
 
                             #[cfg(feature = "logging")]
                             error!(target: "stdout", "{}", &err_msg);
@@ -2511,7 +2479,7 @@ fn build_prompt(
                         match chat_prompt.build_with_tools(&mut chat_request.messages, None) {
                             Ok(prompt) => (prompt, false),
                             Err(e) => {
-                                let err_msg = format!("Fail to build chat prompts. Reason: {}", e);
+                                let err_msg = format!("Fail to build chat prompts. Reason: {e}");
 
                                 #[cfg(feature = "logging")]
                                 error!(target: "stdout", "{}", &err_msg);
@@ -2525,7 +2493,7 @@ fn build_prompt(
             None => match chat_prompt.build_with_tools(&mut chat_request.messages, None) {
                 Ok(prompt) => (prompt, false),
                 Err(e) => {
-                    let err_msg = format!("Fail to build chat prompts. Reason: {}", e);
+                    let err_msg = format!("Fail to build chat prompts. Reason: {e}");
 
                     #[cfg(feature = "logging")]
                     error!(target: "stdout", "{}", &err_msg);
@@ -2535,7 +2503,7 @@ fn build_prompt(
             },
         };
         #[cfg(feature = "logging")]
-        info!(target: "stdout", "Try to set prompt: {}", prompt);
+        info!(target: "stdout", "Try to set prompt: {prompt}");
 
         // set prompt
         set_prompt(model_name, &prompt)?;
@@ -2557,7 +2525,7 @@ fn build_prompt(
                                 let user_message = chat_request.messages.remove(1);
 
                                 #[cfg(feature = "logging")]
-                                info!(target: "stdout", "Remove a user message from the chat history: {:?}", user_message);
+                                info!(target: "stdout", "Remove a user message from the chat history: {user_message:?}");
                             }
 
                             // remove all messages until the message is of `user`
@@ -2572,7 +2540,7 @@ fn build_prompt(
                                     let err_msg = format!("The last message in the chat history should be a user message, but found a {} message.", message.role());
 
                                     #[cfg(feature = "logging")]
-                                    error!(target: "stdout", "{}", err_msg);
+                                    error!(target: "stdout", "{err_msg}");
 
                                     return Err(LlamaCoreError::Operation(err_msg));
                                 }
@@ -2601,7 +2569,7 @@ fn build_prompt(
                                 let user_message = chat_request.messages.remove(0);
 
                                 #[cfg(feature = "logging")]
-                                info!(target: "stdout", "Remove a user message from the chat history: {:?}", user_message);
+                                info!(target: "stdout", "Remove a user message from the chat history: {user_message:?}");
                             }
 
                             // remove all messages until the message is of `user`
@@ -2616,7 +2584,7 @@ fn build_prompt(
                                     let err_msg = format!("The last message in the chat history should be a user message, but found a {} message.", message.role());
 
                                     #[cfg(feature = "logging")]
-                                    error!(target: "stdout", "{}", err_msg);
+                                    error!(target: "stdout", "{err_msg}");
 
                                     return Err(LlamaCoreError::Operation(err_msg));
                                 }
@@ -2654,7 +2622,7 @@ fn build_prompt(
 fn download_image(image_url: impl AsRef<str>) -> Result<String, LlamaCoreError> {
     let image_url = image_url.as_ref();
     let url = reqwest::Url::parse(image_url).map_err(|e| {
-        let err_msg = format!("Fail to parse the image URL: {}. Reason: {}", image_url, e);
+        let err_msg = format!("Fail to parse the image URL: {image_url}. Reason: {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -2665,10 +2633,8 @@ fn download_image(image_url: impl AsRef<str>) -> Result<String, LlamaCoreError> 
     let curr_rt_handle = tokio::runtime::Handle::current();
     let res = curr_rt_handle.block_on(async {
         let response = reqwest::get(url).await.map_err(|e| {
-            let err_msg = format!(
-                "Fail to download the image from the URL: {}. Reason: {}",
-                image_url, e
-            );
+            let err_msg =
+                format!("Fail to download the image from the URL: {image_url}. Reason: {e}");
 
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);
@@ -2682,8 +2648,7 @@ fn download_image(image_url: impl AsRef<str>) -> Result<String, LlamaCoreError> 
             .and_then(|mut segments| segments.next_back())
             .and_then(|name| if name.is_empty() { None } else { Some(name) })
             .ok_or(LlamaCoreError::Operation(format!(
-                "Fail to get the file name: {}",
-                image_url
+                "Fail to get the file name: {image_url}"
             )))?
             .to_string();
 
@@ -2746,7 +2711,7 @@ fn set_prompt(model_name: Option<&String>, prompt: impl AsRef<str>) -> Result<()
     };
 
     let mut chat_graphs = chat_graphs.lock().map_err(|e| {
-        let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
+        let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -2757,7 +2722,7 @@ fn set_prompt(model_name: Option<&String>, prompt: impl AsRef<str>) -> Result<()
     match model_name {
         Some(model_name) => {
             #[cfg(feature = "logging")]
-            info!(target: "stdout", "Set prompt to the chat model named {}", model_name);
+            info!(target: "stdout", "Set prompt to the chat model named {model_name}");
 
             match chat_graphs.contains_key(model_name) {
                 true => {
@@ -2794,7 +2759,7 @@ fn set_prompt(model_name: Option<&String>, prompt: impl AsRef<str>) -> Result<()
                     let err_msg = "There is no model available in the chat graphs while trying to set prompt to the default model.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "stdout", "{}", err_msg);
+                    error!(target: "stdout", "{err_msg}");
 
                     Err(LlamaCoreError::Operation(err_msg.into()))
                 }
@@ -2811,14 +2776,14 @@ fn get_model_metadata(model_name: Option<&String>) -> Result<GgmlMetadata, Llama
             let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             return Err(LlamaCoreError::Operation(err_msg.into()));
         }
     };
 
     let chat_graphs = chat_graphs.lock().map_err(|e| {
-        let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
+        let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -2850,7 +2815,7 @@ fn get_model_metadata(model_name: Option<&String>) -> Result<GgmlMetadata, Llama
                 let err_msg = "There is no model available in the chat graphs.";
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 Err(LlamaCoreError::Operation(err_msg.into()))
             }
@@ -2865,7 +2830,7 @@ fn update_model_metadata(
     let config = match serde_json::to_string(metadata) {
         Ok(config) => config,
         Err(e) => {
-            let err_msg = format!("Fail to serialize metadata to a JSON string. {}", e);
+            let err_msg = format!("Fail to serialize metadata to a JSON string. {e}");
 
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);
@@ -2880,14 +2845,14 @@ fn update_model_metadata(
             let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             return Err(LlamaCoreError::Operation(err_msg.into()));
         }
     };
 
     let mut chat_graphs = chat_graphs.lock().map_err(|e| {
-        let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. Reason: {}", e);
+        let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. Reason: {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -2929,7 +2894,7 @@ fn update_model_metadata(
                     let err_msg = "There is no model available in the chat graphs.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "stdout", "{}", err_msg);
+                    error!(target: "stdout", "{err_msg}");
 
                     Err(LlamaCoreError::Operation(err_msg.into()))
                 }
@@ -3052,8 +3017,7 @@ impl Drop for ChatStream {
                                         // clean up the context
                                         if let Err(e) = graph.finish_single() {
                                             let err_msg = format!(
-                                                "Failed to clean up the context. Reason: {}",
-                                                e
+                                                "Failed to clean up the context. Reason: {e}"
                                             );
 
                                             #[cfg(feature = "logging")]
@@ -3071,8 +3035,7 @@ impl Drop for ChatStream {
                                             // clean up the context
                                             if let Err(e) = graph.finish_single() {
                                                 let err_msg = format!(
-                                                    "Failed to clean up the context. Reason: {}",
-                                                    e
+                                                    "Failed to clean up the context. Reason: {e}"
                                                 );
 
                                                 #[cfg(feature = "logging")]
@@ -3102,7 +3065,7 @@ impl Drop for ChatStream {
                                 },
                                 Err(e) => {
                                     let err_msg =
-                                        format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
+                                        format!("Fail to acquire the lock of `CHAT_GRAPHS`. {e}");
 
                                     #[cfg(feature = "logging")]
                                     error!(target: "stdout", "{}", &err_msg);
@@ -3138,8 +3101,7 @@ impl Drop for ChatStream {
                                         // clean up the context
                                         if let Err(e) = graph.finish_single() {
                                             let err_msg = format!(
-                                                "Failed to clean up the context. Reason: {}",
-                                                e
+                                                "Failed to clean up the context. Reason: {e}"
                                             );
 
                                             #[cfg(feature = "logging")]
@@ -3157,7 +3119,7 @@ impl Drop for ChatStream {
                                             "There is no model available in the chat graphs.";
 
                                         #[cfg(feature = "logging")]
-                                        error!(target: "stdout", "{}", err_msg);
+                                        error!(target: "stdout", "{err_msg}");
 
                                         #[cfg(not(feature = "logging"))]
                                         println!(
@@ -3168,7 +3130,7 @@ impl Drop for ChatStream {
                                 },
                                 Err(e) => {
                                     let err_msg =
-                                        format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
+                                        format!("Fail to acquire the lock of `CHAT_GRAPHS`. {e}");
 
                                     #[cfg(feature = "logging")]
                                     error!(target: "stdout", "{}", &err_msg);
@@ -3203,7 +3165,7 @@ impl Drop for ChatStream {
 
         // reset the model metadata
         if let Err(e) = reset_model_metadata(self.model.as_ref()) {
-            let err_msg = format!("Fail to reset model metadata. Reason: {}", e);
+            let err_msg = format!("Fail to reset model metadata. Reason: {e}");
 
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);
@@ -3365,7 +3327,7 @@ fn compute_stream(
 
     // We're already holding the ChatStream lock, so we know we have exclusive access to the graph
     let mut chat_graphs = chat_graphs.lock().map_err(|e| {
-        let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
+        let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -3403,8 +3365,7 @@ fn compute_stream(
                                                 .get_or_init(|| Mutex::new(Vec::new()));
                                             let mut cached_encodings = mutex.lock().map_err(|e| {
                                             let err_msg = format!(
-                                                "Fail to acquire the lock of `UTF8_ENCODINGS`. Reason: {}",
-                                                e
+                                                "Fail to acquire the lock of `UTF8_ENCODINGS`. Reason: {e}"
                                             );
 
                                             #[cfg(feature = "logging")]
@@ -3427,7 +3388,7 @@ fn compute_stream(
                                                 Err(e) => {
                                                     // TODO This is a temp check. In case, infinite cached encodings happen.
                                                     if cached_encodings.len() > 4 {
-                                                        let err_msg = format!("Fail to convert a vector of bytes to string. The length of the utf8 bytes exceeds 4. {}", e);
+                                                        let err_msg = format!("Fail to convert a vector of bytes to string. The length of the utf8 bytes exceeds 4. {e}");
 
                                                         #[cfg(feature = "logging")]
                                                         error!(target: "stdout", "{}", &err_msg);
@@ -3445,7 +3406,7 @@ fn compute_stream(
 
                                                         String::from("")
                                                     } else {
-                                                        let warn_msg = format!("Fail to convert a vector of bytes to string. {}", e);
+                                                        let warn_msg = format!("Fail to convert a vector of bytes to string. {e}");
 
                                                         #[cfg(feature = "logging")]
                                                         warn!(target: "stdout", "{}", &warn_msg);
@@ -3464,8 +3425,7 @@ fn compute_stream(
                                         .duration_since(std::time::UNIX_EPOCH)
                                         .map_err(|e| {
                                             let err_msg = format!(
-                                                "Failed to get the current time. Reason: {}",
-                                                e
+                                                "Failed to get the current time. Reason: {e}"
                                             );
 
                                             #[cfg(feature = "logging")]
@@ -3500,8 +3460,7 @@ fn compute_stream(
                                     let chunk_str = serde_json::to_string(&chat_completion_chunk)
                                         .map_err(|e| {
                                         let err_msg = format!(
-                                            "Failed to serialize chat completion chunk. Reason: {}",
-                                            e
+                                            "Failed to serialize chat completion chunk. Reason: {e}"
                                         );
 
                                         #[cfg(feature = "logging")]
@@ -3510,7 +3469,7 @@ fn compute_stream(
                                         LlamaCoreError::Operation(err_msg)
                                     })?;
 
-                                    Ok(format!("data: {}\n\n", chunk_str))
+                                    Ok(format!("data: {chunk_str}\n\n"))
                                 }
                                 StreamState::Done => {
                                     *stream_state = StreamState::EndOfSequence;
@@ -3549,8 +3508,7 @@ fn compute_stream(
                                         .duration_since(std::time::UNIX_EPOCH)
                                         .map_err(|e| {
                                             let err_msg = format!(
-                                                "Failed to get the current time. Reason: {}",
-                                                e
+                                                "Failed to get the current time. Reason: {e}"
                                             );
 
                                             #[cfg(feature = "logging")]
@@ -3573,8 +3531,7 @@ fn compute_stream(
                                     let chunk_str = serde_json::to_string(&chat_completion_chunk)
                                         .map_err(|e| {
                                         let err_msg = format!(
-                                            "Failed to serialize chat completion chunk. Reason: {}",
-                                            e
+                                            "Failed to serialize chat completion chunk. Reason: {e}"
                                         );
 
                                         #[cfg(feature = "logging")]
@@ -3583,7 +3540,7 @@ fn compute_stream(
                                         LlamaCoreError::Operation(err_msg)
                                     })?;
 
-                                    Ok(format!("data: {}\n\n", chunk_str))
+                                    Ok(format!("data: {chunk_str}\n\n"))
                                 }
                                 StreamState::Done | StreamState::NoUsage => {
                                     *stream_state = StreamState::EndOfSequence;
@@ -3612,8 +3569,7 @@ fn compute_stream(
                                         .duration_since(std::time::UNIX_EPOCH)
                                         .map_err(|e| {
                                             let err_msg = format!(
-                                                "Failed to get the current time. Reason: {}",
-                                                e
+                                                "Failed to get the current time. Reason: {e}"
                                             );
 
                                             #[cfg(feature = "logging")]
@@ -3647,8 +3603,7 @@ fn compute_stream(
                                     let chunk_str = serde_json::to_string(&chat_completion_chunk)
                                         .map_err(|e| {
                                         let err_msg = format!(
-                                            "Failed to serialize chat completion chunk. Reason: {}",
-                                            e
+                                            "Failed to serialize chat completion chunk. Reason: {e}"
                                         );
 
                                         #[cfg(feature = "logging")]
@@ -3657,7 +3612,7 @@ fn compute_stream(
                                         LlamaCoreError::Operation(err_msg)
                                     })?;
 
-                                    Ok(format!("data: {}\n\n", chunk_str))
+                                    Ok(format!("data: {chunk_str}\n\n"))
                                 }
                                 ContextFullState::Usage => {
                                     *context_full_state = ContextFullState::Done;
@@ -3676,8 +3631,7 @@ fn compute_stream(
                                         .duration_since(std::time::UNIX_EPOCH)
                                         .map_err(|e| {
                                             let err_msg = format!(
-                                                "Failed to get the current time. Reason: {}",
-                                                e
+                                                "Failed to get the current time. Reason: {e}"
                                             );
 
                                             #[cfg(feature = "logging")]
@@ -3700,8 +3654,7 @@ fn compute_stream(
                                     let chunk_str = serde_json::to_string(&chat_completion_chunk)
                                         .map_err(|e| {
                                         let err_msg = format!(
-                                            "Failed to serialize chat completion chunk. Reason: {}",
-                                            e
+                                            "Failed to serialize chat completion chunk. Reason: {e}"
                                         );
 
                                         #[cfg(feature = "logging")]
@@ -3710,7 +3663,7 @@ fn compute_stream(
                                         LlamaCoreError::Operation(err_msg)
                                     })?;
 
-                                    Ok(format!("data: {}\n\n", chunk_str))
+                                    Ok(format!("data: {chunk_str}\n\n"))
                                 }
                                 ContextFullState::Done => {
                                     *context_full_state = ContextFullState::EndOfSequence;
@@ -3739,8 +3692,7 @@ fn compute_stream(
                                         .duration_since(std::time::UNIX_EPOCH)
                                         .map_err(|e| {
                                             let err_msg = format!(
-                                                "Failed to get the current time. Reason: {}",
-                                                e
+                                                "Failed to get the current time. Reason: {e}"
                                             );
 
                                             #[cfg(feature = "logging")]
@@ -3772,8 +3724,7 @@ fn compute_stream(
                                     let chunk_str = serde_json::to_string(&chat_completion_chunk)
                                         .map_err(|e| {
                                         let err_msg = format!(
-                                            "Failed to serialize chat completion chunk. Reason: {}",
-                                            e
+                                            "Failed to serialize chat completion chunk. Reason: {e}"
                                         );
 
                                         #[cfg(feature = "logging")]
@@ -3782,7 +3733,7 @@ fn compute_stream(
                                         LlamaCoreError::Operation(err_msg)
                                     })?;
 
-                                    Ok(format!("data: {}\n\n", chunk_str))
+                                    Ok(format!("data: {chunk_str}\n\n"))
                                 }
                                 PromptTooLongState::Usage => {
                                     *prompt_too_long_state = PromptTooLongState::Done;
@@ -3801,8 +3752,7 @@ fn compute_stream(
                                         .duration_since(std::time::UNIX_EPOCH)
                                         .map_err(|e| {
                                             let err_msg = format!(
-                                                "Failed to get the current time. Reason: {}",
-                                                e
+                                                "Failed to get the current time. Reason: {e}"
                                             );
 
                                             #[cfg(feature = "logging")]
@@ -3825,8 +3775,7 @@ fn compute_stream(
                                     let chunk_str = serde_json::to_string(&chat_completion_chunk)
                                         .map_err(|e| {
                                         let err_msg = format!(
-                                            "Failed to serialize chat completion chunk. Reason: {}",
-                                            e
+                                            "Failed to serialize chat completion chunk. Reason: {e}"
                                         );
 
                                         #[cfg(feature = "logging")]
@@ -3835,7 +3784,7 @@ fn compute_stream(
                                         LlamaCoreError::Operation(err_msg)
                                     })?;
 
-                                    Ok(format!("data: {}\n\n", chunk_str))
+                                    Ok(format!("data: {chunk_str}\n\n"))
                                 }
                                 PromptTooLongState::Done => {
                                     *prompt_too_long_state = PromptTooLongState::EndOfSequence;
@@ -3849,7 +3798,7 @@ fn compute_stream(
                         }
                         Err(e) => {
                             let err_msg =
-                                format!("Failed to compute the chat completion. Reason: {}", e);
+                                format!("Failed to compute the chat completion. Reason: {e}");
 
                             #[cfg(feature = "logging")]
                             error!(target: "stdout", "{}", &err_msg);
@@ -3888,8 +3837,7 @@ fn compute_stream(
                                                         .get_or_init(|| Mutex::new(Vec::new()));
                                                     let mut cached_encodings = mutex.lock().map_err(|e| {
                                             let err_msg = format!(
-                                                "Fail to acquire the lock of `UTF8_ENCODINGS`. Reason: {}",
-                                                e
+                                                "Fail to acquire the lock of `UTF8_ENCODINGS`. Reason: {e}"
                                             );
 
                                             #[cfg(feature = "logging")]
@@ -3915,7 +3863,7 @@ fn compute_stream(
                                                         Err(e) => {
                                                             // TODO This is a temp check. In case, infinite cached encodings happen.
                                                             if cached_encodings.len() > 4 {
-                                                                let err_msg = format!("Fail to convert a vector of bytes to string. The length of the utf8 bytes exceeds 4. {}", e);
+                                                                let err_msg = format!("Fail to convert a vector of bytes to string. The length of the utf8 bytes exceeds 4. {e}");
 
                                                                 #[cfg(feature = "logging")]
                                                                 error!(target: "stdout", "{}", &err_msg);
@@ -3934,7 +3882,7 @@ fn compute_stream(
 
                                                                 String::from("")
                                                             } else {
-                                                                let warn_msg = format!("Fail to convert a vector of bytes to string. {}", e);
+                                                                let warn_msg = format!("Fail to convert a vector of bytes to string. {e}");
 
                                                                 #[cfg(feature = "logging")]
                                                                 warn!(target: "stdout", "{}", &warn_msg);
@@ -3953,8 +3901,7 @@ fn compute_stream(
                                                 .duration_since(std::time::UNIX_EPOCH)
                                                 .map_err(|e| {
                                                     let err_msg = format!(
-                                                "Failed to get the current time. Reason: {}",
-                                                e
+                                                "Failed to get the current time. Reason: {e}"
                                             );
 
                                                     #[cfg(feature = "logging")]
@@ -3990,8 +3937,7 @@ fn compute_stream(
                                                 serde_json::to_string(&chat_completion_chunk)
                                                     .map_err(|e| {
                                                         let err_msg = format!(
-                                            "Failed to serialize chat completion chunk. Reason: {}",
-                                            e
+                                            "Failed to serialize chat completion chunk. Reason: {e}"
                                         );
 
                                                         #[cfg(feature = "logging")]
@@ -4000,7 +3946,7 @@ fn compute_stream(
                                                         LlamaCoreError::Operation(err_msg)
                                                     })?;
 
-                                            Ok(format!("data: {}\n\n", chunk_str))
+                                            Ok(format!("data: {chunk_str}\n\n"))
                                         }
                                         StreamState::Done => {
                                             *stream_state = StreamState::EndOfSequence;
@@ -4039,8 +3985,7 @@ fn compute_stream(
                                                 .duration_since(std::time::UNIX_EPOCH)
                                                 .map_err(|e| {
                                                     let err_msg = format!(
-                                                "Failed to get the current time. Reason: {}",
-                                                e
+                                                "Failed to get the current time. Reason: {e}"
                                             );
 
                                                     #[cfg(feature = "logging")]
@@ -4064,8 +4009,7 @@ fn compute_stream(
                                                 serde_json::to_string(&chat_completion_chunk)
                                                     .map_err(|e| {
                                                         let err_msg = format!(
-                                            "Failed to serialize chat completion chunk. Reason: {}",
-                                            e
+                                            "Failed to serialize chat completion chunk. Reason: {e}"
                                         );
 
                                                         #[cfg(feature = "logging")]
@@ -4074,7 +4018,7 @@ fn compute_stream(
                                                         LlamaCoreError::Operation(err_msg)
                                                     })?;
 
-                                            Ok(format!("data: {}\n\n", chunk_str))
+                                            Ok(format!("data: {chunk_str}\n\n"))
                                         }
                                         StreamState::Done | StreamState::NoUsage => {
                                             *stream_state = StreamState::EndOfSequence;
@@ -4107,8 +4051,7 @@ fn compute_stream(
                                                 .duration_since(std::time::UNIX_EPOCH)
                                                 .map_err(|e| {
                                                     let err_msg = format!(
-                                                "Failed to get the current time. Reason: {}",
-                                                e
+                                                "Failed to get the current time. Reason: {e}"
                                             );
 
                                                     #[cfg(feature = "logging")]
@@ -4144,8 +4087,7 @@ fn compute_stream(
                                                 serde_json::to_string(&chat_completion_chunk)
                                                     .map_err(|e| {
                                                         let err_msg = format!(
-                                            "Failed to serialize chat completion chunk. Reason: {}",
-                                            e
+                                            "Failed to serialize chat completion chunk. Reason: {e}"
                                         );
 
                                                         #[cfg(feature = "logging")]
@@ -4154,7 +4096,7 @@ fn compute_stream(
                                                         LlamaCoreError::Operation(err_msg)
                                                     })?;
 
-                                            Ok(format!("data: {}\n\n", chunk_str))
+                                            Ok(format!("data: {chunk_str}\n\n"))
                                         }
                                         ContextFullState::Usage => {
                                             *context_full_state = ContextFullState::Done;
@@ -4173,8 +4115,7 @@ fn compute_stream(
                                                 .duration_since(std::time::UNIX_EPOCH)
                                                 .map_err(|e| {
                                                     let err_msg = format!(
-                                                "Failed to get the current time. Reason: {}",
-                                                e
+                                                "Failed to get the current time. Reason: {e}"
                                             );
 
                                                     #[cfg(feature = "logging")]
@@ -4198,8 +4139,7 @@ fn compute_stream(
                                                 serde_json::to_string(&chat_completion_chunk)
                                                     .map_err(|e| {
                                                         let err_msg = format!(
-                                            "Failed to serialize chat completion chunk. Reason: {}",
-                                            e
+                                            "Failed to serialize chat completion chunk. Reason: {e}"
                                         );
 
                                                         #[cfg(feature = "logging")]
@@ -4208,7 +4148,7 @@ fn compute_stream(
                                                         LlamaCoreError::Operation(err_msg)
                                                     })?;
 
-                                            Ok(format!("data: {}\n\n", chunk_str))
+                                            Ok(format!("data: {chunk_str}\n\n"))
                                         }
                                         ContextFullState::Done => {
                                             *context_full_state = ContextFullState::EndOfSequence;
@@ -4243,8 +4183,7 @@ fn compute_stream(
                                                 .duration_since(std::time::UNIX_EPOCH)
                                                 .map_err(|e| {
                                                     let err_msg = format!(
-                                                "Failed to get the current time. Reason: {}",
-                                                e
+                                                "Failed to get the current time. Reason: {e}"
                                             );
 
                                                     #[cfg(feature = "logging")]
@@ -4277,8 +4216,7 @@ fn compute_stream(
                                                 serde_json::to_string(&chat_completion_chunk)
                                                     .map_err(|e| {
                                                         let err_msg = format!(
-                                            "Failed to serialize chat completion chunk. Reason: {}",
-                                            e
+                                            "Failed to serialize chat completion chunk. Reason: {e}"
                                         );
 
                                                         #[cfg(feature = "logging")]
@@ -4287,7 +4225,7 @@ fn compute_stream(
                                                         LlamaCoreError::Operation(err_msg)
                                                     })?;
 
-                                            Ok(format!("data: {}\n\n", chunk_str))
+                                            Ok(format!("data: {chunk_str}\n\n"))
                                         }
                                         PromptTooLongState::Usage => {
                                             *prompt_too_long_state = PromptTooLongState::Done;
@@ -4306,8 +4244,7 @@ fn compute_stream(
                                                 .duration_since(std::time::UNIX_EPOCH)
                                                 .map_err(|e| {
                                                     let err_msg = format!(
-                                                "Failed to get the current time. Reason: {}",
-                                                e
+                                                "Failed to get the current time. Reason: {e}"
                                             );
 
                                                     #[cfg(feature = "logging")]
@@ -4331,8 +4268,7 @@ fn compute_stream(
                                                 serde_json::to_string(&chat_completion_chunk)
                                                     .map_err(|e| {
                                                         let err_msg = format!(
-                                            "Failed to serialize chat completion chunk. Reason: {}",
-                                            e
+                                            "Failed to serialize chat completion chunk. Reason: {e}"
                                         );
 
                                                         #[cfg(feature = "logging")]
@@ -4341,7 +4277,7 @@ fn compute_stream(
                                                         LlamaCoreError::Operation(err_msg)
                                                     })?;
 
-                                            Ok(format!("data: {}\n\n", chunk_str))
+                                            Ok(format!("data: {chunk_str}\n\n"))
                                         }
                                         PromptTooLongState::Done => {
                                             *prompt_too_long_state =
@@ -4356,8 +4292,7 @@ fn compute_stream(
                                 }
                                 Err(e) => {
                                     let err_msg = format!(
-                                        "Failed to compute the chat completion. Reason: {}",
-                                        e
+                                        "Failed to compute the chat completion. Reason: {e}"
                                     );
 
                                     #[cfg(feature = "logging")]
@@ -4407,8 +4342,7 @@ fn compute_stream(
                                                 .get_or_init(|| Mutex::new(Vec::new()));
                                             let mut cached_encodings = mutex.lock().map_err(|e| {
                                             let err_msg = format!(
-                                                "Fail to acquire the lock of `UTF8_ENCODINGS`. Reason: {}",
-                                                e
+                                                "Fail to acquire the lock of `UTF8_ENCODINGS`. Reason: {e}"
                                             );
 
                                             #[cfg(feature = "logging")]
@@ -4429,7 +4363,7 @@ fn compute_stream(
                                                 Err(e) => {
                                                     // TODO This is a temp check. In case, infinite cached encodings happen.
                                                     if cached_encodings.len() > 4 {
-                                                        let err_msg = format!("Fail to convert a vector of bytes to string. The length of the utf8 bytes exceeds 4. {}", e);
+                                                        let err_msg = format!("Fail to convert a vector of bytes to string. The length of the utf8 bytes exceeds 4. {e}");
 
                                                         #[cfg(feature = "logging")]
                                                         error!(target: "stdout", "{}", &err_msg);
@@ -4447,7 +4381,7 @@ fn compute_stream(
 
                                                         String::from("")
                                                     } else {
-                                                        let warn_msg = format!("Fail to convert a vector of bytes to string. {}", e);
+                                                        let warn_msg = format!("Fail to convert a vector of bytes to string. {e}");
 
                                                         #[cfg(feature = "logging")]
                                                         warn!(target: "stdout", "{}", &warn_msg);
@@ -4466,8 +4400,7 @@ fn compute_stream(
                                         .duration_since(std::time::UNIX_EPOCH)
                                         .map_err(|e| {
                                             let err_msg = format!(
-                                                "Failed to get the current time. Reason: {}",
-                                                e
+                                                "Failed to get the current time. Reason: {e}"
                                             );
 
                                             #[cfg(feature = "logging")]
@@ -4502,8 +4435,7 @@ fn compute_stream(
                                     let chunk_str = serde_json::to_string(&chat_completion_chunk)
                                         .map_err(|e| {
                                         let err_msg = format!(
-                                            "Failed to serialize chat completion chunk. Reason: {}",
-                                            e
+                                            "Failed to serialize chat completion chunk. Reason: {e}"
                                         );
 
                                         #[cfg(feature = "logging")]
@@ -4512,7 +4444,7 @@ fn compute_stream(
                                         LlamaCoreError::Operation(err_msg)
                                     })?;
 
-                                    Ok(format!("data: {}\n\n", chunk_str))
+                                    Ok(format!("data: {chunk_str}\n\n"))
                                 }
                                 StreamState::Done => {
                                     *stream_state = StreamState::EndOfSequence;
@@ -4551,8 +4483,7 @@ fn compute_stream(
                                         .duration_since(std::time::UNIX_EPOCH)
                                         .map_err(|e| {
                                             let err_msg = format!(
-                                                "Failed to get the current time. Reason: {}",
-                                                e
+                                                "Failed to get the current time. Reason: {e}"
                                             );
 
                                             #[cfg(feature = "logging")]
@@ -4575,8 +4506,7 @@ fn compute_stream(
                                     let chunk_str = serde_json::to_string(&chat_completion_chunk)
                                         .map_err(|e| {
                                         let err_msg = format!(
-                                            "Failed to serialize chat completion chunk. Reason: {}",
-                                            e
+                                            "Failed to serialize chat completion chunk. Reason: {e}"
                                         );
 
                                         #[cfg(feature = "logging")]
@@ -4585,7 +4515,7 @@ fn compute_stream(
                                         LlamaCoreError::Operation(err_msg)
                                     })?;
 
-                                    Ok(format!("data: {}\n\n", chunk_str))
+                                    Ok(format!("data: {chunk_str}\n\n"))
                                 }
                                 StreamState::Done | StreamState::NoUsage => {
                                     *stream_state = StreamState::EndOfSequence;
@@ -4614,8 +4544,7 @@ fn compute_stream(
                                         .duration_since(std::time::UNIX_EPOCH)
                                         .map_err(|e| {
                                             let err_msg = format!(
-                                                "Failed to get the current time. Reason: {}",
-                                                e
+                                                "Failed to get the current time. Reason: {e}"
                                             );
 
                                             #[cfg(feature = "logging")]
@@ -4649,8 +4578,7 @@ fn compute_stream(
                                     let chunk_str = serde_json::to_string(&chat_completion_chunk)
                                         .map_err(|e| {
                                         let err_msg = format!(
-                                            "Failed to serialize chat completion chunk. Reason: {}",
-                                            e
+                                            "Failed to serialize chat completion chunk. Reason: {e}"
                                         );
 
                                         #[cfg(feature = "logging")]
@@ -4659,7 +4587,7 @@ fn compute_stream(
                                         LlamaCoreError::Operation(err_msg)
                                     })?;
 
-                                    Ok(format!("data: {}\n\n", chunk_str))
+                                    Ok(format!("data: {chunk_str}\n\n"))
                                 }
                                 ContextFullState::Usage => {
                                     *context_full_state = ContextFullState::Done;
@@ -4678,8 +4606,7 @@ fn compute_stream(
                                         .duration_since(std::time::UNIX_EPOCH)
                                         .map_err(|e| {
                                             let err_msg = format!(
-                                                "Failed to get the current time. Reason: {}",
-                                                e
+                                                "Failed to get the current time. Reason: {e}"
                                             );
 
                                             #[cfg(feature = "logging")]
@@ -4702,8 +4629,7 @@ fn compute_stream(
                                     let chunk_str = serde_json::to_string(&chat_completion_chunk)
                                         .map_err(|e| {
                                         let err_msg = format!(
-                                            "Failed to serialize chat completion chunk. Reason: {}",
-                                            e
+                                            "Failed to serialize chat completion chunk. Reason: {e}"
                                         );
 
                                         #[cfg(feature = "logging")]
@@ -4712,7 +4638,7 @@ fn compute_stream(
                                         LlamaCoreError::Operation(err_msg)
                                     })?;
 
-                                    Ok(format!("data: {}\n\n", chunk_str))
+                                    Ok(format!("data: {chunk_str}\n\n"))
                                 }
                                 ContextFullState::Done => {
                                     *context_full_state = ContextFullState::EndOfSequence;
@@ -4741,8 +4667,7 @@ fn compute_stream(
                                         .duration_since(std::time::UNIX_EPOCH)
                                         .map_err(|e| {
                                             let err_msg = format!(
-                                                "Failed to get the current time. Reason: {}",
-                                                e
+                                                "Failed to get the current time. Reason: {e}"
                                             );
 
                                             #[cfg(feature = "logging")]
@@ -4774,8 +4699,7 @@ fn compute_stream(
                                     let chunk_str = serde_json::to_string(&chat_completion_chunk)
                                         .map_err(|e| {
                                         let err_msg = format!(
-                                            "Failed to serialize chat completion chunk. Reason: {}",
-                                            e
+                                            "Failed to serialize chat completion chunk. Reason: {e}"
                                         );
 
                                         #[cfg(feature = "logging")]
@@ -4784,7 +4708,7 @@ fn compute_stream(
                                         LlamaCoreError::Operation(err_msg)
                                     })?;
 
-                                    Ok(format!("data: {}\n\n", chunk_str))
+                                    Ok(format!("data: {chunk_str}\n\n"))
                                 }
                                 PromptTooLongState::Usage => {
                                     *prompt_too_long_state = PromptTooLongState::Done;
@@ -4803,8 +4727,7 @@ fn compute_stream(
                                         .duration_since(std::time::UNIX_EPOCH)
                                         .map_err(|e| {
                                             let err_msg = format!(
-                                                "Failed to get the current time. Reason: {}",
-                                                e
+                                                "Failed to get the current time. Reason: {e}"
                                             );
 
                                             #[cfg(feature = "logging")]
@@ -4827,8 +4750,7 @@ fn compute_stream(
                                     let chunk_str = serde_json::to_string(&chat_completion_chunk)
                                         .map_err(|e| {
                                         let err_msg = format!(
-                                            "Failed to serialize chat completion chunk. Reason: {}",
-                                            e
+                                            "Failed to serialize chat completion chunk. Reason: {e}"
                                         );
 
                                         #[cfg(feature = "logging")]
@@ -4837,7 +4759,7 @@ fn compute_stream(
                                         LlamaCoreError::Operation(err_msg)
                                     })?;
 
-                                    Ok(format!("data: {}\n\n", chunk_str))
+                                    Ok(format!("data: {chunk_str}\n\n"))
                                 }
                                 PromptTooLongState::Done => {
                                     *prompt_too_long_state = PromptTooLongState::EndOfSequence;
@@ -4851,7 +4773,7 @@ fn compute_stream(
                         }
                         Err(e) => {
                             let err_msg =
-                                format!("Failed to compute the chat completion. Reason: {}", e);
+                                format!("Failed to compute the chat completion. Reason: {e}");
 
                             #[cfg(feature = "logging")]
                             error!(target: "stdout", "{}", &err_msg);

--- a/crates/llama-core/src/completions.rs
+++ b/crates/llama-core/src/completions.rs
@@ -23,7 +23,7 @@ pub async fn completions(request: &CompletionRequest) -> Result<CompletionObject
         let err_msg = "The completion is only supported in the chat mode.";
 
         #[cfg(feature = "logging")]
-        error!(target: "stdout", "{}", err_msg);
+        error!(target: "stdout", "{err_msg}");
 
         return Err(LlamaCoreError::Operation(err_msg.to_string()));
     }
@@ -49,14 +49,14 @@ fn compute(
             let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             return Err(LlamaCoreError::Operation(err_msg.into()));
         }
     };
 
     let mut chat_graphs = chat_graphs.lock().map_err(|e| {
-        let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
+        let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -119,7 +119,7 @@ fn compute_by_graph(
     graph
         .set_input(0, wasmedge_wasi_nn::TensorType::U8, &[1], &tensor_data)
         .map_err(|e| {
-            let err_msg = format!("Failed to set the input tensor. {}", e);
+            let err_msg = format!("Failed to set the input tensor. {e}");
 
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);
@@ -129,7 +129,7 @@ fn compute_by_graph(
 
     // execute the inference
     graph.compute().map_err(|e| {
-        let err_msg = format!("Failed to execute the inference. {}", e);
+        let err_msg = format!("Failed to execute the inference. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -142,10 +142,8 @@ fn compute_by_graph(
 
     // convert inference result to string
     let model_answer = String::from_utf8(buffer).map_err(|e| {
-        let err_msg = format!(
-            "Failed to decode the buffer of the inference result to a utf-8 string. {}",
-            e
-        );
+        let err_msg =
+            format!("Failed to decode the buffer of the inference result to a utf-8 string. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -163,7 +161,7 @@ fn compute_by_graph(
     let created = SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map_err(|e| {
-            let err_msg = format!("Failed to get the current time. {}", e);
+            let err_msg = format!("Failed to get the current time. {e}");
 
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);

--- a/crates/llama-core/src/embeddings.rs
+++ b/crates/llama-core/src/embeddings.rs
@@ -35,7 +35,7 @@ pub async fn embeddings(
         let err_msg = "Computing embeddings is only supported in the embeddings and rag modes.";
 
         #[cfg(feature = "logging")]
-        error!(target: "stdout", "{}", err_msg);
+        error!(target: "stdout", "{err_msg}");
 
         return Err(LlamaCoreError::Operation(err_msg.into()));
     }
@@ -53,7 +53,7 @@ pub async fn embeddings(
                     let err_msg = "No embedding model is available.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "stdout", "{}", err_msg);
+                    error!(target: "stdout", "{err_msg}");
 
                     return Err(LlamaCoreError::Operation(err_msg.into()));
                 }
@@ -61,7 +61,7 @@ pub async fn embeddings(
         };
 
         let mut embedding_graphs = embedding_graphs.lock().map_err(|e| {
-            let err_msg = format!("Fail to acquire the lock of `EMBEDDING_GRAPHS`. {}", e);
+            let err_msg = format!("Fail to acquire the lock of `EMBEDDING_GRAPHS`. {e}");
 
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);
@@ -167,8 +167,7 @@ fn compute_embeddings(
                 // convert inference result to string
                 let output = std::str::from_utf8(&output_buffer[..]).map_err(|e| {
                     let err_msg = format!(
-                        "Failed to decode the buffer of the inference result to a utf-8 string. Reason: {}",
-                        e
+                        "Failed to decode the buffer of the inference result to a utf-8 string. Reason: {e}"
                     );
 
                     #[cfg(feature = "logging")]
@@ -179,8 +178,7 @@ fn compute_embeddings(
 
                 // deserialize the embedding data
                 let embedding = serde_json::from_str::<Embedding>(output).map_err(|e| {
-                    let err_msg =
-                        format!("Failed to deserialize the embedding data. Reason: {}", e);
+                    let err_msg = format!("Failed to deserialize the embedding data. Reason: {e}");
 
                     #[cfg(feature = "logging")]
                     error!(target: "stdout", "{}", &err_msg);
@@ -204,7 +202,7 @@ fn compute_embeddings(
                 usage.total_tokens = usage.prompt_tokens + usage.completion_tokens;
             }
             Err(e) => {
-                let err_msg = format!("Failed to compute embeddings. Reason: {}", e);
+                let err_msg = format!("Failed to compute embeddings. Reason: {e}");
 
                 #[cfg(feature = "logging")]
                 error!(target: "stdout", "{}", &err_msg);
@@ -241,14 +239,14 @@ pub fn dimension(name: Option<&str>) -> Result<u64, LlamaCoreError> {
             let err_msg = "Fail to get the underlying value of `EMBEDDING_GRAPHS`.";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             return Err(LlamaCoreError::Operation(err_msg.into()));
         }
     };
 
     let embedding_graphs = embedding_graphs.lock().map_err(|e| {
-        let err_msg = format!("Fail to acquire the lock of `EMBEDDING_GRAPHS`. {}", e);
+        let err_msg = format!("Fail to acquire the lock of `EMBEDDING_GRAPHS`. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -260,10 +258,8 @@ pub fn dimension(name: Option<&str>) -> Result<u64, LlamaCoreError> {
         Some(model_name) => match embedding_graphs.get(model_name) {
             Some(graph) => Ok(graph.metadata.ctx_size),
             None => {
-                let err_msg = format!(
-                    "The model `{}` does not exist in the embedding graphs.",
-                    model_name
-                );
+                let err_msg =
+                    format!("The model `{model_name}` does not exist in the embedding graphs.");
 
                 #[cfg(feature = "logging")]
                 error!(target: "stdout", "{}", &err_msg);
@@ -279,7 +275,7 @@ pub fn dimension(name: Option<&str>) -> Result<u64, LlamaCoreError> {
                         let err_msg = "Fail to get the underlying value of `EMBEDDING_GRAPHS`.";
 
                         #[cfg(feature = "logging")]
-                        error!(target: "stdout", "{}", err_msg);
+                        error!(target: "stdout", "{err_msg}");
 
                         return Err(LlamaCoreError::Operation(err_msg.into()));
                     }
@@ -332,7 +328,7 @@ pub fn chunk_text(
         let err_msg = "Failed to upload the target file. Only files with 'txt' and 'md' extensions are supported.";
 
         #[cfg(feature = "logging")]
-        error!(target: "stdout", "{}", err_msg);
+        error!(target: "stdout", "{err_msg}");
 
         return Err(LlamaCoreError::Operation(err_msg.into()));
     }
@@ -395,7 +391,7 @@ pub fn chunk_text(
                 "Failed to upload the target file. Only text and markdown files are supported.";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             Err(LlamaCoreError::Operation(err_msg.into()))
         }
@@ -410,14 +406,14 @@ fn get_model_metadata(model_name: Option<&String>) -> Result<GgmlMetadata, Llama
             let err_msg = "Fail to get the underlying value of `EMBEDDING_GRAPHS`.";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             return Err(LlamaCoreError::Operation(err_msg.into()));
         }
     };
 
     let embedding_graphs = embedding_graphs.lock().map_err(|e| {
-        let err_msg = format!("Fail to acquire the lock of `EMBEDDING_GRAPHS`. {}", e);
+        let err_msg = format!("Fail to acquire the lock of `EMBEDDING_GRAPHS`. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -449,7 +445,7 @@ fn get_model_metadata(model_name: Option<&String>) -> Result<GgmlMetadata, Llama
                 let err_msg = "There is no model available in the embedding graphs.";
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 Err(LlamaCoreError::Operation(err_msg.into()))
             }
@@ -464,7 +460,7 @@ fn update_model_metadata(
     let config = match serde_json::to_string(metadata) {
         Ok(config) => config,
         Err(e) => {
-            let err_msg = format!("Fail to serialize metadata to a JSON string. {}", e);
+            let err_msg = format!("Fail to serialize metadata to a JSON string. {e}");
 
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);
@@ -479,17 +475,14 @@ fn update_model_metadata(
             let err_msg = "Fail to get the underlying value of `EMBEDDING_GRAPHS`.";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             return Err(LlamaCoreError::Operation(err_msg.into()));
         }
     };
 
     let mut embedding_graphs = embedding_graphs.lock().map_err(|e| {
-        let err_msg = format!(
-            "Fail to acquire the lock of `EMBEDDING_GRAPHS`. Reason: {}",
-            e
-        );
+        let err_msg = format!("Fail to acquire the lock of `EMBEDDING_GRAPHS`. Reason: {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -531,7 +524,7 @@ fn update_model_metadata(
                     let err_msg = "There is no model available in the embedding graphs.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "stdout", "{}", err_msg);
+                    error!(target: "stdout", "{err_msg}");
 
                     Err(LlamaCoreError::Operation(err_msg.into()))
                 }

--- a/crates/llama-core/src/files.rs
+++ b/crates/llama-core/src/files.rs
@@ -230,7 +230,7 @@ pub fn download_file(id: impl AsRef<str>) -> Result<(String, Vec<u8>), LlamaCore
     let mut file = match File::open(file_path) {
         Ok(file) => file,
         Err(e) => {
-            let err_msg = format!("Failed to open the target file. {}", e);
+            let err_msg = format!("Failed to open the target file. {e}");
             return Err(LlamaCoreError::Operation(err_msg));
         }
     };
@@ -240,7 +240,7 @@ pub fn download_file(id: impl AsRef<str>) -> Result<(String, Vec<u8>), LlamaCore
     match file.read_to_end(&mut buffer) {
         Ok(_) => Ok((file_object.filename.clone(), buffer)),
         Err(e) => {
-            let err_msg = format!("Failed to read the content of the target file. {}", e);
+            let err_msg = format!("Failed to read the content of the target file. {e}");
 
             // log
             #[cfg(feature = "logging")]
@@ -268,7 +268,7 @@ fn file_to_base64(file_path: impl AsRef<Path>) -> Result<String, LlamaCoreError>
     let mut file = match File::open(file_path) {
         Ok(file) => file,
         Err(e) => {
-            let err_msg = format!("Failed to open the target file. {}", e);
+            let err_msg = format!("Failed to open the target file. {e}");
             return Err(LlamaCoreError::Operation(err_msg));
         }
     };

--- a/crates/llama-core/src/graph.rs
+++ b/crates/llama-core/src/graph.rs
@@ -260,7 +260,7 @@ impl<M: BaseMetadata + serde::Serialize + Clone + Default> Graph<M> {
         let config = match serde_json::to_string(&self.metadata) {
             Ok(config) => config,
             Err(e) => {
-                let err_msg = format!("Failed to update metadta. Reason: Fail to serialize metadata to a JSON string. {}", e);
+                let err_msg = format!("Failed to update metadta. Reason: Fail to serialize metadata to a JSON string. {e}");
 
                 #[cfg(feature = "logging")]
                 error!(target: "stdout", "{}", &err_msg);
@@ -331,10 +331,10 @@ impl<M: BaseMetadata + serde::Serialize + Clone + Default> Drop for Graph<M> {
     fn drop(&mut self) {
         // unload the wasi-nn graph
         if let Err(e) = self.graph.unload() {
-            let err_msg = format!("Failed to unload the wasi-nn graph. Reason: {}", e);
+            let err_msg = format!("Failed to unload the wasi-nn graph. Reason: {e}");
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             #[cfg(not(feature = "logging"))]
             eprintln!("{}", err_msg);

--- a/crates/llama-core/src/images.rs
+++ b/crates/llama-core/src/images.rs
@@ -33,7 +33,7 @@ pub async fn image_generation(
     };
 
     let mut context = text_to_image_ctx.lock().map_err(|e| {
-        let err_msg = format!("Fail to acquire the lock of `SD_TEXT_TO_IMAGE`. {}", e);
+        let err_msg = format!("Fail to acquire the lock of `SD_TEXT_TO_IMAGE`. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -71,17 +71,17 @@ pub async fn image_generation(
     // n
     let n = req.n.unwrap_or(1);
     #[cfg(feature = "logging")]
-    info!(target: "stdout", "number of images to generate: {}", n);
+    info!(target: "stdout", "number of images to generate: {n}");
 
     // cfg_scale
     let cfg_scale = req.cfg_scale.unwrap_or(7.0);
     #[cfg(feature = "logging")]
-    info!(target: "stdout", "cfg_scale: {}", cfg_scale);
+    info!(target: "stdout", "cfg_scale: {cfg_scale}");
 
     // sampling method
     let sample_method = req.sample_method.unwrap_or(SamplingMethod::EulerA);
     #[cfg(feature = "logging")]
-    info!(target: "stdout", "sample_method: {}", sample_method);
+    info!(target: "stdout", "sample_method: {sample_method}");
 
     // convert sample method to value of `SampleMethodT` type
     let sample_method = match sample_method {
@@ -120,33 +120,33 @@ pub async fn image_generation(
     // steps
     let steps = req.steps.unwrap_or(20);
     #[cfg(feature = "logging")]
-    info!(target: "stdout", "steps: {}", steps);
+    info!(target: "stdout", "steps: {steps}");
 
     // size
     let height = req.height.unwrap_or(512);
     let width = req.width.unwrap_or(512);
     #[cfg(feature = "logging")]
-    info!(target: "stdout", "height: {}, width: {}", height, width);
+    info!(target: "stdout", "height: {height}, width: {width}");
 
     // control_strength
     let control_strength = req.control_strength.unwrap_or(0.9);
     #[cfg(feature = "logging")]
-    info!(target: "stdout", "control_strength: {}", control_strength);
+    info!(target: "stdout", "control_strength: {control_strength}");
 
     // seed
     let seed = req.seed.unwrap_or(42);
     #[cfg(feature = "logging")]
-    info!(target: "stdout", "seed: {}", seed);
+    info!(target: "stdout", "seed: {seed}");
 
     // apply canny preprocessor
     let apply_canny_preprocessor = req.apply_canny_preprocessor.unwrap_or(false);
     #[cfg(feature = "logging")]
-    info!(target: "stdout", "apply_canny_preprocessor: {}", apply_canny_preprocessor);
+    info!(target: "stdout", "apply_canny_preprocessor: {apply_canny_preprocessor}");
 
     // style ratio
     let style_ratio = req.style_ratio.unwrap_or(0.2);
     #[cfg(feature = "logging")]
-    info!(target: "stdout", "style_ratio: {}", style_ratio);
+    info!(target: "stdout", "style_ratio: {style_ratio}");
 
     ctx = ctx
         .set_prompt(&req.prompt)
@@ -171,7 +171,7 @@ pub async fn image_generation(
     // control_image
     if let Some(control_image) = &req.control_image {
         #[cfg(feature = "logging")]
-        info!(target: "stdout", "control_image: {:?}", control_image);
+        info!(target: "stdout", "control_image: {control_image:?}");
 
         let control_image_file = Path::new("archives")
             .join(&control_image.id)
@@ -211,7 +211,7 @@ pub async fn image_generation(
     info!(target: "stdout", "generate image");
 
     ctx.generate().map_err(|e| {
-        let err_msg = format!("Fail to dump the image. {}", e);
+        let err_msg = format!("Fail to dump the image. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -229,7 +229,7 @@ pub async fn image_generation(
             let base64_string = match image_to_base64(output_image_file) {
                 Ok(base64_string) => base64_string,
                 Err(e) => {
-                    let err_msg = format!("Fail to convert the image to base64 string. {}", e);
+                    let err_msg = format!("Fail to convert the image to base64 string. {e}");
 
                     #[cfg(feature = "logging")]
                     error!(target: "stdout", "{}", &err_msg);
@@ -298,7 +298,7 @@ pub async fn image_edit(req: &mut ImageEditRequest) -> Result<ListImagesResponse
     };
 
     let mut context = image_to_image_ctx.lock().map_err(|e| {
-        let err_msg = format!("Fail to acquire the lock of `SD_IMAGE_TO_IMAGE`. {}", e);
+        let err_msg = format!("Fail to acquire the lock of `SD_IMAGE_TO_IMAGE`. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -335,17 +335,17 @@ pub async fn image_edit(req: &mut ImageEditRequest) -> Result<ListImagesResponse
     // n
     let n = req.n.unwrap_or(1);
     #[cfg(feature = "logging")]
-    info!(target: "stdout", "number of images to generate: {}", n);
+    info!(target: "stdout", "number of images to generate: {n}");
 
     // cfg scale
     let cfg_scale = req.cfg_scale.unwrap_or(7.0);
     #[cfg(feature = "logging")]
-    info!(target: "stdout", "cfg_scale: {}", cfg_scale);
+    info!(target: "stdout", "cfg_scale: {cfg_scale}");
 
     // sample method
     let sample_method = req.sample_method.unwrap_or(SamplingMethod::EulerA);
     #[cfg(feature = "logging")]
-    info!(target: "stdout", "sample_method: {:?}", sample_method);
+    info!(target: "stdout", "sample_method: {sample_method:?}");
     // convert sample method to value of `SampleMethodT` type
     let sample_method = match sample_method {
         SamplingMethod::Euler => {
@@ -383,38 +383,38 @@ pub async fn image_edit(req: &mut ImageEditRequest) -> Result<ListImagesResponse
     // steps
     let steps = req.steps.unwrap_or(20);
     #[cfg(feature = "logging")]
-    info!(target: "stdout", "steps: {}", steps);
+    info!(target: "stdout", "steps: {steps}");
 
     // size
     let height = req.height.unwrap_or(512);
     let width = req.width.unwrap_or(512);
     #[cfg(feature = "logging")]
-    info!(target: "stdout", "height: {}, width: {}", height, width);
+    info!(target: "stdout", "height: {height}, width: {width}");
 
     // control_strength
     let control_strength = req.control_strength.unwrap_or(0.9);
     #[cfg(feature = "logging")]
-    info!(target: "stdout", "control_strength: {}", control_strength);
+    info!(target: "stdout", "control_strength: {control_strength}");
 
     // seed
     let seed = req.seed.unwrap_or(42);
     #[cfg(feature = "logging")]
-    info!(target: "stdout", "seed: {}", seed);
+    info!(target: "stdout", "seed: {seed}");
 
     // strength
     let strength = req.strength.unwrap_or(0.75);
     #[cfg(feature = "logging")]
-    info!(target: "stdout", "strength: {}", strength);
+    info!(target: "stdout", "strength: {strength}");
 
     // apply canny preprocessor
     let apply_canny_preprocessor = req.apply_canny_preprocessor.unwrap_or(false);
     #[cfg(feature = "logging")]
-    info!(target: "stdout", "apply_canny_preprocessor: {}", apply_canny_preprocessor);
+    info!(target: "stdout", "apply_canny_preprocessor: {apply_canny_preprocessor}");
 
     // style ratio
     let style_ratio = req.style_ratio.unwrap_or(0.2);
     #[cfg(feature = "logging")]
-    info!(target: "stdout", "style_ratio: {}", style_ratio);
+    info!(target: "stdout", "style_ratio: {style_ratio}");
 
     // create and dump the generated image
     ctx = ctx
@@ -441,7 +441,7 @@ pub async fn image_edit(req: &mut ImageEditRequest) -> Result<ListImagesResponse
     info!(target: "stdout", "generate image");
 
     ctx.generate().map_err(|e| {
-        let err_msg = format!("Fail to dump the image. {}", e);
+        let err_msg = format!("Fail to dump the image. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -459,7 +459,7 @@ pub async fn image_edit(req: &mut ImageEditRequest) -> Result<ListImagesResponse
             let base64_string = match image_to_base64(output_image_file) {
                 Ok(base64_string) => base64_string,
                 Err(e) => {
-                    let err_msg = format!("Fail to convert the image to base64 string. {}", e);
+                    let err_msg = format!("Fail to convert the image to base64 string. {e}");
 
                     #[cfg(feature = "logging")]
                     error!(target: "stdout", "{}", &err_msg);

--- a/crates/llama-core/src/lib.rs
+++ b/crates/llama-core/src/lib.rs
@@ -82,7 +82,7 @@ pub fn init_ggml_chat_context(metadata_for_chats: &[GgmlMetadata]) -> Result<(),
         let err_msg = "The metadata for chat models is empty";
 
         #[cfg(feature = "logging")]
-        error!(target: "stdout", "{}", err_msg);
+        error!(target: "stdout", "{err_msg}");
 
         return Err(LlamaCoreError::InitContext(err_msg.into()));
     }
@@ -97,7 +97,7 @@ pub fn init_ggml_chat_context(metadata_for_chats: &[GgmlMetadata]) -> Result<(),
             let err_msg = "Failed to initialize the core context. Reason: The `CHAT_GRAPHS` has already been initialized";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             LlamaCoreError::InitContext(err_msg.into())
         })?;
@@ -114,7 +114,7 @@ pub fn init_ggml_chat_context(metadata_for_chats: &[GgmlMetadata]) -> Result<(),
                 let err_msg = "Failed to initialize the chat context. Reason: The `RUNNING_MODE` has already been initialized";
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 LlamaCoreError::InitContext(err_msg.into())
             })?;
@@ -135,7 +135,7 @@ pub fn init_ggml_embeddings_context(
         let err_msg = "The metadata for chat models is empty";
 
         #[cfg(feature = "logging")]
-        error!(target: "stdout", "{}", err_msg);
+        error!(target: "stdout", "{err_msg}");
 
         return Err(LlamaCoreError::InitContext(err_msg.into()));
     }
@@ -152,7 +152,7 @@ pub fn init_ggml_embeddings_context(
                 let err_msg = "Failed to initialize the core context. Reason: The `EMBEDDING_GRAPHS` has already been initialized";
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 LlamaCoreError::InitContext(err_msg.into())
             })?;
@@ -169,7 +169,7 @@ pub fn init_ggml_embeddings_context(
                 let err_msg = "Failed to initialize the embeddings context. Reason: The `RUNNING_MODE` has already been initialized";
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 LlamaCoreError::InitContext(err_msg.into())
             })?;
@@ -193,7 +193,7 @@ pub fn init_ggml_rag_context(
         let err_msg = "The metadata for chat models is empty";
 
         #[cfg(feature = "logging")]
-        error!(target: "stdout", "{}", err_msg);
+        error!(target: "stdout", "{err_msg}");
 
         return Err(LlamaCoreError::InitContext(err_msg.into()));
     }
@@ -207,7 +207,7 @@ pub fn init_ggml_rag_context(
         let err_msg = "Failed to initialize the core context. Reason: The `CHAT_GRAPHS` has already been initialized";
 
         #[cfg(feature = "logging")]
-        error!(target: "stdout", "{}", err_msg);
+        error!(target: "stdout", "{err_msg}");
 
         LlamaCoreError::InitContext(err_msg.into())
     })?;
@@ -217,7 +217,7 @@ pub fn init_ggml_rag_context(
         let err_msg = "The metadata for embeddings is empty";
 
         #[cfg(feature = "logging")]
-        error!(target: "stdout", "{}", err_msg);
+        error!(target: "stdout", "{err_msg}");
 
         return Err(LlamaCoreError::InitContext(err_msg.into()));
     }
@@ -233,7 +233,7 @@ pub fn init_ggml_rag_context(
             let err_msg = "Failed to initialize the core context. Reason: The `EMBEDDING_GRAPHS` has already been initialized";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             LlamaCoreError::InitContext(err_msg.into())
         })?;
@@ -250,7 +250,7 @@ pub fn init_ggml_rag_context(
                     let err_msg = "Failed to initialize the rag context. Reason: The `RUNNING_MODE` has already been initialized";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "stdout", "{}", err_msg);
+                    error!(target: "stdout", "{err_msg}");
 
                     LlamaCoreError::InitContext(err_msg.into())
                 })?;
@@ -269,7 +269,7 @@ pub fn init_ggml_tts_context(metadata_for_tts: &[GgmlTtsMetadata]) -> Result<(),
         let err_msg = "The metadata for tts models is empty";
 
         #[cfg(feature = "logging")]
-        error!(target: "stdout", "{}", err_msg);
+        error!(target: "stdout", "{err_msg}");
 
         return Err(LlamaCoreError::InitContext(err_msg.into()));
     }
@@ -284,7 +284,7 @@ pub fn init_ggml_tts_context(metadata_for_tts: &[GgmlTtsMetadata]) -> Result<(),
         let err_msg = "Failed to initialize the core context. Reason: The `TTS_GRAPHS` has already been initialized";
 
         #[cfg(feature = "logging")]
-        error!(target: "stdout", "{}", err_msg);
+        error!(target: "stdout", "{err_msg}");
 
         LlamaCoreError::InitContext(err_msg.into())
     })?;
@@ -301,7 +301,7 @@ pub fn init_ggml_tts_context(metadata_for_tts: &[GgmlTtsMetadata]) -> Result<(),
                 let err_msg = "Failed to initialize the embeddings context. Reason: The `RUNNING_MODE` has already been initialized";
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 LlamaCoreError::InitContext(err_msg.into())
             })?;
@@ -327,14 +327,14 @@ pub fn get_plugin_info() -> Result<PluginInfo, LlamaCoreError> {
                 let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 return Err(LlamaCoreError::Operation(err_msg.into()));
             }
         };
 
         let chat_graphs = chat_graphs.lock().map_err(|e| {
-            let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
+            let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {e}");
 
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);
@@ -348,7 +348,7 @@ pub fn get_plugin_info() -> Result<PluginInfo, LlamaCoreError> {
                 let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 return Err(LlamaCoreError::Operation(err_msg.into()));
             }
@@ -362,14 +362,14 @@ pub fn get_plugin_info() -> Result<PluginInfo, LlamaCoreError> {
                 let err_msg = "Fail to get the underlying value of `EMBEDDING_GRAPHS`.";
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 return Err(LlamaCoreError::Operation(err_msg.into()));
             }
         };
 
         let embedding_graphs = embedding_graphs.lock().map_err(|e| {
-            let err_msg = format!("Fail to acquire the lock of `EMBEDDING_GRAPHS`. {}", e);
+            let err_msg = format!("Fail to acquire the lock of `EMBEDDING_GRAPHS`. {e}");
 
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);
@@ -383,7 +383,7 @@ pub fn get_plugin_info() -> Result<PluginInfo, LlamaCoreError> {
                 let err_msg = "Fail to get the underlying value of `EMBEDDING_GRAPHS`.";
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 return Err(LlamaCoreError::Operation(err_msg.into()));
             }
@@ -397,14 +397,14 @@ pub fn get_plugin_info() -> Result<PluginInfo, LlamaCoreError> {
                 let err_msg = "Fail to get the underlying value of `TTS_GRAPHS`.";
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 return Err(LlamaCoreError::Operation(err_msg.into()));
             }
         };
 
         let tts_graphs = tts_graphs.lock().map_err(|e| {
-            let err_msg = format!("Fail to acquire the lock of `TTS_GRAPHS`. {}", e);
+            let err_msg = format!("Fail to acquire the lock of `TTS_GRAPHS`. {e}");
 
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);
@@ -418,7 +418,7 @@ pub fn get_plugin_info() -> Result<PluginInfo, LlamaCoreError> {
                 let err_msg = "Fail to get the underlying value of `TTS_GRAPHS`.";
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 return Err(LlamaCoreError::Operation(err_msg.into()));
             }
@@ -429,7 +429,7 @@ pub fn get_plugin_info() -> Result<PluginInfo, LlamaCoreError> {
         let err_msg = "RUNNING_MODE is not set";
 
         #[cfg(feature = "logging")]
-        error!(target: "stdout", "{}", err_msg);
+        error!(target: "stdout", "{err_msg}");
 
         Err(LlamaCoreError::Operation(err_msg.into()))
     }
@@ -444,7 +444,7 @@ fn get_plugin_info_by_graph<M: BaseMetadata + serde::Serialize + Clone + Default
     // get the plugin metadata
     let output_buffer = get_output_buffer(graph, PLUGIN_VERSION)?;
     let metadata: serde_json::Value = serde_json::from_slice(&output_buffer[..]).map_err(|e| {
-        let err_msg = format!("Fail to deserialize the plugin metadata. {}", e);
+        let err_msg = format!("Fail to deserialize the plugin metadata. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -460,7 +460,7 @@ fn get_plugin_info_by_graph<M: BaseMetadata + serde::Serialize + Clone + Default
                 let err_msg = "Failed to convert the build number of the plugin to u64";
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 return Err(LlamaCoreError::Operation(err_msg.into()));
             }
@@ -469,7 +469,7 @@ fn get_plugin_info_by_graph<M: BaseMetadata + serde::Serialize + Clone + Default
             let err_msg = "Metadata does not have the field `llama_build_number`.";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             return Err(LlamaCoreError::Operation(err_msg.into()));
         }
@@ -483,7 +483,7 @@ fn get_plugin_info_by_graph<M: BaseMetadata + serde::Serialize + Clone + Default
                 let err_msg = "Failed to convert the commit id of the plugin to string";
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 return Err(LlamaCoreError::Operation(err_msg.into()));
             }
@@ -492,14 +492,14 @@ fn get_plugin_info_by_graph<M: BaseMetadata + serde::Serialize + Clone + Default
             let err_msg = "Metadata does not have the field `llama_commit`.";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             return Err(LlamaCoreError::Operation(err_msg.into()));
         }
     };
 
     #[cfg(feature = "logging")]
-    debug!(target: "stdout", "Plugin info: b{}(commit {})", plugin_build_number, plugin_commit);
+    debug!(target: "stdout", "Plugin info: b{plugin_build_number}(commit {plugin_commit})");
 
     Ok(PluginInfo {
         build_number: plugin_build_number,
@@ -532,10 +532,10 @@ pub fn running_mode() -> Result<RunningMode, LlamaCoreError> {
         Some(mode) => match mode.read() {
             Ok(mode) => Ok(*mode),
             Err(e) => {
-                let err_msg = format!("Fail to get the underlying value of `RUNNING_MODE`. {}", e);
+                let err_msg = format!("Fail to get the underlying value of `RUNNING_MODE`. {e}");
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 Err(LlamaCoreError::Operation(err_msg))
             }
@@ -544,7 +544,7 @@ pub fn running_mode() -> Result<RunningMode, LlamaCoreError> {
             let err_msg = "Fail to get the underlying value of `RUNNING_MODE`.";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             Err(LlamaCoreError::Operation(err_msg.into()))
         }
@@ -593,37 +593,31 @@ pub fn init_sd_context_with_full_model(
     if task == StableDiffusionTask::Full || task == StableDiffusionTask::TextToImage {
         let sd = SDBuidler::new(Task::TextToImage, model_file.as_ref())
             .map_err(|e| {
-                let err_msg = format!(
-                    "Failed to initialize the stable diffusion context. Reason: {}",
-                    e
-                );
+                let err_msg =
+                    format!("Failed to initialize the stable diffusion context. Reason: {e}");
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 LlamaCoreError::InitContext(err_msg)
             })?
             .with_lora_model_dir(lora_model_dir.unwrap_or_default())
             .map_err(|e| {
-                let err_msg = format!(
-                    "Failed to initialize the stable diffusion context. Reason: {}",
-                    e
-                );
+                let err_msg =
+                    format!("Failed to initialize the stable diffusion context. Reason: {e}");
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 LlamaCoreError::InitContext(err_msg)
             })?
             .use_control_net(controlnet_path.unwrap_or_default(), control_net_on_cpu)
             .map_err(|e| {
-                let err_msg = format!(
-                    "Failed to initialize the stable diffusion context. Reason: {}",
-                    e
-                );
+                let err_msg =
+                    format!("Failed to initialize the stable diffusion context. Reason: {e}");
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 LlamaCoreError::InitContext(err_msg)
             })?
@@ -636,7 +630,7 @@ pub fn init_sd_context_with_full_model(
         info!(target: "stdout", "sd: {:?}", &sd);
 
         let ctx = sd.create_context().map_err(|e| {
-            let err_msg = format!("Fail to create the context. {}", e);
+            let err_msg = format!("Fail to create the context. {e}");
 
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);
@@ -650,7 +644,7 @@ pub fn init_sd_context_with_full_model(
                 let err_msg = "Fail to get the context for the text-to-image task";
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 return Err(LlamaCoreError::InitContext(err_msg.into()));
             }
@@ -663,7 +657,7 @@ pub fn init_sd_context_with_full_model(
         let err_msg = "Failed to initialize the stable diffusion context. Reason: The `SD_TEXT_TO_IMAGE` has already been initialized";
 
         #[cfg(feature = "logging")]
-        error!(target: "stdout", "{}", err_msg);
+        error!(target: "stdout", "{err_msg}");
 
         LlamaCoreError::InitContext(err_msg.into())
     })?;
@@ -676,37 +670,31 @@ pub fn init_sd_context_with_full_model(
     if task == StableDiffusionTask::Full || task == StableDiffusionTask::ImageToImage {
         let sd = SDBuidler::new(Task::ImageToImage, model_file.as_ref())
             .map_err(|e| {
-                let err_msg = format!(
-                    "Failed to initialize the stable diffusion context. Reason: {}",
-                    e
-                );
+                let err_msg =
+                    format!("Failed to initialize the stable diffusion context. Reason: {e}");
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 LlamaCoreError::InitContext(err_msg)
             })?
             .with_lora_model_dir(lora_model_dir.unwrap_or_default())
             .map_err(|e| {
-                let err_msg = format!(
-                    "Failed to initialize the stable diffusion context. Reason: {}",
-                    e
-                );
+                let err_msg =
+                    format!("Failed to initialize the stable diffusion context. Reason: {e}");
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 LlamaCoreError::InitContext(err_msg)
             })?
             .use_control_net(controlnet_path.unwrap_or_default(), control_net_on_cpu)
             .map_err(|e| {
-                let err_msg = format!(
-                    "Failed to initialize the stable diffusion context. Reason: {}",
-                    e
-                );
+                let err_msg =
+                    format!("Failed to initialize the stable diffusion context. Reason: {e}");
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 LlamaCoreError::InitContext(err_msg)
             })?
@@ -719,7 +707,7 @@ pub fn init_sd_context_with_full_model(
         info!(target: "stdout", "sd: {:?}", &sd);
 
         let ctx = sd.create_context().map_err(|e| {
-            let err_msg = format!("Fail to create the context. {}", e);
+            let err_msg = format!("Fail to create the context. {e}");
 
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);
@@ -733,7 +721,7 @@ pub fn init_sd_context_with_full_model(
                 let err_msg = "Fail to get the context for the image-to-image task";
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 return Err(LlamaCoreError::InitContext(err_msg.into()));
             }
@@ -746,7 +734,7 @@ pub fn init_sd_context_with_full_model(
             let err_msg = "Failed to initialize the stable diffusion context. Reason: The `SD_IMAGE_TO_IMAGE` has already been initialized";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             LlamaCoreError::InitContext(err_msg.into())
         })?;
@@ -809,73 +797,61 @@ pub fn init_sd_context_with_standalone_model(
     if task == StableDiffusionTask::Full || task == StableDiffusionTask::TextToImage {
         let sd = SDBuidler::new_with_standalone_model(Task::TextToImage, model_file.as_ref())
             .map_err(|e| {
-                let err_msg = format!(
-                    "Failed to initialize the stable diffusion context. Reason: {}",
-                    e
-                );
+                let err_msg =
+                    format!("Failed to initialize the stable diffusion context. Reason: {e}");
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 LlamaCoreError::InitContext(err_msg)
             })?
             .with_vae_path(vae.as_ref())
             .map_err(|e| {
-                let err_msg = format!(
-                    "Failed to initialize the stable diffusion context. Reason: {}",
-                    e
-                );
+                let err_msg =
+                    format!("Failed to initialize the stable diffusion context. Reason: {e}");
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 LlamaCoreError::InitContext(err_msg)
             })?
             .with_clip_l_path(clip_l.as_ref())
             .map_err(|e| {
-                let err_msg = format!(
-                    "Failed to initialize the stable diffusion context. Reason: {}",
-                    e
-                );
+                let err_msg =
+                    format!("Failed to initialize the stable diffusion context. Reason: {e}");
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 LlamaCoreError::InitContext(err_msg)
             })?
             .with_t5xxl_path(t5xxl.as_ref())
             .map_err(|e| {
-                let err_msg = format!(
-                    "Failed to initialize the stable diffusion context. Reason: {}",
-                    e
-                );
+                let err_msg =
+                    format!("Failed to initialize the stable diffusion context. Reason: {e}");
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 LlamaCoreError::InitContext(err_msg)
             })?
             .with_lora_model_dir(lora_model_dir.unwrap_or_default())
             .map_err(|e| {
-                let err_msg = format!(
-                    "Failed to initialize the stable diffusion context. Reason: {}",
-                    e
-                );
+                let err_msg =
+                    format!("Failed to initialize the stable diffusion context. Reason: {e}");
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 LlamaCoreError::InitContext(err_msg)
             })?
             .use_control_net(controlnet_path.unwrap_or_default(), control_net_on_cpu)
             .map_err(|e| {
-                let err_msg = format!(
-                    "Failed to initialize the stable diffusion context. Reason: {}",
-                    e
-                );
+                let err_msg =
+                    format!("Failed to initialize the stable diffusion context. Reason: {e}");
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 LlamaCoreError::InitContext(err_msg)
             })?
@@ -888,7 +864,7 @@ pub fn init_sd_context_with_standalone_model(
         info!(target: "stdout", "sd: {:?}", &sd);
 
         let ctx = sd.create_context().map_err(|e| {
-            let err_msg = format!("Fail to create the context. {}", e);
+            let err_msg = format!("Fail to create the context. {e}");
 
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);
@@ -902,7 +878,7 @@ pub fn init_sd_context_with_standalone_model(
                 let err_msg = "Fail to get the context for the text-to-image task";
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 return Err(LlamaCoreError::InitContext(err_msg.into()));
             }
@@ -915,7 +891,7 @@ pub fn init_sd_context_with_standalone_model(
             let err_msg = "Failed to initialize the stable diffusion context. Reason: The `SD_TEXT_TO_IMAGE` has already been initialized";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             LlamaCoreError::InitContext(err_msg.into())
         })?;
@@ -928,73 +904,61 @@ pub fn init_sd_context_with_standalone_model(
     if task == StableDiffusionTask::Full || task == StableDiffusionTask::ImageToImage {
         let sd = SDBuidler::new_with_standalone_model(Task::ImageToImage, model_file.as_ref())
             .map_err(|e| {
-                let err_msg = format!(
-                    "Failed to initialize the stable diffusion context. Reason: {}",
-                    e
-                );
+                let err_msg =
+                    format!("Failed to initialize the stable diffusion context. Reason: {e}");
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 LlamaCoreError::InitContext(err_msg)
             })?
             .with_vae_path(vae.as_ref())
             .map_err(|e| {
-                let err_msg = format!(
-                    "Failed to initialize the stable diffusion context. Reason: {}",
-                    e
-                );
+                let err_msg =
+                    format!("Failed to initialize the stable diffusion context. Reason: {e}");
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 LlamaCoreError::InitContext(err_msg)
             })?
             .with_clip_l_path(clip_l.as_ref())
             .map_err(|e| {
-                let err_msg = format!(
-                    "Failed to initialize the stable diffusion context. Reason: {}",
-                    e
-                );
+                let err_msg =
+                    format!("Failed to initialize the stable diffusion context. Reason: {e}");
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 LlamaCoreError::InitContext(err_msg)
             })?
             .with_t5xxl_path(t5xxl.as_ref())
             .map_err(|e| {
-                let err_msg = format!(
-                    "Failed to initialize the stable diffusion context. Reason: {}",
-                    e
-                );
+                let err_msg =
+                    format!("Failed to initialize the stable diffusion context. Reason: {e}");
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 LlamaCoreError::InitContext(err_msg)
             })?
             .with_lora_model_dir(lora_model_dir.unwrap_or_default())
             .map_err(|e| {
-                let err_msg = format!(
-                    "Failed to initialize the stable diffusion context. Reason: {}",
-                    e
-                );
+                let err_msg =
+                    format!("Failed to initialize the stable diffusion context. Reason: {e}");
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 LlamaCoreError::InitContext(err_msg)
             })?
             .use_control_net(controlnet_path.unwrap_or_default(), control_net_on_cpu)
             .map_err(|e| {
-                let err_msg = format!(
-                    "Failed to initialize the stable diffusion context. Reason: {}",
-                    e
-                );
+                let err_msg =
+                    format!("Failed to initialize the stable diffusion context. Reason: {e}");
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 LlamaCoreError::InitContext(err_msg)
             })?
@@ -1007,7 +971,7 @@ pub fn init_sd_context_with_standalone_model(
         info!(target: "stdout", "sd: {:?}", &sd);
 
         let ctx = sd.create_context().map_err(|e| {
-            let err_msg = format!("Fail to create the context. {}", e);
+            let err_msg = format!("Fail to create the context. {e}");
 
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);
@@ -1021,7 +985,7 @@ pub fn init_sd_context_with_standalone_model(
                 let err_msg = "Fail to get the context for the image-to-image task";
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 return Err(LlamaCoreError::InitContext(err_msg.into()));
             }
@@ -1034,7 +998,7 @@ pub fn init_sd_context_with_standalone_model(
         let err_msg = "Failed to initialize the stable diffusion context. Reason: The `SD_IMAGE_TO_IMAGE` has already been initialized";
 
         #[cfg(feature = "logging")]
-        error!(target: "stdout", "{}", err_msg);
+        error!(target: "stdout", "{err_msg}");
 
         LlamaCoreError::InitContext(err_msg.into())
     })?;
@@ -1074,10 +1038,10 @@ pub fn init_whisper_context(whisper_metadata: &WhisperMetadata) -> Result<(), Ll
             match mutex_graph.lock() {
                 Ok(mut locked_graph) => *locked_graph = graph,
                 Err(e) => {
-                    let err_msg = format!("Failed to lock the graph. Reason: {}", e);
+                    let err_msg = format!("Failed to lock the graph. Reason: {e}");
 
                     #[cfg(feature = "logging")]
-                    error!(target: "stdout", "{}", err_msg);
+                    error!(target: "stdout", "{err_msg}");
 
                     return Err(LlamaCoreError::InitContext(err_msg));
                 }
@@ -1091,7 +1055,7 @@ pub fn init_whisper_context(whisper_metadata: &WhisperMetadata) -> Result<(), Ll
                 let err_msg = "Failed to initialize the audio context. Reason: The `AUDIO_GRAPH` has already been initialized";
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 LlamaCoreError::InitContext(err_msg.into())
             })?;
@@ -1139,7 +1103,7 @@ pub fn init_piper_context(
             let err_msg = "Failed to initialize the piper context. Reason: The `PIPER_GRAPH` has already been initialized";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             LlamaCoreError::InitContext(err_msg.into())
         })?;

--- a/crates/llama-core/src/models.rs
+++ b/crates/llama-core/src/models.rs
@@ -13,7 +13,7 @@ pub async fn models() -> Result<ListModelsResponse, LlamaCoreError> {
     {
         if let Some(chat_graphs) = CHAT_GRAPHS.get() {
             let chat_graphs = chat_graphs.lock().map_err(|e| {
-                let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
+                let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {e}");
 
                 #[cfg(feature = "logging")]
                 error!(target: "stdout", "{}", &err_msg);
@@ -41,8 +41,7 @@ pub async fn models() -> Result<ListModelsResponse, LlamaCoreError> {
         if let Some(embedding_graphs) = EMBEDDING_GRAPHS.get() {
             let embedding_graphs = embedding_graphs.lock().map_err(|e| {
                 LlamaCoreError::Operation(format!(
-                    "Fail to acquire the lock of `EMBEDDING_GRAPHS`. {}",
-                    e
+                    "Fail to acquire the lock of `EMBEDDING_GRAPHS`. {e}"
                 ))
             })?;
 

--- a/crates/llama-core/src/rag.rs
+++ b/crates/llama-core/src/rag.rs
@@ -26,10 +26,8 @@ pub async fn rag_doc_chunks_to_embeddings(
 
     let running_mode = running_mode()?;
     if running_mode != RunningMode::RAG {
-        let err_msg = format!(
-            "Creating knowledge base is not supported in the {} mode.",
-            running_mode
-        );
+        let err_msg =
+            format!("Creating knowledge base is not supported in the {running_mode} mode.");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -65,7 +63,7 @@ pub async fn rag_doc_chunks_to_embeddings(
 
     #[cfg(feature = "logging")]
     if let Ok(request_str) = serde_json::to_string(&embedding_request) {
-        debug!(target: "stdout", "Embedding request: {}", request_str);
+        debug!(target: "stdout", "Embedding request: {request_str}");
     }
 
     // compute embeddings for the document
@@ -165,10 +163,7 @@ pub async fn rag_retrieve_context(
 
     let running_mode = running_mode()?;
     if running_mode != RunningMode::RAG {
-        let err_msg = format!(
-            "The context retrieval is not supported in the {} mode.",
-            running_mode
-        );
+        let err_msg = format!("The context retrieval is not supported in the {running_mode} mode.");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -202,7 +197,7 @@ pub async fn rag_retrieve_context(
         Ok(points) => points,
         Err(e) => {
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", e);
+            error!(target: "stdout", "{e}");
 
             return Err(e);
         }
@@ -251,7 +246,7 @@ pub async fn rag_retrieve_context(
                     // For debugging purpose, log the optional search field if it exists
                     #[cfg(feature = "logging")]
                     if let Some(search) = payload.get("search").and_then(Value::as_str) {
-                        info!(target: "stdout", "search: {}", search);
+                        info!(target: "stdout", "search: {search}");
                     }
                 }
             }
@@ -326,7 +321,7 @@ async fn qdrant_persist_embeddings(
         .upsert_points(collection_name.as_ref(), points)
         .await
     {
-        let err_msg = format!("{}", e);
+        let err_msg = format!("{e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);

--- a/crates/llama-core/src/search.rs
+++ b/crates/llama-core/src/search.rs
@@ -113,10 +113,9 @@ impl SearchConfig {
             Err(_) => {
                 let msg = "Malformed endpoint url";
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "perform_search: {}", msg);
+                error!(target: "stdout", "perform_search: {msg}");
                 return Err(LlamaCoreError::Search(format!(
-                    "When parsing endpoint url: {}",
-                    msg
+                    "When parsing endpoint url: {msg}"
                 )));
             }
         };
@@ -126,10 +125,9 @@ impl SearchConfig {
             _ => {
                 let msg = "Non Standard or unknown method";
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "perform_search: {}", msg);
+                error!(target: "stdout", "perform_search: {msg}");
                 return Err(LlamaCoreError::Search(format!(
-                    "When converting method from bytes: {}",
-                    msg
+                    "When converting method from bytes: {msg}"
                 )));
             }
         };
@@ -143,10 +141,9 @@ impl SearchConfig {
                 Err(_) => {
                     let msg = "Failed to convert headers from HashMaps to HeaderMaps";
                     #[cfg(feature = "logging")]
-                    error!(target: "stdout", "perform_search: {}", msg);
+                    error!(target: "stdout", "perform_search: {msg}");
                     return Err(LlamaCoreError::Search(format!(
-                        "On converting headers: {}",
-                        msg
+                        "On converting headers: {msg}"
                     )));
                 }
             },
@@ -165,7 +162,7 @@ impl SearchConfig {
                     method_as_string.to_owned()
                 );
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "perform_search: {}", msg);
+                error!(target: "stdout", "perform_search: {msg}");
                 return Err(LlamaCoreError::Search(msg));
             }
         };
@@ -175,10 +172,9 @@ impl SearchConfig {
             Err(e) => {
                 let msg = e.to_string();
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "perform_search: {}", msg);
+                error!(target: "stdout", "perform_search: {msg}");
                 return Err(LlamaCoreError::Search(format!(
-                    "When recieving response: {}",
-                    msg
+                    "When recieving response: {msg}"
                 )));
             }
         };
@@ -188,20 +184,18 @@ impl SearchConfig {
                 if length == 0 {
                     let msg = "Empty response from server";
                     #[cfg(feature = "logging")]
-                    error!(target: "stdout", "perform_search: {}", msg);
+                    error!(target: "stdout", "perform_search: {msg}");
                     return Err(LlamaCoreError::Search(format!(
-                        "Unexpected content length: {}",
-                        msg
+                        "Unexpected content length: {msg}"
                     )));
                 }
             }
             None => {
                 let msg = "Content length returned None";
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "perform_search: {}", msg);
+                error!(target: "stdout", "perform_search: {msg}");
                 return Err(LlamaCoreError::Search(format!(
-                    "Content length field not found: {}",
-                    msg
+                    "Content length field not found: {msg}"
                 )));
             }
         }
@@ -218,23 +212,21 @@ impl SearchConfig {
                     Err(e) => {
                         let msg = e.to_string();
                         #[cfg(feature = "logging")]
-                        error!(target: "stdout", "perform_search: {}", msg);
+                        error!(target: "stdout", "perform_search: {msg}");
                         return Err(LlamaCoreError::Search(format!(
-                            "When accessing response body: {}",
-                            msg
+                            "When accessing response body: {msg}"
                         )));
                     }
                 };
-                println!("{}", body_text);
+                println!("{body_text}");
                 raw_results = match serde_json::from_str(body_text.as_str()) {
                     Ok(value) => value,
                     Err(e) => {
                         let msg = e.to_string();
                         #[cfg(feature = "logging")]
-                        error!(target: "stdout", "perform_search: {}", msg);
+                        error!(target: "stdout", "perform_search: {msg}");
                         return Err(LlamaCoreError::Search(format!(
-                            "When converting to a JSON object: {}",
-                            msg
+                            "When converting to a JSON object: {msg}"
                         )));
                     }
                 };
@@ -249,10 +241,9 @@ impl SearchConfig {
             Err(e) => {
                 let msg = e.to_string();
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "perform_search: {}", msg);
+                error!(target: "stdout", "perform_search: {msg}");
                 return Err(LlamaCoreError::Search(format!(
-                    "When calling parse_into_results: {}",
-                    msg
+                    "When calling parse_into_results: {msg}"
                 )));
             }
         };
@@ -325,7 +316,7 @@ fn summarize(
         let err_msg = "Summarization is not supported in the EMBEDDINGS running mode.";
 
         #[cfg(feature = "logging")]
-        error!(target: "stdout", "{}", err_msg);
+        error!(target: "stdout", "{err_msg}");
 
         return Err(LlamaCoreError::Search(err_msg.into()));
     }
@@ -337,14 +328,14 @@ fn summarize(
             let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             return Err(LlamaCoreError::Search(err_msg.into()));
         }
     };
 
     let mut chat_graphs = chat_graphs.lock().map_err(|e| {
-        let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
+        let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -363,7 +354,7 @@ fn summarize(
             let err_msg = "No available chat graph.";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             return Err(LlamaCoreError::Search(err_msg.into()));
         }

--- a/crates/llama-core/src/tts.rs
+++ b/crates/llama-core/src/tts.rs
@@ -17,7 +17,7 @@ pub async fn create_speech(request: SpeechRequest) -> Result<Vec<u8>, LlamaCoreE
         let err_msg = "Generating audio speech is only supported in the tts mode.";
 
         #[cfg(feature = "logging")]
-        error!(target: "stdout", "{}", err_msg);
+        error!(target: "stdout", "{err_msg}");
 
         return Err(LlamaCoreError::Operation(err_msg.into()));
     }
@@ -38,7 +38,7 @@ pub async fn create_speech(request: SpeechRequest) -> Result<Vec<u8>, LlamaCoreE
         };
 
         let mut tts_graphs = tts_graphs.lock().map_err(|e| {
-            let err_msg = format!("Fail to acquire the lock of `TTS_GRAPHS`. {}", e);
+            let err_msg = format!("Fail to acquire the lock of `TTS_GRAPHS`. {e}");
 
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);
@@ -91,7 +91,7 @@ fn compute_by_graph(
     #[cfg(feature = "logging")]
     info!(target: "stdout", "Generate audio");
     if let Err(e) = graph.compute() {
-        let err_msg = format!("Failed to compute the graph. {}", e);
+        let err_msg = format!("Failed to compute the graph. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -105,7 +105,7 @@ fn compute_by_graph(
 
     let mut output_buffer = vec![0u8; MAX_BUFFER_SIZE];
     let output_size = graph.get_output(0, &mut output_buffer).map_err(|e| {
-        let err_msg = format!("Failed to get the output tensor. {}", e);
+        let err_msg = format!("Failed to get the output tensor. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -114,7 +114,7 @@ fn compute_by_graph(
     })?;
 
     #[cfg(feature = "logging")]
-    info!(target: "stdout", "Output buffer size: {}", output_size);
+    info!(target: "stdout", "Output buffer size: {output_size}");
 
     Ok(output_buffer)
 }
@@ -127,14 +127,14 @@ fn get_model_metadata(model_name: Option<&String>) -> Result<GgmlTtsMetadata, Ll
             let err_msg = "Fail to get the underlying value of `TTS_GRAPHS`.";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             return Err(LlamaCoreError::Operation(err_msg.into()));
         }
     };
 
     let tts_graphs = tts_graphs.lock().map_err(|e| {
-        let err_msg = format!("Fail to acquire the lock of `TTS_GRAPHS`. {}", e);
+        let err_msg = format!("Fail to acquire the lock of `TTS_GRAPHS`. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -166,7 +166,7 @@ fn get_model_metadata(model_name: Option<&String>) -> Result<GgmlTtsMetadata, Ll
                 let err_msg = "There is no model available in the tts graphs.";
 
                 #[cfg(feature = "logging")]
-                error!(target: "stdout", "{}", err_msg);
+                error!(target: "stdout", "{err_msg}");
 
                 Err(LlamaCoreError::Operation(err_msg.into()))
             }
@@ -181,7 +181,7 @@ fn update_model_metadata(
     let config = match serde_json::to_string(metadata) {
         Ok(config) => config,
         Err(e) => {
-            let err_msg = format!("Fail to serialize metadata to a JSON string. {}", e);
+            let err_msg = format!("Fail to serialize metadata to a JSON string. {e}");
 
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);
@@ -196,14 +196,14 @@ fn update_model_metadata(
             let err_msg = "Fail to get the underlying value of `TTS_GRAPHS`.";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             return Err(LlamaCoreError::Operation(err_msg.into()));
         }
     };
 
     let mut tts_graphs = tts_graphs.lock().map_err(|e| {
-        let err_msg = format!("Fail to acquire the lock of `TTS_GRAPHS`. Reason: {}", e);
+        let err_msg = format!("Fail to acquire the lock of `TTS_GRAPHS`. Reason: {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -245,7 +245,7 @@ fn update_model_metadata(
                     let err_msg = "There is no model available in the tts graphs.";
 
                     #[cfg(feature = "logging")]
-                    error!(target: "stdout", "{}", err_msg);
+                    error!(target: "stdout", "{err_msg}");
 
                     Err(LlamaCoreError::Operation(err_msg.into()))
                 }

--- a/crates/llama-core/src/utils.rs
+++ b/crates/llama-core/src/utils.rs
@@ -23,14 +23,14 @@ pub fn chat_model_names() -> Result<Vec<String>, LlamaCoreError> {
             let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             return Err(LlamaCoreError::Operation(err_msg.into()));
         }
     };
 
     let chat_graphs = chat_graphs.lock().map_err(|e| {
-        let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
+        let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -63,7 +63,7 @@ pub fn embedding_model_names() -> Result<Vec<String>, LlamaCoreError> {
     let embedding_graphs = match embedding_graphs.lock() {
         Ok(embedding_graphs) => embedding_graphs,
         Err(e) => {
-            let err_msg = format!("Fail to acquire the lock of `EMBEDDING_GRAPHS`. {}", e);
+            let err_msg = format!("Fail to acquire the lock of `EMBEDDING_GRAPHS`. {e}");
 
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);
@@ -85,7 +85,7 @@ pub fn chat_prompt_template(name: Option<&str>) -> Result<PromptTemplateType, Ll
     #[cfg(feature = "logging")]
     match name {
         Some(name) => {
-            info!(target: "stdout", "Get the chat prompt template type from the chat model named {}.", name)
+            info!(target: "stdout", "Get the chat prompt template type from the chat model named {name}.")
         }
         None => {
             info!(target: "stdout", "Get the chat prompt template type from the default chat model.")
@@ -98,14 +98,14 @@ pub fn chat_prompt_template(name: Option<&str>) -> Result<PromptTemplateType, Ll
             let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             return Err(LlamaCoreError::Operation(err_msg.into()));
         }
     };
 
     let chat_graphs = chat_graphs.lock().map_err(|e| {
-        let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
+        let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -175,7 +175,7 @@ where
     let mut output_buffer: Vec<u8> = Vec::with_capacity(MAX_BUFFER_SIZE);
 
     let output_size: usize = graph.get_output(index, &mut output_buffer).map_err(|e| {
-        let err_msg = format!("Fail to get the generated output tensor. {msg}", msg = e);
+        let err_msg = format!("Fail to get the generated output tensor. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -206,7 +206,7 @@ where
     let output_size: usize = graph
         .get_output_single(index, &mut output_buffer)
         .map_err(|e| {
-            let err_msg = format!("Fail to get plugin metadata. {msg}", msg = e);
+            let err_msg = format!("Fail to get plugin metadata. {e}");
 
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);
@@ -233,7 +233,7 @@ where
         .set_input(idx, wasmedge_wasi_nn::TensorType::U8, &[1], tensor_data)
         .is_err()
     {
-        let err_msg = format!("Fail to set input tensor at index {}", idx);
+        let err_msg = format!("Fail to set input tensor at index {idx}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -256,7 +256,7 @@ where
     let token_info: Value = match serde_json::from_slice(&output_buffer[..]) {
         Ok(token_info) => token_info,
         Err(e) => {
-            let err_msg = format!("Fail to deserialize token info: {msg}", msg = e);
+            let err_msg = format!("Fail to deserialize token info: {e}");
 
             #[cfg(feature = "logging")]
             error!(target: "stdout", "{}", &err_msg);
@@ -271,7 +271,7 @@ where
             let err_msg = "Fail to convert `input_tokens` to u64.";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             return Err(LlamaCoreError::Operation(err_msg.into()));
         }
@@ -282,7 +282,7 @@ where
             let err_msg = "Fail to convert `output_tokens` to u64.";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             return Err(LlamaCoreError::Operation(err_msg.into()));
         }
@@ -304,14 +304,14 @@ pub(crate) fn get_token_info_by_graph_name(
             let err_msg = "Fail to get the underlying value of `CHAT_GRAPHS`.";
 
             #[cfg(feature = "logging")]
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             return Err(LlamaCoreError::Operation(err_msg.into()));
         }
     };
 
     let chat_graphs = chat_graphs.lock().map_err(|e| {
-        let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {}", e);
+        let err_msg = format!("Fail to acquire the lock of `CHAT_GRAPHS`. {e}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -390,7 +390,7 @@ where
         .set_input(idx, T::tensor_type(), &T::shape(shape), tensor_data)
         .is_err()
     {
-        let err_msg = format!("Fail to set input tensor at index {}", idx);
+        let err_msg = format!("Fail to set input tensor at index {idx}");
 
         #[cfg(feature = "logging")]
         error!(target: "stdout", "{}", &err_msg);
@@ -427,6 +427,6 @@ impl std::fmt::Display for RunningMode {
 
         mode = mode.trim_end_matches(", ").to_string();
 
-        write!(f, "{}", mode)
+        write!(f, "{mode}")
     }
 }

--- a/llama-api-server/Cargo.toml
+++ b/llama-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "llama-api-server"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 
 [dependencies]

--- a/llama-api-server/src/backend/ggml.rs
+++ b/llama-api-server/src/backend/ggml.rs
@@ -26,7 +26,7 @@ pub(crate) async fn models_handler() -> Response<Body> {
     let list_models_response = match llama_core::models::models().await {
         Ok(list_models_response) => list_models_response,
         Err(e) => {
-            let err_msg = format!("Failed to get model list. Reason: {}", e);
+            let err_msg = format!("Failed to get model list. Reason: {e}");
 
             // log
             error!(target: "stdout", "{}", &err_msg);
@@ -39,7 +39,7 @@ pub(crate) async fn models_handler() -> Response<Body> {
     let s = match serde_json::to_string(&list_models_response) {
         Ok(s) => s,
         Err(e) => {
-            let err_msg = format!("Failed to serialize the model list result. Reason: {}", e);
+            let err_msg = format!("Failed to serialize the model list result. Reason: {e}");
 
             // log
             error!(target: "stdout", "{}", &err_msg);
@@ -58,7 +58,7 @@ pub(crate) async fn models_handler() -> Response<Body> {
     let res = match result {
         Ok(response) => response,
         Err(e) => {
-            let err_msg = format!("Failed to get model list. Reason: {}", e);
+            let err_msg = format!("Failed to get model list. Reason: {e}");
 
             // log
             error!(target: "stdout", "{}", &err_msg);
@@ -81,9 +81,9 @@ pub(crate) async fn embeddings_handler(mut req: Request<Body>) -> Response<Body>
     let running_mode = match llama_core::running_mode() {
         Ok(mode) => mode,
         Err(e) => {
-            let err_msg = format!("Failed to get running mode: {}", e);
+            let err_msg = format!("Failed to get running mode: {e}");
 
-            error!(target: "stdout", "{}", e);
+            error!(target: "stdout", "{e}");
 
             return error::internal_server_error(err_msg);
         }
@@ -92,7 +92,7 @@ pub(crate) async fn embeddings_handler(mut req: Request<Body>) -> Response<Body>
     {
         let err_msg = "Embeddings tasks are only supported in the chat or embeddingsmode.";
 
-        error!(target: "stdout", "{}", err_msg);
+        error!(target: "stdout", "{err_msg}");
 
         return error::internal_server_error(err_msg);
     }
@@ -122,7 +122,7 @@ pub(crate) async fn embeddings_handler(mut req: Request<Body>) -> Response<Body>
     let body_bytes = match to_bytes(req.body_mut()).await {
         Ok(body_bytes) => body_bytes,
         Err(e) => {
-            let err_msg = format!("Fail to read buffer from request body. {}", e);
+            let err_msg = format!("Fail to read buffer from request body. {e}");
 
             // log
             error!(target: "stdout", "{}", &err_msg);
@@ -133,10 +133,10 @@ pub(crate) async fn embeddings_handler(mut req: Request<Body>) -> Response<Body>
     let mut embedding_request: EmbeddingRequest = match serde_json::from_slice(&body_bytes) {
         Ok(embedding_request) => embedding_request,
         Err(e) => {
-            let mut err_msg = format!("Fail to deserialize embedding request: {}.", e);
+            let mut err_msg = format!("Fail to deserialize embedding request: {e}.");
 
             if let Ok(json_value) = serde_json::from_slice::<serde_json::Value>(&body_bytes) {
-                err_msg = format!("{}\njson_value: {}", err_msg, json_value);
+                err_msg = format!("{err_msg}\njson_value: {json_value}");
             }
 
             // log
@@ -180,7 +180,7 @@ pub(crate) async fn embeddings_handler(mut req: Request<Body>) -> Response<Body>
                     }
                 }
                 Err(e) => {
-                    let err_msg = format!("Fail to serialize embedding object. {}", e);
+                    let err_msg = format!("Fail to serialize embedding object. {e}");
 
                     // log
                     error!(target: "stdout", "{}", &err_msg);
@@ -212,9 +212,9 @@ pub(crate) async fn completions_handler(mut req: Request<Body>) -> Response<Body
     let running_mode = match llama_core::running_mode() {
         Ok(mode) => mode,
         Err(e) => {
-            let err_msg = format!("Failed to get running mode: {}", e);
+            let err_msg = format!("Failed to get running mode: {e}");
 
-            error!(target: "stdout", "{}", e);
+            error!(target: "stdout", "{e}");
 
             return error::internal_server_error(err_msg);
         }
@@ -222,7 +222,7 @@ pub(crate) async fn completions_handler(mut req: Request<Body>) -> Response<Body
     if !running_mode.contains(RunningMode::CHAT) {
         let err_msg = "Completions tasks are only supported in the chat mode.";
 
-        error!(target: "stdout", "{}", err_msg);
+        error!(target: "stdout", "{err_msg}");
 
         return error::internal_server_error(err_msg);
     }
@@ -252,7 +252,7 @@ pub(crate) async fn completions_handler(mut req: Request<Body>) -> Response<Body
     let body_bytes = match to_bytes(req.body_mut()).await {
         Ok(body_bytes) => body_bytes,
         Err(e) => {
-            let err_msg = format!("Fail to read buffer from request body. {}", e);
+            let err_msg = format!("Fail to read buffer from request body. {e}");
 
             // log
             error!(target: "stdout", "{}", &err_msg);
@@ -263,10 +263,10 @@ pub(crate) async fn completions_handler(mut req: Request<Body>) -> Response<Body
     let mut completion_request: CompletionRequest = match serde_json::from_slice(&body_bytes) {
         Ok(completion_request) => completion_request,
         Err(e) => {
-            let mut err_msg = format!("Fail to deserialize completions request: {}.", e);
+            let mut err_msg = format!("Fail to deserialize completions request: {e}.");
 
             if let Ok(json_value) = serde_json::from_slice::<serde_json::Value>(&body_bytes) {
-                err_msg = format!("{}\njson_value: {}", err_msg, json_value);
+                err_msg = format!("{err_msg}\njson_value: {json_value}");
             }
 
             // log
@@ -290,7 +290,7 @@ pub(crate) async fn completions_handler(mut req: Request<Body>) -> Response<Body
             let s = match serde_json::to_string(&completion_object) {
                 Ok(s) => s,
                 Err(e) => {
-                    let err_msg = format!("Fail to serialize completion object. {}", e);
+                    let err_msg = format!("Fail to serialize completion object. {e}");
 
                     // log
                     error!(target: "stdout", "{}", &err_msg);
@@ -341,9 +341,9 @@ pub(crate) async fn chat_completions_handler(mut req: Request<Body>) -> Response
     let running_mode = match llama_core::running_mode() {
         Ok(mode) => mode,
         Err(e) => {
-            let err_msg = format!("Failed to get running mode: {}", e);
+            let err_msg = format!("Failed to get running mode: {e}");
 
-            error!(target: "stdout", "{}", e);
+            error!(target: "stdout", "{e}");
 
             return error::internal_server_error(err_msg);
         }
@@ -351,7 +351,7 @@ pub(crate) async fn chat_completions_handler(mut req: Request<Body>) -> Response
     if !running_mode.contains(RunningMode::CHAT) {
         let err_msg = "Chat completion tasks are only supported in the chat mode.";
 
-        error!(target: "stdout", "{}", err_msg);
+        error!(target: "stdout", "{err_msg}");
 
         return error::internal_server_error(err_msg);
     }
@@ -383,7 +383,7 @@ pub(crate) async fn chat_completions_handler(mut req: Request<Body>) -> Response
     let body_bytes = match to_bytes(req.body_mut()).await {
         Ok(body_bytes) => body_bytes,
         Err(e) => {
-            let err_msg = format!("Fail to read buffer from request body. {}", e);
+            let err_msg = format!("Fail to read buffer from request body. {e}");
 
             // log
             error!(target: "stdout", "{}", &err_msg);
@@ -394,10 +394,10 @@ pub(crate) async fn chat_completions_handler(mut req: Request<Body>) -> Response
     let mut chat_request: ChatCompletionRequest = match serde_json::from_slice(&body_bytes) {
         Ok(chat_request) => chat_request,
         Err(e) => {
-            let mut err_msg = format!("Fail to deserialize chat completion request: {}.", e);
+            let mut err_msg = format!("Fail to deserialize chat completion request: {e}.");
 
             if let Ok(json_value) = serde_json::from_slice::<serde_json::Value>(&body_bytes) {
-                err_msg = format!("{}\njson_value: {}", err_msg, json_value);
+                err_msg = format!("{err_msg}\njson_value: {json_value}");
             }
 
             // log
@@ -443,7 +443,7 @@ pub(crate) async fn chat_completions_handler(mut req: Request<Body>) -> Response
                     }
                     Err(e) => {
                         let err_msg =
-                            format!("Failed chat completions in stream mode. Reason: {}", e);
+                            format!("Failed chat completions in stream mode. Reason: {e}");
 
                         // log
                         error!(target: "stdout", "{}", &err_msg);
@@ -457,7 +457,7 @@ pub(crate) async fn chat_completions_handler(mut req: Request<Body>) -> Response
                 let s = match serde_json::to_string(&chat_completion_object) {
                     Ok(s) => s,
                     Err(e) => {
-                        let err_msg = format!("Failed to serialize chat completion object. {}", e);
+                        let err_msg = format!("Failed to serialize chat completion object. {e}");
 
                         // log
                         error!(target: "stdout", "{}", &err_msg);
@@ -485,7 +485,7 @@ pub(crate) async fn chat_completions_handler(mut req: Request<Body>) -> Response
                     }
                     Err(e) => {
                         let err_msg =
-                            format!("Failed chat completions in non-stream mode. Reason: {}", e);
+                            format!("Failed chat completions in non-stream mode. Reason: {e}");
 
                         // log
                         error!(target: "stdout", "{}", &err_msg);
@@ -496,7 +496,7 @@ pub(crate) async fn chat_completions_handler(mut req: Request<Body>) -> Response
             }
         },
         Err(e) => {
-            let err_msg = format!("Failed to get chat completions. Reason: {}", e);
+            let err_msg = format!("Failed to get chat completions. Reason: {e}");
 
             // log
             error!(target: "stdout", "{}", &err_msg);
@@ -537,7 +537,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
         let body_bytes = match to_bytes(req_body).await {
             Ok(body_bytes) => body_bytes,
             Err(e) => {
-                let err_msg = format!("Fail to read buffer from request body. {}", e);
+                let err_msg = format!("Fail to read buffer from request body. {e}");
 
                 // log
                 error!(target: "stdout", "{}", &err_msg);
@@ -586,7 +586,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
                 let size_in_bytes = match field.data.read_to_end(&mut buffer) {
                     Ok(size_in_bytes) => size_in_bytes,
                     Err(e) => {
-                        let err_msg = format!("Failed to read the target file. {}", e);
+                        let err_msg = format!("Failed to read the target file. {e}");
 
                         // log
                         error!(target: "stdout", "{}", &err_msg);
@@ -656,7 +656,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
                 let s = match serde_json::to_string(&fo) {
                     Ok(s) => s,
                     Err(e) => {
-                        let err_msg = format!("Failed to serialize file object. {}", e);
+                        let err_msg = format!("Failed to serialize file object. {e}");
 
                         // log
                         error!(target: "stdout", "{}", &err_msg);
@@ -704,7 +704,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
             ["", "v1", "files"] => list_files(),
             ["", "v1", "files", file_id, "content"] => {
                 if !file_id.starts_with("file_") {
-                    let err_msg = format!("unsupported uri path: {}", uri_path);
+                    let err_msg = format!("unsupported uri path: {uri_path}");
 
                     // log
                     error!(target: "stdout", "{}", &err_msg);
@@ -716,7 +716,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
             }
             ["", "v1", "files", file_id] => {
                 if !file_id.starts_with("file_") {
-                    let err_msg = format!("unsupported uri path: {}", uri_path);
+                    let err_msg = format!("unsupported uri path: {uri_path}");
 
                     // log
                     error!(target: "stdout", "{}", &err_msg);
@@ -728,7 +728,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
             }
             ["", "v1", "files", "download", file_id] => download_file(file_id),
             _ => {
-                let err_msg = format!("unsupported uri path: {}", uri_path);
+                let err_msg = format!("unsupported uri path: {uri_path}");
 
                 // log
                 error!(target: "stdout", "{}", &err_msg);
@@ -741,7 +741,7 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
         let status = match llama_core::files::remove_file(id) {
             Ok(status) => status,
             Err(e) => {
-                let err_msg = format!("Failed to delete the target file with id {}. {}", id, e);
+                let err_msg = format!("Failed to delete the target file with id {id}. {e}");
 
                 // log
                 error!(target: "stdout", "{}", &err_msg);
@@ -758,10 +758,8 @@ pub(crate) async fn files_handler(req: Request<Body>) -> Response<Body> {
         let s = match serde_json::to_string(&status) {
             Ok(s) => s,
             Err(e) => {
-                let err_msg = format!(
-                    "Failed to serialize the status of the file deletion operation. {}",
-                    e
-                );
+                let err_msg =
+                    format!("Failed to serialize the status of the file deletion operation. {e}");
 
                 // log
                 error!(target: "stdout", "{}", &err_msg);
@@ -829,7 +827,7 @@ fn list_files() -> Response<Body> {
             let s = match serde_json::to_string(&file_objects) {
                 Ok(s) => s,
                 Err(e) => {
-                    let err_msg = format!("Failed to serialize file list. {}", e);
+                    let err_msg = format!("Failed to serialize file list. {e}");
 
                     // log
                     error!(target: "stdout", "{}", &err_msg);
@@ -859,7 +857,7 @@ fn list_files() -> Response<Body> {
             }
         }
         Err(e) => {
-            let err_msg = format!("Failed to list all files. {}", e);
+            let err_msg = format!("Failed to list all files. {e}");
 
             // log
             error!(target: "stdout", "{}", &err_msg);
@@ -876,7 +874,7 @@ fn retrieve_file(id: impl AsRef<str>) -> Response<Body> {
             let s = match serde_json::to_string(&fo) {
                 Ok(s) => s,
                 Err(e) => {
-                    let err_msg = format!("Failed to serialize file object. {}", e);
+                    let err_msg = format!("Failed to serialize file object. {e}");
 
                     // log
                     error!(target: "stdout", "{}", &err_msg);
@@ -906,7 +904,7 @@ fn retrieve_file(id: impl AsRef<str>) -> Response<Body> {
             }
         }
         Err(e) => {
-            let err_msg = format!("{}", e);
+            let err_msg = format!("{e}");
 
             // log
             error!(target: "stdout", "{}", &err_msg);
@@ -923,7 +921,7 @@ fn retrieve_file_content(id: impl AsRef<str>) -> Response<Body> {
             let s = match serde_json::to_string(&content) {
                 Ok(s) => s,
                 Err(e) => {
-                    let err_msg = format!("Failed to serialize file content. {}", e);
+                    let err_msg = format!("Failed to serialize file content. {e}");
 
                     // log
                     error!(target: "stdout", "{}", &err_msg);
@@ -953,7 +951,7 @@ fn retrieve_file_content(id: impl AsRef<str>) -> Response<Body> {
             }
         }
         Err(e) => {
-            let err_msg = format!("{}", e);
+            let err_msg = format!("{e}");
 
             // log
             error!(target: "stdout", "{}", &err_msg);
@@ -981,7 +979,7 @@ fn download_file(id: impl AsRef<str>) -> Response<Body> {
                 "mp4" => "video/mp4",
                 "md" => "text/markdown",
                 _ => {
-                    let err_msg = format!("Unsupported file extension: {}", extension);
+                    let err_msg = format!("Unsupported file extension: {extension}");
 
                     // log
                     error!(target: "stdout", "{}", &err_msg);
@@ -989,7 +987,7 @@ fn download_file(id: impl AsRef<str>) -> Response<Body> {
                     return error::internal_server_error(err_msg);
                 }
             };
-            let content_disposition = format!("attachment; filename={}", filename);
+            let content_disposition = format!("attachment; filename={filename}");
 
             // return response
             let result = Response::builder()
@@ -1013,7 +1011,7 @@ fn download_file(id: impl AsRef<str>) -> Response<Body> {
             }
         }
         Err(e) => {
-            let err_msg = format!("{}", e);
+            let err_msg = format!("{e}");
 
             // log
             error!(target: "stdout", "{}", &err_msg);
@@ -1053,7 +1051,7 @@ pub(crate) async fn chunks_handler(mut req: Request<Body>) -> Response<Body> {
     let body_bytes = match to_bytes(req.body_mut()).await {
         Ok(body_bytes) => body_bytes,
         Err(e) => {
-            let err_msg = format!("Fail to read buffer from request body. {}", e);
+            let err_msg = format!("Fail to read buffer from request body. {e}");
 
             // log
             error!(target: "stdout", "{}", &err_msg);
@@ -1065,10 +1063,10 @@ pub(crate) async fn chunks_handler(mut req: Request<Body>) -> Response<Body> {
     let chunks_request: ChunksRequest = match serde_json::from_slice(&body_bytes) {
         Ok(chunks_request) => chunks_request,
         Err(e) => {
-            let mut err_msg = format!("Fail to deserialize chunks request: {}.", e);
+            let mut err_msg = format!("Fail to deserialize chunks request: {e}.");
 
             if let Ok(json_value) = serde_json::from_slice::<serde_json::Value>(&body_bytes) {
-                err_msg = format!("{}\njson_value: {}", err_msg, json_value);
+                err_msg = format!("{err_msg}\njson_value: {json_value}");
             }
 
             // log
@@ -1192,7 +1190,7 @@ pub(crate) async fn chunks_handler(mut req: Request<Body>) -> Response<Body> {
                     }
                 }
                 Err(e) => {
-                    let err_msg = format!("Fail to serialize chunks response. {}", e);
+                    let err_msg = format!("Fail to serialize chunks response. {e}");
 
                     // log
                     error!(target: "stdout", "{}", &err_msg);
@@ -1238,7 +1236,7 @@ pub(crate) async fn server_info_handler() -> Response<Body> {
     let s = match serde_json::to_string(&server_info) {
         Ok(s) => s,
         Err(e) => {
-            let err_msg = format!("Fail to serialize server info. {}", e);
+            let err_msg = format!("Fail to serialize server info. {e}");
 
             // log
             error!(target: "stdout", "{}", &err_msg);
@@ -1279,9 +1277,9 @@ pub(crate) async fn audio_speech_handler(req: Request<Body>) -> Response<Body> {
     let running_mode = match llama_core::running_mode() {
         Ok(mode) => mode,
         Err(e) => {
-            let err_msg = format!("Failed to get running mode: {}", e);
+            let err_msg = format!("Failed to get running mode: {e}");
 
-            error!(target: "stdout", "{}", e);
+            error!(target: "stdout", "{e}");
 
             return error::internal_server_error(err_msg);
         }
@@ -1289,7 +1287,7 @@ pub(crate) async fn audio_speech_handler(req: Request<Body>) -> Response<Body> {
     if !running_mode.contains(RunningMode::TTS) {
         let err_msg = "Audio speech tasks are only supported in the tts mode.";
 
-        error!(target: "stdout", "{}", err_msg);
+        error!(target: "stdout", "{err_msg}");
 
         return error::internal_server_error(err_msg);
     }
@@ -1321,7 +1319,7 @@ pub(crate) async fn audio_speech_handler(req: Request<Body>) -> Response<Body> {
     let body_bytes = match to_bytes(req.into_body()).await {
         Ok(body_bytes) => body_bytes,
         Err(e) => {
-            let err_msg = format!("Fail to read buffer from request body. {}", e);
+            let err_msg = format!("Fail to read buffer from request body. {e}");
 
             // log
             error!(target: "stdout", "{}", &err_msg);
@@ -1332,7 +1330,7 @@ pub(crate) async fn audio_speech_handler(req: Request<Body>) -> Response<Body> {
     let speech_request: SpeechRequest = match serde_json::from_slice(&body_bytes) {
         Ok(speech_request) => speech_request,
         Err(e) => {
-            let err_msg = format!("Fail to deserialize speech request: {msg}", msg = e);
+            let err_msg = format!("Fail to deserialize speech request: {e}");
 
             // log
             error!(target: "stdout", "{}", &err_msg);
@@ -1344,7 +1342,7 @@ pub(crate) async fn audio_speech_handler(req: Request<Body>) -> Response<Body> {
     let audio_buffer = match llama_core::tts::create_speech(speech_request).await {
         Ok(buffer) => buffer,
         Err(e) => {
-            let err_msg = format!("Failed to transcribe the audio. {}", e);
+            let err_msg = format!("Failed to transcribe the audio. {e}");
 
             // log
             error!(target: "stdout", "{}", &err_msg);

--- a/llama-api-server/src/backend/mod.rs
+++ b/llama-api-server/src/backend/mod.rs
@@ -16,7 +16,7 @@ pub(crate) async fn handle_llama_request(req: Request<Body>) -> Response<Body> {
             if path.starts_with("/v1/files") {
                 ggml::files_handler(req).await
             } else {
-                error!(target: "stdout", "Invalid endpoint: {}", path);
+                error!(target: "stdout", "Invalid endpoint: {path}");
 
                 error::invalid_endpoint(path)
             }

--- a/llama-api-server/src/config.rs
+++ b/llama-api-server/src/config.rs
@@ -51,8 +51,7 @@ impl<'de> Deserialize<'de> for ServerConfig {
         let helper = Helper::deserialize(deserializer)?;
         let socket_addr = helper.socket_addr.parse().map_err(|e| {
             Error::custom(format!(
-                "Failed to parse socket address from config file: {}",
-                e
+                "Failed to parse socket address from config file: {e}"
             ))
         })?;
 
@@ -164,8 +163,7 @@ impl<'de> Deserialize<'de> for ChatConfig {
             .parse::<PromptTemplateType>()
             .map_err(|e| {
                 Error::custom(format!(
-                    "Failed to parse prompt_template from config file: {}",
-                    e
+                    "Failed to parse prompt_template from config file: {e}"
                 ))
             })?;
 

--- a/llama-api-server/src/main.rs
+++ b/llama-api-server/src/main.rs
@@ -191,15 +191,15 @@ async fn main() -> Result<(), ServerError> {
     if let Ok(api_key) = std::env::var("API_KEY") {
         // define a const variable for the API key
         if let Err(e) = LLAMA_API_KEY.set(api_key) {
-            let err_msg = format!("Failed to set API key. {}", e);
+            let err_msg = format!("Failed to set API key. {e}");
 
-            error!(target: "stdout", "{}", err_msg);
+            error!(target: "stdout", "{err_msg}");
 
             return Err(ServerError::Operation(err_msg));
         }
     }
 
-    info!(target: "stdout", "LOG LEVEL: {}", log_level);
+    info!(target: "stdout", "LOG LEVEL: {log_level}");
 
     // log the version of the server
     info!(target: "stdout", "SERVER VERSION: {}", env!("CARGO_PKG_VERSION"));
@@ -219,7 +219,7 @@ async fn main() -> Result<(), ServerError> {
                 if !chat && !embedding && !tts {
                     let err_msg = "Specify at least one of the following: chat, embedding, and/or TTS. by using --chat, --embedding, and/or --tts.";
 
-                    error!(target: "stdout", "{}", err_msg);
+                    error!(target: "stdout", "{err_msg}");
 
                     return Err(ServerError::Operation(err_msg.to_string()));
                 }
@@ -329,7 +329,7 @@ async fn main() -> Result<(), ServerError> {
 
                     // initialize the chat context
                     llama_core::init_ggml_chat_context(&[metadata_chat])
-                        .map_err(|e| ServerError::Operation(format!("{}", e)))?;
+                        .map_err(|e| ServerError::Operation(format!("{e}")))?;
                 }
 
                 // embedding model
@@ -394,7 +394,7 @@ async fn main() -> Result<(), ServerError> {
 
                     // initialize the embeddings context
                     llama_core::init_ggml_embeddings_context(&[metadata_embedding])
-                        .map_err(|e| ServerError::Operation(format!("{}", e)))?;
+                        .map_err(|e| ServerError::Operation(format!("{e}")))?;
                 }
 
                 // tts model
@@ -464,13 +464,13 @@ async fn main() -> Result<(), ServerError> {
 
                     // initialize the tts context
                     llama_core::init_ggml_tts_context(&[metadata_tts])
-                        .map_err(|e| ServerError::Operation(format!("{}", e)))?;
+                        .map_err(|e| ServerError::Operation(format!("{e}")))?;
                 }
 
                 // get running mode
                 let running_mode = llama_core::running_mode()
                     .map_err(|e| ServerError::Operation(e.to_string()))?;
-                info!(target: "stdout", "running_mode: {}", running_mode);
+                info!(target: "stdout", "running_mode: {running_mode}");
 
                 // log plugin version
                 let plugin_info = llama_core::get_plugin_info()
@@ -480,7 +480,7 @@ async fn main() -> Result<(), ServerError> {
                     build_number = plugin_info.build_number,
                     commit_id = plugin_info.commit_id,
                 );
-                info!(target: "stdout", "plugin_ggml_version: {}", plugin_version);
+                info!(target: "stdout", "plugin_ggml_version: {plugin_version}");
 
                 // socket address
                 let addr = config.server.socket_addr;
@@ -522,7 +522,7 @@ async fn main() -> Result<(), ServerError> {
                 });
 
                 let tcp_listener = TcpListener::bind(addr).await.unwrap();
-                info!(target: "stdout", "Listening on {}", addr);
+                info!(target: "stdout", "Listening on {addr}");
 
                 let server = Server::from_tcp(tcp_listener.into_std().unwrap())
                     .unwrap()
@@ -550,7 +550,7 @@ async fn main() -> Result<(), ServerError> {
         } else if cli.server_args.model_alias.len() == 2 {
             model_alias = cli.server_args.model_alias.join(",").to_string();
         }
-        info!(target: "stdout", "model_alias: {}", model_alias);
+        info!(target: "stdout", "model_alias: {model_alias}");
 
         // log context size
         if cli.server_args.ctx_size.is_empty() && cli.server_args.ctx_size.len() > 2 {
@@ -570,7 +570,7 @@ async fn main() -> Result<(), ServerError> {
                 .collect::<Vec<String>>()
                 .join(",");
         }
-        info!(target: "stdout", "ctx_size: {}", ctx_sizes_str);
+        info!(target: "stdout", "ctx_size: {ctx_sizes_str}");
 
         // log batch size
         if cli.server_args.batch_size.is_empty() && cli.server_args.batch_size.len() > 2 {
@@ -590,7 +590,7 @@ async fn main() -> Result<(), ServerError> {
                 .collect::<Vec<String>>()
                 .join(",");
         }
-        info!(target: "stdout", "batch_size: {}", batch_sizes_str);
+        info!(target: "stdout", "batch_size: {batch_sizes_str}");
 
         // log ubatch size
         let mut ubatch_sizes_str = String::new();
@@ -605,7 +605,7 @@ async fn main() -> Result<(), ServerError> {
                 .collect::<Vec<String>>()
                 .join(",");
         }
-        info!(target: "stdout", "ubatch_size: {}", ubatch_sizes_str);
+        info!(target: "stdout", "ubatch_size: {ubatch_sizes_str}");
 
         // log prompt template
         if cli.server_args.prompt_template.is_empty() && cli.server_args.prompt_template.len() > 2 {
@@ -621,7 +621,7 @@ async fn main() -> Result<(), ServerError> {
             .map(|n| n.to_string())
             .collect::<Vec<String>>()
             .join(",");
-        info!(target: "stdout", "prompt_template: {}", prompt_template_str);
+        info!(target: "stdout", "prompt_template: {prompt_template_str}");
         if cli.server_args.model_name.len() != cli.server_args.prompt_template.len() {
             return Err(ServerError::ArgumentError(
                 "The number of model names and prompt templates must be the same.".to_owned(),
@@ -630,7 +630,7 @@ async fn main() -> Result<(), ServerError> {
 
         // log reverse prompt
         if let Some(reverse_prompt) = &cli.server_args.reverse_prompt {
-            info!(target: "stdout", "reverse_prompt: {}", reverse_prompt);
+            info!(target: "stdout", "reverse_prompt: {reverse_prompt}");
         }
 
         // log n_predict
@@ -644,12 +644,12 @@ async fn main() -> Result<(), ServerError> {
 
         // log main_gpu
         if let Some(main_gpu) = &cli.server_args.main_gpu {
-            info!(target: "stdout", "main_gpu: {}", main_gpu);
+            info!(target: "stdout", "main_gpu: {main_gpu}");
         }
 
         // log tensor_split
         if let Some(tensor_split) = &cli.server_args.tensor_split {
-            info!(target: "stdout", "tensor_split: {}", tensor_split);
+            info!(target: "stdout", "tensor_split: {tensor_split}");
         }
 
         // log threads
@@ -657,7 +657,7 @@ async fn main() -> Result<(), ServerError> {
 
         // log no_mmap
         if let Some(no_mmap) = &cli.server_args.no_mmap {
-            info!(target: "stdout", "no_mmap: {}", no_mmap);
+            info!(target: "stdout", "no_mmap: {no_mmap}");
         }
 
         // log temperature
@@ -682,12 +682,12 @@ async fn main() -> Result<(), ServerError> {
 
         // log json schema
         if let Some(json_schema) = &cli.server_args.json_schema {
-            info!(target: "stdout", "json_schema: {}", json_schema);
+            info!(target: "stdout", "json_schema: {json_schema}");
         }
 
         // log multimodal projector
         if let Some(llava_mmproj) = &cli.server_args.llava_mmproj {
-            info!(target: "stdout", "llava_mmproj: {}", llava_mmproj);
+            info!(target: "stdout", "llava_mmproj: {llava_mmproj}");
         }
 
         // log include_usage
@@ -740,7 +740,7 @@ async fn main() -> Result<(), ServerError> {
 
                     // initialize the embeddings context
                     llama_core::init_ggml_embeddings_context(&[metadata_embedding])
-                        .map_err(|e| ServerError::Operation(format!("{}", e)))?;
+                        .map_err(|e| ServerError::Operation(format!("{e}")))?;
                 }
                 _ => {
                     // create a Metadata instance
@@ -797,7 +797,7 @@ async fn main() -> Result<(), ServerError> {
 
                     // initialize the chat context
                     llama_core::init_ggml_chat_context(&[metadata_chat])
-                        .map_err(|e| ServerError::Operation(format!("{}", e)))?;
+                        .map_err(|e| ServerError::Operation(format!("{e}")))?;
                 }
             }
         } else if cli.server_args.prompt_template.len() == 2 {
@@ -855,7 +855,7 @@ async fn main() -> Result<(), ServerError> {
 
             // initialize the chat context
             llama_core::init_ggml_chat_context(&[metadata_chat])
-                .map_err(|e| ServerError::Operation(format!("{}", e)))?;
+                .map_err(|e| ServerError::Operation(format!("{e}")))?;
 
             // create a Metadata instance
             let metadata_embedding = GgmlMetadataBuilder::new(
@@ -898,13 +898,13 @@ async fn main() -> Result<(), ServerError> {
 
             // initialize the embeddings context
             llama_core::init_ggml_embeddings_context(&[metadata_embedding])
-                .map_err(|e| ServerError::Operation(format!("{}", e)))?;
+                .map_err(|e| ServerError::Operation(format!("{e}")))?;
         }
 
         // get running mode
         let running_mode =
             llama_core::running_mode().map_err(|e| ServerError::Operation(e.to_string()))?;
-        info!(target: "stdout", "running_mode: {}", running_mode);
+        info!(target: "stdout", "running_mode: {running_mode}");
 
         // log plugin version
         let plugin_info =
@@ -914,7 +914,7 @@ async fn main() -> Result<(), ServerError> {
             build_number = plugin_info.build_number,
             commit_id = plugin_info.commit_id,
         );
-        info!(target: "stdout", "plugin_ggml_version: {}", plugin_version);
+        info!(target: "stdout", "plugin_ggml_version: {plugin_version}");
 
         // socket address
         let addr = match cli.server_args.socket_addr {
@@ -949,7 +949,7 @@ async fn main() -> Result<(), ServerError> {
         });
 
         let tcp_listener = TcpListener::bind(addr).await.unwrap();
-        info!(target: "stdout", "Listening on {}", addr);
+        info!(target: "stdout", "Listening on {addr}");
 
         let server = Server::from_tcp(tcp_listener.into_std().unwrap())
             .unwrap()
@@ -979,13 +979,13 @@ async fn handle_request(
             let auth_header = match auth_header.to_str() {
                 Ok(auth_header) => auth_header,
                 Err(e) => {
-                    let err_msg = format!("Failed to get authorization header: {}", e);
+                    let err_msg = format!("Failed to get authorization header: {e}");
                     return Ok(error::unauthorized(err_msg));
                 }
             };
 
             let api_key = auth_header.split(" ").nth(1).unwrap_or_default();
-            info!(target: "stdout", "API Key: {}", api_key);
+            info!(target: "stdout", "API Key: {api_key}");
 
             if let Some(stored_api_key) = LLAMA_API_KEY.get() {
                 if api_key != stored_api_key {
@@ -1008,11 +1008,11 @@ async fn handle_request(
                 None => 0,
             };
 
-            info!(target: "stdout", "method: {}, http_version: {}, content-length: {}", method, version, size);
-            info!(target: "stdout", "endpoint: {}", path);
+            info!(target: "stdout", "method: {method}, http_version: {version}, content-length: {size}");
+            info!(target: "stdout", "endpoint: {path}");
         } else {
-            info!(target: "stdout", "method: {}, http_version: {}", method, version);
-            info!(target: "stdout", "endpoint: {}", path);
+            info!(target: "stdout", "method: {method}, http_version: {version}");
+            info!(target: "stdout", "endpoint: {path}");
         }
     }
 
@@ -1028,26 +1028,26 @@ async fn handle_request(
         if status_code.as_u16() < 400 {
             // log response
             let response_version = format!("{:?}", response.version());
-            info!(target: "stdout", "response_version: {}", response_version);
+            info!(target: "stdout", "response_version: {response_version}");
             let response_body_size: u64 = response.body().size_hint().lower();
-            info!(target: "stdout", "response_body_size: {}", response_body_size);
+            info!(target: "stdout", "response_body_size: {response_body_size}");
             let response_status = status_code.as_u16();
-            info!(target: "stdout", "response_status: {}", response_status);
+            info!(target: "stdout", "response_status: {response_status}");
             let response_is_success = status_code.is_success();
-            info!(target: "stdout", "response_is_success: {}", response_is_success);
+            info!(target: "stdout", "response_is_success: {response_is_success}");
         } else {
             let response_version = format!("{:?}", response.version());
-            error!(target: "stdout", "response_version: {}", response_version);
+            error!(target: "stdout", "response_version: {response_version}");
             let response_body_size: u64 = response.body().size_hint().lower();
-            error!(target: "stdout", "response_body_size: {}", response_body_size);
+            error!(target: "stdout", "response_body_size: {response_body_size}");
             let response_status = status_code.as_u16();
-            error!(target: "stdout", "response_status: {}", response_status);
+            error!(target: "stdout", "response_status: {response_status}");
             let response_is_success = status_code.is_success();
-            error!(target: "stdout", "response_is_success: {}", response_is_success);
+            error!(target: "stdout", "response_is_success: {response_is_success}");
             let response_is_client_error = status_code.is_client_error();
-            error!(target: "stdout", "response_is_client_error: {}", response_is_client_error);
+            error!(target: "stdout", "response_is_client_error: {response_is_client_error}");
             let response_is_server_error = status_code.is_server_error();
-            error!(target: "stdout", "response_is_server_error: {}", response_is_server_error);
+            error!(target: "stdout", "response_is_server_error: {response_is_server_error}");
         }
     }
 

--- a/llama-api-server/src/utils.rs
+++ b/llama-api-server/src/utils.rs
@@ -64,7 +64,7 @@ impl std::str::FromStr for LogLevel {
             "warn" => Ok(LogLevel::Warn),
             "error" => Ok(LogLevel::Error),
             "critical" => Ok(LogLevel::Critical),
-            _ => Err(format!("Invalid log level: {}", s)),
+            _ => Err(format!("Invalid log level: {s}")),
         }
     }
 }

--- a/llama-chat/Cargo.toml
+++ b/llama-chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "llama-chat"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 
 [dependencies]

--- a/llama-chat/src/main.rs
+++ b/llama-chat/src/main.rs
@@ -116,11 +116,11 @@ async fn main() -> anyhow::Result<()> {
     log(format!("[INFO] Context size: {}", &cli.ctx_size));
     // reverse prompt
     if let Some(reverse_prompt) = &cli.reverse_prompt {
-        log(format!("[INFO] reverse prompt: {}", reverse_prompt));
+        log(format!("[INFO] reverse prompt: {reverse_prompt}"));
     }
     // system prompt
     if let Some(system_prompt) = &cli.system_prompt {
-        log(format!("[INFO] system prompt: {}", system_prompt));
+        log(format!("[INFO] system prompt: {system_prompt}"));
     }
     // n_predict
     log(format!(
@@ -134,11 +134,11 @@ async fn main() -> anyhow::Result<()> {
     ));
     // main_gpu
     if let Some(main_gpu) = &cli.main_gpu {
-        log(format!("[INFO] Main GPU to use: {}", main_gpu));
+        log(format!("[INFO] Main GPU to use: {main_gpu}"));
     }
     // tensor_split
     if let Some(tensor_split) = &cli.tensor_split {
-        log(format!("[INFO] Tensor split: {}", tensor_split));
+        log(format!("[INFO] Tensor split: {tensor_split}"));
     }
     log(format!("[INFO] Threads: {}", &cli.threads));
     // no_mmap
@@ -156,11 +156,11 @@ async fn main() -> anyhow::Result<()> {
     // temp and top_p
     if cli.temp.is_none() && cli.top_p.is_none() {
         let temp = 1.0;
-        log(format!("[INFO] Temperature for sampling: {}", temp));
+        log(format!("[INFO] Temperature for sampling: {temp}"));
     } else if let Some(temp) = cli.temp {
-        log(format!("[INFO] Temperature for sampling: {}", temp));
+        log(format!("[INFO] Temperature for sampling: {temp}"));
     } else if let Some(top_p) = cli.top_p {
-        log(format!("[INFO] Top-p sampling (1.0 = disabled): {}", top_p));
+        log(format!("[INFO] Top-p sampling (1.0 = disabled): {top_p}"));
     }
     // repeat penalty
     log(format!(
@@ -181,7 +181,7 @@ async fn main() -> anyhow::Result<()> {
     log(format!("[INFO] BNF-like grammar: {}", &cli.grammar));
     // json schema
     if let Some(json_schema) = &cli.json_schema {
-        log(format!("[INFO] JSON schema: {}", json_schema));
+        log(format!("[INFO] JSON schema: {json_schema}"));
     }
     // log prompts
     log(format!("[INFO] Enable prompt log: {}", &cli.log_prompts));
@@ -210,17 +210,17 @@ async fn main() -> anyhow::Result<()> {
     // temp and top_p
     let builder = if cli.temp.is_none() && cli.top_p.is_none() {
         let temp = 1.0;
-        log(format!("[INFO] Temperature for sampling: {}", temp));
+        log(format!("[INFO] Temperature for sampling: {temp}"));
         builder.with_temperature(temp)
     } else if let Some(temp) = cli.temp {
-        log(format!("[INFO] Temperature for sampling: {}", temp));
+        log(format!("[INFO] Temperature for sampling: {temp}"));
         builder.with_temperature(temp)
     } else if let Some(top_p) = cli.top_p {
-        log(format!("[INFO] Top-p sampling (1.0 = disabled): {}", top_p));
+        log(format!("[INFO] Top-p sampling (1.0 = disabled): {top_p}"));
         builder.with_top_p(top_p)
     } else {
         let temp = cli.temp.unwrap();
-        log(format!("[INFO] Temperature for sampling: {}", temp));
+        log(format!("[INFO] Temperature for sampling: {temp}"));
         builder.with_temperature(temp)
     };
     // create a Metadata instance
@@ -305,7 +305,7 @@ async fn main() -> anyhow::Result<()> {
                                 }
                                 if assistant_answer.is_empty() {
                                     let content = content.trim_start();
-                                    print!("{}", content);
+                                    print!("{content}");
                                     assistant_answer.push_str(content);
                                 } else {
                                     print!("{content}");
@@ -394,7 +394,7 @@ fn print_log_begin_separator(
     separator.push_str(&title);
     separator.push_str(ch.repeat(separator_len).as_str());
     separator.push('\n');
-    println!("{}", separator);
+    println!("{separator}");
     total_len
 }
 
@@ -403,7 +403,7 @@ fn print_log_end_separator(ch: Option<&str>, len: Option<usize>) {
     let mut separator = "\n\n".to_string();
     separator.push_str(ch.repeat(len.unwrap_or(100)).as_str());
     separator.push('\n');
-    println!("{}", separator);
+    println!("{separator}");
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
@@ -454,7 +454,7 @@ pub struct Metadata {
 }
 
 fn log(msg: impl std::fmt::Display) {
-    println!("{}", msg);
+    println!("{msg}");
 }
 
 fn parse_sse_event(s: &str) -> Option<ChatCompletionChunk> {
@@ -478,9 +478,7 @@ fn parse_sse_event(s: &str) -> Option<ChatCompletionChunk> {
                 Ok(chunk) => Some(chunk),
                 Err(e) => {
                     log(format!(
-                        "[ERROR] Fail to parse SSE data. Reason: {msg}. Data: {data}",
-                        msg = e,
-                        data = s
+                        "[ERROR] Fail to parse SSE data. Reason: {e}. Data: {s}"
                     ));
                     None
                 }

--- a/llama-chat/src/main.rs
+++ b/llama-chat/src/main.rs
@@ -295,7 +295,7 @@ async fn main() -> anyhow::Result<()> {
         println!("\n[Bot]:");
         let mut assistant_answer = String::new();
         match llama_core::chat::chat(&mut chat_request).await {
-            Ok(res) => match res {
+            Ok((res, _include_tool_calls)) => match res {
                 Left(mut stream) => {
                     while let Some(data) = stream.try_next().await? {
                         if let Some(chunk) = parse_sse_event(&data) {

--- a/llama-simple/Cargo.toml
+++ b/llama-simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "llama-simple"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 
 [dependencies]

--- a/llama-simple/src/main.rs
+++ b/llama-simple/src/main.rs
@@ -100,20 +100,17 @@ fn main() -> Result<(), String> {
     CTX_SIZE
         .set(*ctx_size as usize * 6)
         .expect("Fail to parse prompt context size");
-    println!("[INFO] prompt context size: {size}", size = ctx_size);
+    println!("[INFO] prompt context size: {ctx_size}");
     options.ctx_size = *ctx_size as u64;
 
     // number of tokens to predict
     let n_predict = matches.get_one::<u32>("n_predict").unwrap();
-    println!("[INFO] Number of tokens to predict: {n}", n = n_predict);
+    println!("[INFO] Number of tokens to predict: {n_predict}");
     options.n_predict = *n_predict as u64;
 
     // n_gpu_layers
     let n_gpu_layers = matches.get_one::<u32>("n_gpu_layers").unwrap();
-    println!(
-        "[INFO] Number of layers to run on the GPU: {n}",
-        n = n_gpu_layers
-    );
+    println!("[INFO] Number of layers to run on the GPU: {n_gpu_layers}",);
     options.n_gpu_layers = *n_gpu_layers as u64;
 
     // no_mmap
@@ -123,10 +120,7 @@ fn main() -> Result<(), String> {
 
     // batch size
     let batch_size = matches.get_one::<u32>("batch_size").unwrap();
-    println!(
-        "[INFO] Batch size for prompt processing: {size}",
-        size = batch_size
-    );
+    println!("[INFO] Batch size for prompt processing: {batch_size}");
     options.batch_size = *batch_size as u64;
 
     // reverse_prompt
@@ -137,7 +131,7 @@ fn main() -> Result<(), String> {
 
     // log
     let log_enable = matches.get_flag("log_enable");
-    println!("[INFO] Log enable: {enable}", enable = log_enable);
+    println!("[INFO] Log enable: {log_enable}");
     options.log_enable = log_enable;
 
     // load the model into wasi-nn
@@ -181,7 +175,7 @@ fn main() -> Result<(), String> {
     output_size = std::cmp::min(*CTX_SIZE.get().unwrap(), output_size);
     let output = String::from_utf8_lossy(&output_buffer[..output_size]).to_string();
 
-    println!("\n[Answer]:\n\n{}", output);
+    println!("\n[Answer]:\n\n{output}");
 
     Ok(())
 }


### PR DESCRIPTION
Major changes:

- Improve the fundamental data types in `endpoints` crate
  - (NEW) Introduce `JsonObject` type
  - (NEW) Implement `From<ToolCallForChunk>` for `ToolCall`
  - (NEW) Extend `IndexRequest` with `name` field
  - (NEW) Extend `ChatCompletionRequest` with `weighted_alpha` field
  - (BREAKING) Improve the type of `parameters` field of `ToolFunction`

- `llama-core` crate
  - (BREAKING) Improve the return type of `chat` API
  - (BREAKING) Remove deprected `chat_completions_stream` and `chat_completions` APIs