### PR TITLE
version: bump to `0.18.0`

### DIFF
--- a/llama-api-server/Cargo.toml
+++ b/llama-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "llama-api-server"
-version = "0.17.1"
+version = "0.18.0"
 edition = "2021"
 
 [dependencies]

--- a/llama-chat/Cargo.toml
+++ b/llama-chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "llama-chat"
-version = "0.17.1"
+version = "0.18.0"
 edition = "2021"
 
 [dependencies]

--- a/llama-simple/Cargo.toml
+++ b/llama-simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "llama-simple"
-version = "0.17.1"
+version = "0.18.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Major changes:

- Improve the fundamental data types in `endpoints` crate
  - (NEW) Introduce `JsonObject` type
  - (NEW) Implement `From<ToolCallForChunk>` for `ToolCall`
  - (NEW) Extend `IndexRequest` with `name` field
  - (NEW) Extend `ChatCompletionRequest` with `weighted_alpha` field
  - (BREAKING) Improve the type of `parameters` field of `ToolFunction`

- `llama-core` crate
  - (BREAKING) Improve the return type of `chat` API
  - (BREAKING) Remove deprected `chat_completions_stream` and `chat_completions` APIs