### PR TITLE
Release 0.19.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 [workspace.dependencies]
 serde            = { version = "1.0", features = ["derive"] }
 serde_json       = "1.0"
-endpoints        = { path = "crates/endpoints", version = "^0.26" }
+endpoints        = { path = "crates/endpoints", version = "^0.27" }
 chat-prompts     = { path = "crates/chat-prompts", version = "^0.30" }
 thiserror        = "1"
 uuid             = { version = "1.4", features = ["v4", "fast-rng", "macro-diagnostics"] }

--- a/crates/chat-prompts/Cargo.toml
+++ b/crates/chat-prompts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "chat-prompts"
-version       = "0.30.0"
+version       = "0.30.1"
 edition       = "2021"
 readme        = "README.md"
 repository    = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/endpoints/Cargo.toml
+++ b/crates/endpoints/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "endpoints"
-version       = "0.26.0"
+version       = "0.27.0"
 edition       = "2021"
 readme        = "README.md"
 repository    = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/endpoints/src/chat.rs
+++ b/crates/endpoints/src/chat.rs
@@ -288,7 +288,7 @@ impl ChatCompletionRequestBuilder {
     /// * `kw_index_name` - The name of the index to use for keyword search.
     #[cfg(all(feature = "rag", feature = "index"))]
     pub fn with_kw_index_name(mut self, kw_index_name: impl Into<String>) -> Self {
-        self.req.kw_index_name = Some(kw_index_name.into());
+        self.req.kw_search_index = Some(kw_index_name.into());
         self
     }
 
@@ -449,8 +449,8 @@ pub struct ChatCompletionRequest {
     pub kw_search_url: Option<String>,
     /// The name of the index to use for the keyword search. This parameter is only used in RAG chat completions.
     #[cfg(all(feature = "rag", feature = "index"))]
-    #[serde(rename = "kw_index_name", skip_serializing_if = "Option::is_none")]
-    pub kw_index_name: Option<String>,
+    #[serde(rename = "kw_search_index", skip_serializing_if = "Option::is_none")]
+    pub kw_search_index: Option<String>,
     /// The number of top keyword search results to return. Defaults to 5. This parameter is only used in RAG chat completions.
     #[cfg(all(feature = "rag", feature = "index"))]
     #[serde(rename = "kw_top_k", skip_serializing_if = "Option::is_none")]
@@ -522,7 +522,7 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
                 #[cfg(all(feature = "rag", feature = "index"))]
                 let mut kw_search_url = None;
                 #[cfg(all(feature = "rag", feature = "index"))]
-                let mut kw_index_name: Option<String> = None;
+                let mut kw_search_index: Option<String> = None;
                 #[cfg(all(feature = "rag", feature = "index"))]
                 let mut kw_top_k: Option<u64> = None;
                 #[cfg(all(feature = "rag", feature = "index"))]
@@ -571,7 +571,7 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
                         #[cfg(all(feature = "rag", feature = "index"))]
                         "kw_search_url" => kw_search_url = map.next_value()?,
                         #[cfg(all(feature = "rag", feature = "index"))]
-                        "kw_index_name" => kw_index_name = map.next_value()?,
+                        "kw_search_index" => kw_search_index = map.next_value()?,
                         #[cfg(all(feature = "rag", feature = "index"))]
                         "kw_top_k" => kw_top_k = map.next_value()?,
                         #[cfg(all(feature = "rag", feature = "index"))]
@@ -623,12 +623,12 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
                 }
 
                 #[cfg(all(feature = "rag", feature = "index"))]
-                if let Some(name) = &kw_index_name {
+                if let Some(name) = &kw_search_index {
                     if name.is_empty() {
                         #[cfg(feature = "logging")]
                         warn!(target: "stdout", "Found empty index name");
 
-                        kw_index_name = None;
+                        kw_search_index = None;
                     }
                 }
 
@@ -678,7 +678,7 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
                     #[cfg(all(feature = "rag", feature = "index"))]
                     kw_search_url,
                     #[cfg(all(feature = "rag", feature = "index"))]
-                    kw_index_name,
+                    kw_search_index,
                     #[cfg(all(feature = "rag", feature = "index"))]
                     kw_top_k,
                     #[cfg(all(feature = "rag", feature = "index"))]
@@ -726,7 +726,7 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
             #[cfg(all(feature = "rag", feature = "index"))]
             "kw_search_url",
             #[cfg(all(feature = "rag", feature = "index"))]
-            "kw_index_name",
+            "kw_search_index",
             #[cfg(all(feature = "rag", feature = "index"))]
             "kw_top_k",
             #[cfg(all(feature = "rag", feature = "index"))]
@@ -781,7 +781,7 @@ impl Default for ChatCompletionRequest {
             #[cfg(all(feature = "rag", feature = "index"))]
             kw_search_url: None,
             #[cfg(all(feature = "rag", feature = "index"))]
-            kw_index_name: None,
+            kw_search_index: None,
             #[cfg(all(feature = "rag", feature = "index"))]
             kw_top_k: Some(5),
             #[cfg(all(feature = "rag", feature = "index"))]
@@ -1421,7 +1421,7 @@ fn test_chat_deserialize_chat_request() {
             request.kw_search_url,
             Some("http://localhost:9069".to_string())
         );
-        assert_eq!(request.kw_index_name, Some("index-name".to_string()));
+        assert_eq!(request.kw_search_index, Some("index-name".to_string()));
         assert_eq!(request.kw_top_k, Some(5));
     }
 }

--- a/crates/endpoints/src/chat.rs
+++ b/crates/endpoints/src/chat.rs
@@ -280,6 +280,7 @@ impl ChatCompletionRequestBuilder {
     /// * `kw_top_k` - The number of top keyword search results to return.
     /// * `weighted_alpha` - The weighted alpha for the keyword search results (alpha) and the embedding search results (1-alpha).
     /// * `kw_api_key` - The API key for the keyword search server.
+    #[cfg(all(feature = "rag", feature = "index"))]
     pub fn with_kw_search_settings(
         mut self,
         kw_search_url: impl Into<String>,
@@ -296,17 +297,6 @@ impl ChatCompletionRequestBuilder {
         self.req.weighted_alpha = weighted_alpha;
         self.req.kw_api_key = kw_api_key;
 
-        self
-    }
-
-    /// Sets the weighted alpha for the keyword search results (alpha) and the embedding search results (1-alpha).
-    ///
-    /// # Arguments
-    ///
-    /// * `weighted_alpha` - The weighted alpha for the keyword search results (alpha) and the embedding search results (1-alpha).
-    #[cfg(all(feature = "rag", feature = "index"))]
-    pub fn with_weighted_alpha(mut self, weighted_alpha: f32) -> Self {
-        self.req.weighted_alpha = Some(weighted_alpha);
         self
     }
 

--- a/crates/endpoints/src/chat.rs
+++ b/crates/endpoints/src/chat.rs
@@ -287,7 +287,7 @@ impl ChatCompletionRequestBuilder {
         kw_search_index: impl Into<String>,
         kw_search_fields: Option<Vec<String>>,
         kw_search_limit: Option<u64>,
-        weighted_alpha: Option<f32>,
+        weighted_alpha: Option<f64>,
         kw_api_key: Option<String>,
     ) -> Self {
         self.req.kw_search_url = Some(kw_search_url.into());
@@ -452,7 +452,7 @@ pub struct ChatCompletionRequest {
     /// The weighted alpha for the keyword search results (alpha) and the embedding search results (1-alpha). Defaults to 0.5.
     #[cfg(all(feature = "rag", feature = "index"))]
     #[serde(rename = "weighted_alpha", skip_serializing_if = "Option::is_none")]
-    pub weighted_alpha: Option<f32>,
+    pub weighted_alpha: Option<f64>,
 }
 #[allow(deprecated)]
 impl<'de> Deserialize<'de> for ChatCompletionRequest {
@@ -516,7 +516,7 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
                 #[cfg(all(feature = "rag", feature = "index"))]
                 let mut kw_api_key: Option<String> = None;
                 #[cfg(all(feature = "rag", feature = "index"))]
-                let mut weighted_alpha: Option<f32> = None;
+                let mut weighted_alpha: Option<f64> = None;
 
                 while let Some(key) = map.next_key::<String>()? {
                     #[cfg(feature = "logging")]

--- a/crates/endpoints/src/chat.rs
+++ b/crates/endpoints/src/chat.rs
@@ -459,6 +459,10 @@ pub struct ChatCompletionRequest {
     #[cfg(all(feature = "rag", feature = "index"))]
     #[serde(rename = "kw_search_fields", skip_serializing_if = "Option::is_none")]
     pub kw_search_fields: Option<Vec<String>>,
+    /// The API key for the keyword search server.
+    #[cfg(all(feature = "rag", feature = "index"))]
+    #[serde(rename = "kw_api_key", skip_serializing_if = "Option::is_none")]
+    pub kw_api_key: Option<String>,
     /// The weighted alpha for the keyword search results (alpha) and the embedding search results (1-alpha). Defaults to 0.5.
     #[cfg(all(feature = "rag", feature = "index"))]
     #[serde(rename = "weighted_alpha", skip_serializing_if = "Option::is_none")]
@@ -524,6 +528,8 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
                 #[cfg(all(feature = "rag", feature = "index"))]
                 let mut kw_search_fields: Option<Vec<String>> = None;
                 #[cfg(all(feature = "rag", feature = "index"))]
+                let mut kw_api_key: Option<String> = None;
+                #[cfg(all(feature = "rag", feature = "index"))]
                 let mut weighted_alpha: Option<f32> = None;
 
                 while let Some(key) = map.next_key::<String>()? {
@@ -570,6 +576,8 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
                         "kw_top_k" => kw_top_k = map.next_value()?,
                         #[cfg(all(feature = "rag", feature = "index"))]
                         "kw_search_fields" => kw_search_fields = map.next_value()?,
+                        #[cfg(all(feature = "rag", feature = "index"))]
+                        "kw_api_key" => kw_api_key = map.next_value()?,
                         #[cfg(all(feature = "rag", feature = "index"))]
                         "weighted_alpha" => weighted_alpha = map.next_value()?,
                         _ => {
@@ -676,6 +684,8 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
                     #[cfg(all(feature = "rag", feature = "index"))]
                     kw_search_fields,
                     #[cfg(all(feature = "rag", feature = "index"))]
+                    kw_api_key,
+                    #[cfg(all(feature = "rag", feature = "index"))]
                     weighted_alpha,
                 })
             }
@@ -721,6 +731,8 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
             "kw_top_k",
             #[cfg(all(feature = "rag", feature = "index"))]
             "kw_search_fields",
+            #[cfg(all(feature = "rag", feature = "index"))]
+            "kw_api_key",
             #[cfg(all(feature = "rag", feature = "index"))]
             "weighted_alpha",
         ];
@@ -774,6 +786,8 @@ impl Default for ChatCompletionRequest {
             kw_top_k: Some(5),
             #[cfg(all(feature = "rag", feature = "index"))]
             kw_search_fields: None,
+            #[cfg(all(feature = "rag", feature = "index"))]
+            kw_api_key: None,
             #[cfg(all(feature = "rag", feature = "index"))]
             weighted_alpha: Some(0.5),
         }

--- a/crates/endpoints/src/chat.rs
+++ b/crates/endpoints/src/chat.rs
@@ -455,6 +455,10 @@ pub struct ChatCompletionRequest {
     #[cfg(all(feature = "rag", feature = "index"))]
     #[serde(rename = "kw_top_k", skip_serializing_if = "Option::is_none")]
     pub kw_top_k: Option<u64>,
+    /// The fields to use for the keyword search. This parameter is only used in RAG chat completions and reserved for Elasticsearch.
+    #[cfg(all(feature = "rag", feature = "index"))]
+    #[serde(rename = "kw_search_fields", skip_serializing_if = "Option::is_none")]
+    pub kw_search_fields: Option<Vec<String>>,
     /// The weighted alpha for the keyword search results (alpha) and the embedding search results (1-alpha). Defaults to 0.5.
     #[cfg(all(feature = "rag", feature = "index"))]
     #[serde(rename = "weighted_alpha", skip_serializing_if = "Option::is_none")]
@@ -518,6 +522,8 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
                 #[cfg(all(feature = "rag", feature = "index"))]
                 let mut kw_top_k: Option<u64> = None;
                 #[cfg(all(feature = "rag", feature = "index"))]
+                let mut kw_search_fields: Option<Vec<String>> = None;
+                #[cfg(all(feature = "rag", feature = "index"))]
                 let mut weighted_alpha: Option<f32> = None;
 
                 while let Some(key) = map.next_key::<String>()? {
@@ -562,6 +568,8 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
                         "kw_index_name" => kw_index_name = map.next_value()?,
                         #[cfg(all(feature = "rag", feature = "index"))]
                         "kw_top_k" => kw_top_k = map.next_value()?,
+                        #[cfg(all(feature = "rag", feature = "index"))]
+                        "kw_search_fields" => kw_search_fields = map.next_value()?,
                         #[cfg(all(feature = "rag", feature = "index"))]
                         "weighted_alpha" => weighted_alpha = map.next_value()?,
                         _ => {
@@ -666,6 +674,8 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
                     #[cfg(all(feature = "rag", feature = "index"))]
                     kw_top_k,
                     #[cfg(all(feature = "rag", feature = "index"))]
+                    kw_search_fields,
+                    #[cfg(all(feature = "rag", feature = "index"))]
                     weighted_alpha,
                 })
             }
@@ -709,6 +719,10 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
             "kw_index_name",
             #[cfg(all(feature = "rag", feature = "index"))]
             "kw_top_k",
+            #[cfg(all(feature = "rag", feature = "index"))]
+            "kw_search_fields",
+            #[cfg(all(feature = "rag", feature = "index"))]
+            "weighted_alpha",
         ];
         deserializer.deserialize_struct(
             "ChatCompletionRequest",
@@ -758,6 +772,8 @@ impl Default for ChatCompletionRequest {
             kw_index_name: None,
             #[cfg(all(feature = "rag", feature = "index"))]
             kw_top_k: Some(5),
+            #[cfg(all(feature = "rag", feature = "index"))]
+            kw_search_fields: None,
             #[cfg(all(feature = "rag", feature = "index"))]
             weighted_alpha: Some(0.5),
         }

--- a/crates/endpoints/src/keyword_search.rs
+++ b/crates/endpoints/src/keyword_search.rs
@@ -61,5 +61,5 @@ pub struct QueryResponse {
 pub struct SearchHit {
     pub title: String,
     pub content: String,
-    pub score: f32,
+    pub score: f64,
 }

--- a/crates/endpoints/src/rag.rs
+++ b/crates/endpoints/src/rag.rs
@@ -24,7 +24,7 @@ pub struct RagScoredPoint {
     pub source: String,
 
     /// Points vector distance to the query vector
-    pub score: f32,
+    pub score: f64,
 }
 
 #[test]

--- a/crates/llama-core/Cargo.toml
+++ b/crates/llama-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "llama-core"
-version       = "0.32.6"
+version       = "0.32.7"
 edition       = "2021"
 readme        = "README.md"
 repository    = "https://github.com/LlamaEdge/LlamaEdge"

--- a/llama-api-server/Cargo.toml
+++ b/llama-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "llama-api-server"
-version = "0.18.6"
+version = "0.19.0"
 edition = "2021"
 
 [dependencies]

--- a/llama-chat/Cargo.toml
+++ b/llama-chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "llama-chat"
-version = "0.18.6"
+version = "0.19.0"
 edition = "2021"
 
 [dependencies]

--- a/llama-simple/Cargo.toml
+++ b/llama-simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "llama-simple"
-version = "0.18.6"
+version = "0.19.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Major changes:

- `endpoints` crate
  - (BREAKING) Rename `kw_index_name` to `kw_search_index` in `ChatCompletionRequest`
  - (BREAKING) Rename `kw_top_k` to `kw_search_limit` in `ChatCompletionRequest`
  - (BREAKING) Remove `with_kw_search_url`, `with_kw_index_name`, and `with_kw_top_k` methods in `ChatCompletionRequestBuild`
  - (BREAKING) Update type of `score` field of `SearchHit`
  - (BREAKING) Update type of `weighted_alpha` field of `ChatCompletionRequest`
  - (BREAKING) Update type of `score` field of `RagScoredPoint`
  - (NEW) Add `with_kw_search_settings` method in `ChatCompletionRequestBuilde`
  - (NEW) Add `kw_api_key` field to `ChatCompletionRequest`
  - (NEW) Add `kw_search_fields` field to `ChatCompletionRequest`
