### PR TITLE
Release 0.22.0

### DIFF
--- a/.github/workflows/test_api_server.yml
+++ b/.github/workflows/test_api_server.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         wasmedge_version: [0.14.1]
-        ggml_version: [b5575]
+        ggml_version: [b5593]
     steps:
       - name: Clone project
         id: checkout
@@ -125,7 +125,7 @@ jobs:
     strategy:
       matrix:
         wasmedge_version: [0.14.1]
-        ggml_version: [b5575]
+        ggml_version: [b5593]
     steps:
       - name: Clone project
         id: checkout
@@ -221,7 +221,7 @@ jobs:
     strategy:
       matrix:
         wasmedge_version: [0.14.1]
-        ggml_version: [b5575]
+        ggml_version: [b5593]
     steps:
       - name: Clone project
         id: checkout
@@ -317,7 +317,7 @@ jobs:
     strategy:
       matrix:
         wasmedge_version: [0.14.1]
-        ggml_version: [b5575]
+        ggml_version: [b5593]
     steps:
       - name: Clone project
         id: checkout

--- a/.github/workflows/test_api_server.yml
+++ b/.github/workflows/test_api_server.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         wasmedge_version: [0.14.1]
-        ggml_version: [b5361]
+        ggml_version: [b5575]
     steps:
       - name: Clone project
         id: checkout
@@ -125,7 +125,7 @@ jobs:
     strategy:
       matrix:
         wasmedge_version: [0.14.1]
-        ggml_version: [b5361]
+        ggml_version: [b5575]
     steps:
       - name: Clone project
         id: checkout
@@ -221,7 +221,7 @@ jobs:
     strategy:
       matrix:
         wasmedge_version: [0.14.1]
-        ggml_version: [b5361]
+        ggml_version: [b5575]
     steps:
       - name: Clone project
         id: checkout
@@ -317,7 +317,7 @@ jobs:
     strategy:
       matrix:
         wasmedge_version: [0.14.1]
-        ggml_version: [b5361]
+        ggml_version: [b5575]
     steps:
       - name: Clone project
         id: checkout

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 [workspace.dependencies]
 serde            = { version = "1.0", features = ["derive"] }
 serde_json       = "1.0"
-endpoints        = { path = "crates/endpoints", version = "^0.29" }
+endpoints        = { path = "crates/endpoints", version = "^0.30" }
 chat-prompts     = { path = "crates/chat-prompts", version = "^0.31" }
 thiserror        = "1"
 uuid             = { version = "1.4", features = ["v4", "fast-rng", "macro-diagnostics"] }

--- a/crates/chat-prompts/Cargo.toml
+++ b/crates/chat-prompts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "chat-prompts"
-version       = "0.31.0"
+version       = "0.31.1"
 edition       = "2021"
 readme        = "README.md"
 repository    = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/endpoints/Cargo.toml
+++ b/crates/endpoints/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "endpoints"
-version       = "0.29.0"
+version       = "0.30.0"
 edition       = "2021"
 readme        = "README.md"
 repository    = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/endpoints/src/chat.rs
+++ b/crates/endpoints/src/chat.rs
@@ -2503,6 +2503,15 @@ pub enum McpTransport {
     #[serde(rename = "stdio")]
     Stdio,
 }
+impl fmt::Display for McpTransport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            McpTransport::Sse => write!(f, "sse"),
+            McpTransport::StreamHttp => write!(f, "stream-http"),
+            McpTransport::Stdio => write!(f, "stdio"),
+        }
+    }
+}
 
 /// Message for comprising the conversation.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]

--- a/crates/endpoints/src/chat.rs
+++ b/crates/endpoints/src/chat.rs
@@ -449,21 +449,6 @@ pub struct ChatCompletionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<String>,
 
-    //* OpenAI specific parameters
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[deprecated(
-        since = "0.10.0",
-        note = "Please use `tools` and `tool_choice` instead."
-    )]
-    #[allow(deprecated)]
-    pub functions: Option<Vec<ChatCompletionRequestFunction>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[deprecated(
-        since = "0.10.0",
-        note = "Please use `tools` and `tool_choice` instead."
-    )]
-    pub function_call: Option<String>,
-
     /// Format that the model must output
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response_format: Option<ChatResponseFormat>,
@@ -614,8 +599,6 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
                 let mut frequency_penalty = None;
                 let mut logit_bias = None;
                 let mut user = None;
-                let mut functions = None;
-                let mut function_call = None;
                 let mut response_format = None;
                 let mut tools = None;
                 let mut tool_choice = None;
@@ -689,8 +672,6 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
                         "frequency_penalty" => frequency_penalty = map.next_value()?,
                         "logit_bias" => logit_bias = map.next_value()?,
                         "user" => user = map.next_value()?,
-                        "functions" => functions = map.next_value()?,
-                        "function_call" => function_call = map.next_value()?,
                         "response_format" => response_format = map.next_value()?,
                         "tools" => tools = map.next_value()?,
                         "tool_choice" => tool_choice = map.next_value()?,
@@ -806,8 +787,6 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
                     frequency_penalty,
                     logit_bias,
                     user,
-                    functions,
-                    function_call,
                     response_format,
                     tools,
                     tool_choice,
@@ -874,8 +853,6 @@ impl<'de> Deserialize<'de> for ChatCompletionRequest {
             "frequency_penalty",
             "logit_bias",
             "user",
-            "functions",
-            "function_call",
             "response_format",
             "tools",
             "tool_choice",
@@ -947,8 +924,6 @@ impl Default for ChatCompletionRequest {
             frequency_penalty: Some(0.0),
             logit_bias: None,
             user: None,
-            functions: None,
-            function_call: None,
             response_format: None,
             tools: None,
             tool_choice: None,

--- a/crates/endpoints/src/chat.rs
+++ b/crates/endpoints/src/chat.rs
@@ -2500,6 +2500,8 @@ pub enum McpTransport {
     Sse,
     #[serde(rename = "stream-http")]
     StreamHttp,
+    #[serde(rename = "stdio")]
+    Stdio,
 }
 
 /// Message for comprising the conversation.

--- a/crates/llama-core/Cargo.toml
+++ b/crates/llama-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "llama-core"
-version       = "0.32.9"
+version       = "0.32.10"
 edition       = "2021"
 readme        = "README.md"
 repository    = "https://github.com/LlamaEdge/LlamaEdge"

--- a/crates/llama-core/src/chat.rs
+++ b/crates/llama-core/src/chat.rs
@@ -2254,14 +2254,9 @@ fn post_process(
     } else if *template_ty == PromptTemplateType::GemmaInstruct
         || *template_ty == PromptTemplateType::Gemma3
     {
-        let mut s = output.as_ref().trim();
+        let s = output.as_ref().trim();
         if s.ends_with("<end_of_turn>") {
-            s = s.trim_end_matches("<end_of_turn>").trim();
-        }
-
-        if s.contains("<end_of_turn>") {
-            let parts = s.split("<end_of_turn>").collect::<Vec<_>>();
-            parts.last().unwrap().trim().to_owned()
+            s.trim_end_matches("<end_of_turn>").trim().to_owned()
         } else {
             s.to_owned()
         }

--- a/crates/llama-core/src/chat.rs
+++ b/crates/llama-core/src/chat.rs
@@ -2254,9 +2254,14 @@ fn post_process(
     } else if *template_ty == PromptTemplateType::GemmaInstruct
         || *template_ty == PromptTemplateType::Gemma3
     {
-        let s = output.as_ref().trim();
+        let mut s = output.as_ref().trim();
         if s.ends_with("<end_of_turn>") {
-            s.trim_end_matches("<end_of_turn>").trim().to_owned()
+            s = s.trim_end_matches("<end_of_turn>").trim();
+        }
+
+        if s.contains("<end_of_turn>") {
+            let parts = s.split("<end_of_turn>").collect::<Vec<_>>();
+            parts.last().unwrap().trim().to_owned()
         } else {
             s.to_owned()
         }

--- a/llama-api-server/Cargo.toml
+++ b/llama-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "llama-api-server"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 
 [dependencies]

--- a/llama-chat/Cargo.toml
+++ b/llama-chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "llama-chat"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 
 [dependencies]

--- a/llama-simple/Cargo.toml
+++ b/llama-simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "llama-simple"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Major changes:

- `endpoints` crate
  - (BREAKING) Remove deprecated `functions` and `function_call` fields from `ChatCompletionRequest`
  - (NEW) Add `mcp_tools` field in `ChatCompletionRequest`
  - (NEW) Add `mcp_tools` field in `ChatCompletionRequest`
  - (NEW) Introduce `McpTransport`